### PR TITLE
Fix import sorting lint error in test_simulated_apis.py

### DIFF
--- a/tests/test_simulated_apis.py
+++ b/tests/test_simulated_apis.py
@@ -2,10 +2,17 @@
 
 import pytest
 
-from swarm.env.simulated_apis.gating import ApprovalConfig, IrreversibleActionRequiresApproval
+from swarm.env.simulated_apis.gating import (
+    ApprovalConfig,
+    IrreversibleActionRequiresApproval,
+)
 from swarm.env.simulated_apis.metrics import compute_episode_metrics
 from swarm.env.simulated_apis.spec import Domain, Split
-from swarm.env.simulated_apis.suite import generate_task_bundle, make_service_and_log, score_task_bundle
+from swarm.env.simulated_apis.suite import (
+    generate_task_bundle,
+    make_service_and_log,
+    score_task_bundle,
+)
 from swarm.env.simulated_apis.templates import list_templates
 
 


### PR DESCRIPTION
Reformat long import lines to comply with ruff I001 (isort) rule.

https://claude.ai/code/session_01DVuxr3AT2bie7D74vUsDYr

## Summary

Brief description of the changes.

## Changes

- ...
- ...

## Test Plan

- [ ] Existing tests pass (`pytest tests/ -v`)
- [ ] Lint passes (`ruff check src/ tests/`)
- [ ] Type check passes (`mypy src/`)
- [ ] New tests added (if applicable)

## Related Issues

Closes #
