### PR TITLE
test: skip CSV export test when pandas not installed

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,6 +147,7 @@ class TestRunSubcommand:
 
     def test_run_export_csv(self, monkeypatch, capsys, tmp_path):
         """run with --export-csv should create CSV files in the given directory."""
+        pytest.importorskip("pandas", reason="pandas required for CSV export")
         if not Path(BASELINE_SCENARIO).exists():
             pytest.skip("baseline.yaml not found")
         csv_dir = tmp_path / "csv_output"


### PR DESCRIPTION
Add pytest.importorskip for pandas in test_run_export_csv since pandas is an optional dependency (analysis extra) not installed by the CI's [dev,runtime] extras.

https://claude.ai/code/session_01YKhZvVLUMt45X3hXbZd53i

## Summary

Brief description of the changes.

## Changes

- ...
- ...

## Test Plan

- [ ] Existing tests pass (`pytest tests/ -v`)
- [ ] Lint passes (`ruff check src/ tests/`)
- [ ] Type check passes (`mypy src/`)
- [ ] New tests added (if applicable)

## Related Issues

Closes #
