### PR TITLE
Add seed parameter to test_request_external_interaction

### DIFF
--- a/tests/test_boundaries.py
+++ b/tests/test_boundaries.py
@@ -836,6 +836,7 @@ class TestBoundaryIntegration:
             enable_boundaries=True,
             n_epochs=1,
             steps_per_epoch=1,
+            seed=42,
         )
         orchestrator = Orchestrator(config)
 


### PR DESCRIPTION
## Summary

Add explicit seed parameter to the Orchestrator configuration in `test_request_external_interaction` to ensure reproducible test results.

## Changes

- Added `seed=42` parameter to the Orchestrator config in `test_request_external_interaction` test case

## Test Plan

- [ ] Existing tests pass (`pytest tests/ -v`)
- [ ] Lint passes (`ruff check src/ tests/`)
- [ ] Type check passes (`mypy src/`)
- [ ] New tests added (if applicable)

## Related Issues

Closes #

https://claude.ai/code/session_012kze9eM7H8L4iJatT8XDCL