### PR TITLE
Add LessWrong multi-agent experiments article to references

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,4 +309,5 @@ distributional-agi-safety/
 - [Distributional Safety in Agentic Systems](https://arxiv.org/abs/2512.16856)
 - [Multi-Agent Market Dynamics](https://arxiv.org/abs/2502.14143)
 - [The Hot Mess Theory of AI](https://alignment.anthropic.com/2026/hot-mess-of-ai/)
+- [The need for multi-agent experiments](https://www.lesswrong.com/posts/gtLkvS6tDLstBd8uY/the-need-for-multi-agent-experiments-1) - LessWrong
 - [Moltbook](https://moltbook.com) | [@sebkrier](https://x.com/sebkrier/status/2017993948132774232)


### PR DESCRIPTION
Cites "The need for multi-agent experiments" which argues for direct
multi-agent AI testing frameworks - directly relevant to this repo's
mission of simulating multi-agent safety scenarios.

https://claude.ai/code/session_016VbwC745gD8y9xPk1PdHam