### PR TITLE
Fix mobile formula rendering by removing dead polyfill.io and adding responsive math CSS

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -5,9 +5,16 @@ window.MathJax = {
     processEscapes: true,
     processEnvironments: true
   },
+  chtml: {
+    matchFontHeight: false,
+    mtextInheritFont: true
+  },
   options: {
     ignoreHtmlClass: ".*|",
-    processHtmlClass: "arithmatex"
+    processHtmlClass: "arithmatex",
+    renderActions: {
+      addMenu: []
+    }
   }
 };
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -101,6 +101,20 @@
   font-weight: 800;
 }
 
+/* MathJax display math: allow horizontal scroll on narrow screens */
+.MathJax {
+  overflow-x: auto;
+  overflow-y: hidden;
+  max-width: 100%;
+}
+
+mjx-container[jax="CHTML"][display="true"] {
+  overflow-x: auto;
+  overflow-y: hidden;
+  max-width: 100%;
+  padding: 0.25rem 0;
+}
+
 /* Hero section on homepage */
 .md-content__inner > h1:first-child {
   display: none;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,7 +71,6 @@ markdown_extensions:
 
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 plugins:


### PR DESCRIPTION
The polyfill.io CDN was acquired by a malicious actor in 2024 and is now
blocked by most mobile browsers, preventing MathJax from loading. Removing
it fixes formula rendering since MathJax 3 doesn't need ES6 polyfills.

Also adds overflow scrolling for display math on narrow screens and
improves MathJax CHTML output config for mobile.

https://claude.ai/code/session_011fiWCtYmMR9yeswyUYsnBc