### PR TITLE
Fix Theory page LaTeX rendering and add proper paper references

### DIFF
--- a/demo/pages/5_Theory.py
+++ b/demo/pages/5_Theory.py
@@ -7,6 +7,7 @@ PROJECT_ROOT = Path(__file__).parent.parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+import pandas as pd
 import streamlit as st
 
 st.set_page_config(page_title="Theory", page_icon="📐", layout="wide")
@@ -21,18 +22,20 @@ st.markdown(
 st.header("1. Proxy Computation")
 st.markdown(r"""
 Observable signals from each interaction are combined into a raw proxy score:
-
-$$\hat{v} = \sum_i w_i \cdot x_i \quad \in [-1, +1]$$
-
+""")
+st.latex(r"\hat{v} = \sum_i w_i \cdot x_i \quad \in [-1, +1]")
+st.markdown(r"""
 where $x_i$ are normalised observables (task progress, rework count, verifier rejections,
 engagement) and $w_i$ are calibrated weights.
 
 The raw score is then mapped to a probability through a calibrated sigmoid:
-
-$$p = P(v = +1 \mid \hat{v}) = \frac{1}{1 + e^{-k(\hat{v} - b)}}$$
-
-where $k$ controls steepness and $b$ is the bias. This gives us a **soft label** —
+""")
+st.latex(r"p = P(v = +1 \mid \hat{v}) = \frac{1}{1 + e^{-k(\hat{v} - b)}}")
+st.markdown(r"""
+where $k$ controls steepness and $b$ is the bias. This gives us a **soft label** ---
 a probability that the interaction is beneficial, rather than a binary decision.
+Using probabilistic labels avoids the brittleness of hard binary classifications and
+better captures uncertainty [4, 5].
 """)
 
 # ── Payoff Structure ──────────────────────────────────────────────────────────
@@ -40,26 +43,28 @@ a probability that the interaction is beneficial, rather than a binary decision.
 st.header("2. Soft Payoff Structure")
 st.markdown(r"""
 Given a soft label $p$, the expected surplus and externality are:
-
-$$S_{\text{soft}} = p \cdot s^{+} - (1-p) \cdot s^{-}$$
-
-$$E_{\text{soft}} = (1-p) \cdot h$$
-
+""")
+st.latex(r"S_{\text{soft}} = p \cdot s^{+} - (1-p) \cdot s^{-}")
+st.latex(r"E_{\text{soft}} = (1-p) \cdot h")
+st.markdown(r"""
 where:
 - $s^{+}$ = surplus when interaction is beneficial
 - $s^{-}$ = cost when interaction is harmful
 - $h$ = externality harm parameter
 
 **Agent payoffs** decompose as:
-
-$$\pi_i = \underbrace{\alpha_i \cdot S_{\text{soft}}}_{\text{surplus share}}
-        + \underbrace{T_i}_{\text{transfers}}
-        - \underbrace{G_i}_{\text{governance cost}}
-        - \underbrace{\rho_i \cdot E_{\text{soft}}}_{\text{externality cost}}
-        + \underbrace{w_{\text{rep}} \cdot \Delta R_i}_{\text{reputation}}$$
-
+""")
+st.latex(
+    r"\pi_i = \underbrace{\alpha_i \cdot S_{\text{soft}}}_{\text{surplus share}}"
+    r" + \underbrace{T_i}_{\text{transfers}}"
+    r" - \underbrace{G_i}_{\text{governance cost}}"
+    r" - \underbrace{\rho_i \cdot E_{\text{soft}}}_{\text{externality cost}}"
+    r" + \underbrace{w_{\text{rep}} \cdot \Delta R_i}_{\text{reputation}}"
+)
+st.markdown(r"""
 The externality internalisation parameters $\rho_a, \rho_b \in [0, 1]$ control how much
-each party bears the cost of ecosystem harm.
+each party bears the cost of ecosystem harm. This payoff decomposition draws on
+mechanism design principles [3] and the distributional safety framework [4].
 """)
 
 # ── Acceptance Threshold ──────────────────────────────────────────────────────
@@ -71,29 +76,33 @@ is the acceptance threshold (default 0.5). Rejected interactions still generate 
 for the participants but are excluded from the "official" ecosystem metrics.
 
 This creates a natural tension: agents may exploit borderline interactions that
-are accepted with $p$ slightly above $\theta$.
+are accepted with $p$ slightly above $\theta$. This is analogous to the adverse
+selection problem described by Glosten & Milgrom [2], where willingness to
+trade at a given price reveals private information.
 """)
 
 # ── Safety Metrics ────────────────────────────────────────────────────────────
 
 st.header("4. Safety Metrics")
 st.markdown(r"""
-**Toxicity rate** measures expected harm among accepted interactions:
-
-$$\text{Toxicity} = \mathbb{E}[1 - p \mid \text{accepted}]
-= \frac{\sum_{i \in \text{accepted}} (1 - p_i)}{|\text{accepted}|}$$
-
+**Toxicity rate** measures expected harm among accepted interactions [4]:
+""")
+st.latex(
+    r"\text{Toxicity} = \mathbb{E}[1 - p \mid \text{accepted}]"
+    r" = \frac{\sum_{i \in \text{accepted}} (1 - p_i)}{|\text{accepted}|}"
+)
+st.markdown(r"""
 **Quality gap** measures selection effects:
-
-$$\text{QualityGap} = \mathbb{E}[p \mid \text{accepted}] - \mathbb{E}[p \mid \text{rejected}]$$
-
-A **negative** quality gap signals **adverse selection** — the ecosystem is preferentially
-accepting lower-quality interactions.
+""")
+st.latex(r"\text{QualityGap} = \mathbb{E}[p \mid \text{accepted}] - \mathbb{E}[p \mid \text{rejected}]")
+st.markdown(r"""
+A **negative** quality gap signals **adverse selection** --- the ecosystem is preferentially
+accepting lower-quality interactions. This is the multi-agent analogue of Akerlof's
+"lemons" problem, where markets attract the worst risks [2].
 
 **Total welfare** sums all agent payoffs:
-
-$$W = \sum_{i} \pi_i$$
 """)
+st.latex(r"W = \sum_{i} \pi_i")
 
 # ── Governance Levers ─────────────────────────────────────────────────────────
 
@@ -134,27 +143,53 @@ governance_data = {
     ],
 }
 
-import pandas as pd
 st.dataframe(pd.DataFrame(governance_data), use_container_width=True, hide_index=True)
+
+st.markdown("""
+These levers are inspired by economic mechanism design [3] --- creating incentive
+structures where truthful, cooperative behaviour is the dominant strategy.
+""")
 
 # ── Agent Types ───────────────────────────────────────────────────────────────
 
 st.header("6. Agent Behavioural Types")
-st.markdown(r"""
-| Type | Strategy | Typical $p$ |
-|------|----------|-------------|
-| **Honest** | Always cooperates, high-quality interactions | $p \approx 0.8\text{–}1.0$ |
-| **Opportunistic** | Cooperates when observed, exploits when possible | $p \approx 0.4\text{–}0.8$ |
-| **Deceptive** | Mimics honest behaviour, gradually becomes exploitative | $p$ starts high, decays |
-| **Adversarial** | Actively tries to harm ecosystem or extract value | $p \approx 0.1\text{–}0.3$ |
-| **Adaptive Adversary** | Learns from detection, evolves strategies to evade governance | varies |
+st.markdown("""
+The agent taxonomy maps to the informed-vs-uninformed trader framework from
+Kyle [1], where agents with private information can strategically exploit it:
+""")
+
+agent_data = {
+    "Type": ["Honest", "Opportunistic", "Deceptive", "Adversarial", "Adaptive Adversary"],
+    "Strategy": [
+        "Always cooperates, high-quality interactions",
+        "Cooperates when observed, exploits when possible",
+        "Mimics honest behaviour, gradually becomes exploitative",
+        "Actively tries to harm ecosystem or extract value",
+        "Learns from detection, evolves strategies to evade governance",
+    ],
+    "Typical p": [
+        "p ≈ 0.8\u20131.0",
+        "p ≈ 0.4\u20130.8",
+        "p starts high, decays",
+        "p ≈ 0.1\u20130.3",
+        "varies",
+    ],
+}
+
+st.dataframe(pd.DataFrame(agent_data), use_container_width=True, hide_index=True)
+
+st.markdown("""
+Deceptive agents, like Kyle's informed traders [1], profit by selectively engaging when
+they have private knowledge that an interaction will benefit them at others' expense.
+The acceptance mechanism acts as a market maker [2], setting a "price" (threshold) that
+reveals information about interaction quality.
 """)
 
 # ── Information Flow & Boundaries ─────────────────────────────────────────────
 
 st.header("7. Semi-Permeable Boundaries")
 st.markdown(r"""
-The boundary module models information flow between the sandbox and external world:
+The boundary module models information flow between the sandbox and external world [5]:
 
 - **Inbound flows**: data entering the sandbox (queries to external services, data imports)
 - **Outbound flows**: data leaving the sandbox (results, logs, potential leakage)
@@ -172,13 +207,19 @@ using configurable regex rules, generating alerts and recommendations.
 
 st.header("References")
 st.markdown("""
-1. **Distributional safety**: Ensuring that the *distribution* of outcomes across
-   all agents remains fair, not just the average.
-2. **Soft labelling**: Using probabilistic labels avoids the brittleness of hard
-   binary classifications and better captures uncertainty.
-3. **Mechanism design**: Governance levers are inspired by economic mechanism design
-   — creating incentive structures where truthful, cooperative behaviour is the
-   dominant strategy.
-4. **Adverse selection**: From insurance economics — when a market mechanism
-   preferentially attracts the worst risks, leading to market failure.
+1. Kyle, A.S. (1985). *Continuous Auctions and Insider Trading*.
+   Econometrica, 53(6), 1315--1335.
+2. Glosten, L.R. & Milgrom, P.R. (1985). *Bid, Ask and Transaction Prices in a Specialist
+   Market with Heterogeneously Informed Traders*. Journal of Financial Economics, 14(1), 71--100.
+3. Myerson, R.B. (1981). *Optimal Auction Design*. Mathematics of Operations Research, 6(1),
+   58--73. See also Hurwicz, L. (1960). *Optimality and Informational Efficiency in Resource
+   Allocation Processes*. Mathematical Methods in the Social Sciences.
+4. [Distributional Safety in Agentic Systems](https://arxiv.org/abs/2512.16856)
+5. [Multi-Agent Market Dynamics](https://arxiv.org/abs/2502.14143)
+
+**Further reading:**
+- Akerlof, G.A. (1970). *The Market for "Lemons": Quality Uncertainty and the Market
+  Mechanism*. Quarterly Journal of Economics, 84(3), 488--500.
+- [Moltbook](https://moltbook.com)
+- [@sebkrier's thread on agent economies](https://x.com/sebkrier/status/2017993948132774232)
 """)


### PR DESCRIPTION
- Move all display equations from $$...$$ in st.markdown to st.latex()
  to prevent Streamlit's markdown parser from interfering with KaTeX
  rendering (multi-line equations, \underbrace, \mathbb, \text, \frac)
- Convert agent types markdown table to st.dataframe() to fix inline
  math ($...$) that fails to render inside markdown table cells
- Replace generic concept descriptions in References with proper
  academic citations (Kyle 1985, Glosten-Milgrom 1985, Myerson 1981,
  plus the two arXiv papers from docs/theory.md)
- Add numbered in-text citations [1]-[5] throughout all theory sections
- Move pandas import to top of file alongside streamlit

https://claude.ai/code/session_01FK8ey6TvaagBpLkkmXxDqD