### PR TITLE
Fix sweep chart labels and strengthen audit reputation penalty

### DIFF
--- a/demo/utils/charts.py
+++ b/demo/utils/charts.py
@@ -201,8 +201,11 @@ def sweep_tradeoff_scatter(
     import plotly.graph_objects as go
     from plotly.subplots import make_subplots
 
+    # Human-readable label for the swept parameter
+    pretty = x_key.replace("_", " ").title()
+
     fig = make_subplots(rows=1, cols=2,
-                        subplot_titles=("Toxicity vs Tax Rate", "Welfare vs Tax Rate"))
+                        subplot_titles=(f"Toxicity vs {pretty}", f"Welfare vs {pretty}"))
 
     x_vals = [r[x_key] for r in sweep_results]
 
@@ -221,6 +224,6 @@ def sweep_tradeoff_scatter(
     )
 
     fig.update_layout(height=height, showlegend=False)
-    fig.update_xaxes(title_text="Tax Rate", row=1, col=1)
-    fig.update_xaxes(title_text="Tax Rate", row=1, col=2)
+    fig.update_xaxes(title_text=pretty, row=1, col=1)
+    fig.update_xaxes(title_text=pretty, row=1, col=2)
     return fig

--- a/src/governance/audits.py
+++ b/src/governance/audits.py
@@ -70,9 +70,10 @@ class RandomAuditLever(GovernanceLever):
             cost_a = base_penalty
             penalty_applied = True
 
-            # Reputation penalty: degrade the initiator's reputation so
-            # future interactions produce worse observables.
-            reputation_deltas[interaction.initiator] = -shortfall
+            # Reputation penalty scaled by the same multiplier as the cost
+            # so the feedback through reputation → observables → p is
+            # strong enough to show up in parameter sweeps.
+            reputation_deltas[interaction.initiator] = -base_penalty
 
         return LeverEffect(
             cost_a=cost_a,


### PR DESCRIPTION
Two fixes:

1. sweep_tradeoff_scatter: subplot titles and x-axis labels were hardcoded to "Tax Rate" regardless of which parameter was being swept. Now derives the label from the x_key parameter.

2. Audit reputation penalty was -shortfall (typically -0.05 to -0.15), too weak relative to the positive reputation gains from non-audited interactions. Now scaled by audit_penalty_multiplier (default 2.0) to match the cost penalty, making audit_probability sweeps show a visible effect on toxicity.

https://claude.ai/code/session_01SN6toWqC3Png2xcn9pv9c4