### PR TITLE
Fix formatting and dependency quoting issues

### DIFF
--- a/swarm/core/sigmoid.py
+++ b/swarm/core/sigmoid.py
@@ -11,10 +11,10 @@ def calibrated_sigmoid(v_hat: float, k: float = 2.0) -> float:
     Args:
         v_hat: Raw proxy score in [-1, +1]
         k: Calibration sharpness parameter (default 2.0)
-           - k = 0: Always returns 0.5
-           - k < 2: Soft/uncertain labels
-           - k = 2: Moderate calibration
-           - k > 2: Sharp/confident labels
+            - k = 0: Always returns 0.5
+            - k < 2: Soft/uncertain labels
+            - k = 2: Moderate calibration
+            - k > 2: Sharp/confident labels
 
     Returns:
         p: Probability in [0, 1]

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "uv pip install --system mkdocs-material mkdocstrings[python] pymdown-extensions && mkdocs build",
+  "buildCommand": "uv pip install --system mkdocs-material 'mkdocstrings[python]' pymdown-extensions && mkdocs build",
   "outputDirectory": "site",
   "framework": null
 }


### PR DESCRIPTION
## Summary

This PR fixes two minor issues: docstring indentation in the sigmoid module and dependency quoting in the Vercel build configuration.

## Changes

- Fixed docstring indentation in `swarm/core/sigmoid.py` to align parameter documentation consistently (4 spaces instead of mixed indentation)
- Added quotes around `mkdocstrings[python]` in `vercel.json` to properly handle the bracket syntax in pip install commands

## Test Plan

- [ ] Existing tests pass (`pytest tests/ -v`)
- [ ] Lint passes (`ruff check src/ tests/`)
- [ ] Type check passes (`mypy src/`)
- [ ] New tests added (if applicable)

## Related Issues

Closes #

https://claude.ai/code/session_01L1hECYqRcomyLJoYaznYXz