### PR TITLE
Add get_sybil_clusters and get_flagged_sybil_agents to Orchestrator

### DIFF
--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -1010,6 +1010,18 @@ class Orchestrator:
             return None
         return self.governance_engine.get_collusion_report()
 
+    def get_sybil_clusters(self) -> List[set]:
+        """Get detected Sybil clusters."""
+        if self.governance_engine is None:
+            return []
+        return self.governance_engine.get_sybil_clusters()
+
+    def get_flagged_sybil_agents(self) -> frozenset:
+        """Get set of agents flagged as Sybils."""
+        if self.governance_engine is None:
+            return frozenset()
+        return self.governance_engine.get_flagged_sybil_agents()
+
     # =========================================================================
     # Composite Task Support
     # =========================================================================


### PR DESCRIPTION
These delegation methods forward to GovernanceEngine, matching the
existing pattern used by get_collusion_report(). Without them,
calling orchestrator.get_sybil_clusters() or
orchestrator.get_flagged_sybil_agents() raises AttributeError.

https://claude.ai/code/session_0187pBsNJpagRgqfbSsnY2Mf