### PR TITLE
Add Diversity as Defense (DaD) governance lever

### DIFF
--- a/swarm/governance/__init__.py
+++ b/swarm/governance/__init__.py
@@ -6,6 +6,7 @@ from swarm.governance.circuit_breaker import CircuitBreakerLever
 from swarm.governance.collusion import CollusionPenaltyLever
 from swarm.governance.config import GovernanceConfig
 from swarm.governance.decomposition import DecompositionLever
+from swarm.governance.diversity import DiversityDefenseLever, DiversityMetrics
 from swarm.governance.dynamic_friction import IncoherenceFrictionLever
 from swarm.governance.engine import GovernanceEffect, GovernanceEngine
 from swarm.governance.ensemble import SelfEnsembleLever
@@ -39,4 +40,6 @@ __all__ = [
     "IncoherenceFrictionLever",
     "MoltbookRateLimitLever",
     "ChallengeVerificationLever",
+    "DiversityDefenseLever",
+    "DiversityMetrics",
 ]

--- a/swarm/governance/config.py
+++ b/swarm/governance/config.py
@@ -125,6 +125,19 @@ class GovernanceConfig(BaseModel):
     moltbook_challenge_enabled: bool = False
     moltbook_challenge_difficulty: float = 0.5
     moltbook_challenge_window_steps: int = 1
+
+    # Diversity as Defense (DaD)
+    diversity_enabled: bool = False
+    diversity_rho_max: float = 0.5  # Correlation cap (Rule 1)
+    diversity_entropy_min: float = 0.5  # Minimum Shannon entropy of type mix (Rule 2)
+    diversity_adversarial_fraction_min: float = 0.0  # Min adversarial probe fraction (Rule 3)
+    diversity_disagreement_tau: float = 0.7  # Disagreement threshold for audit trigger (Rule 4)
+    diversity_error_threshold_p: float = 0.5  # p below this counts as an error
+    diversity_correlation_penalty_rate: float = 0.05  # Cost when correlation cap violated
+    diversity_entropy_penalty_rate: float = 0.05  # Cost when entropy floor violated
+    diversity_audit_cost: float = 0.1  # Cost applied when disagreement triggers audit
+    diversity_correlation_window: int = 50  # Window of recent interactions for correlation
+
     @model_validator(mode="after")
     def _run_validation(self) -> "GovernanceConfig":
         self._check_values()
@@ -247,3 +260,29 @@ class GovernanceConfig(BaseModel):
             raise ValueError("moltbook_challenge_difficulty must be in [0, 1]")
         if self.moltbook_challenge_window_steps < 0:
             raise ValueError("moltbook_challenge_window_steps must be >= 0")
+
+        # Diversity as Defense validation
+        if not 0.0 <= self.diversity_rho_max <= 1.0:
+            raise ValueError("diversity_rho_max must be in [0, 1]")
+        if self.diversity_entropy_min < 0.0:
+            raise ValueError("diversity_entropy_min must be non-negative")
+        if not 0.0 <= self.diversity_adversarial_fraction_min <= 1.0:
+            raise ValueError(
+                "diversity_adversarial_fraction_min must be in [0, 1]"
+            )
+        if not 0.0 <= self.diversity_disagreement_tau <= 1.0:
+            raise ValueError("diversity_disagreement_tau must be in [0, 1]")
+        if not 0.0 <= self.diversity_error_threshold_p <= 1.0:
+            raise ValueError("diversity_error_threshold_p must be in [0, 1]")
+        if self.diversity_correlation_penalty_rate < 0:
+            raise ValueError(
+                "diversity_correlation_penalty_rate must be non-negative"
+            )
+        if self.diversity_entropy_penalty_rate < 0:
+            raise ValueError(
+                "diversity_entropy_penalty_rate must be non-negative"
+            )
+        if self.diversity_audit_cost < 0:
+            raise ValueError("diversity_audit_cost must be non-negative")
+        if self.diversity_correlation_window < 1:
+            raise ValueError("diversity_correlation_window must be >= 1")

--- a/swarm/governance/diversity.py
+++ b/swarm/governance/diversity.py
@@ -1,0 +1,512 @@
+"""Diversity as Defense (DaD) governance lever.
+
+Implements the governance principle: maintain sufficient agent heterogeneity
+to keep error correlations below a controlled threshold; minimize tail risk
+(correlation-amplified failure), not mean error.
+
+The lever tracks pairwise error correlations across agent types and enforces:
+  Rule 1 - Correlation cap: rho_bar(x) <= rho_max
+  Rule 2 - Entropy floor: H(x) >= H_min
+  Rule 3 - Adversarial fraction: sum of adversarial type weights >= alpha_min
+  Rule 4 - Disagreement-triggered audit: D(t) >= tau triggers audit
+"""
+
+import math
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+from swarm.env.state import EnvState
+from swarm.governance.config import GovernanceConfig
+from swarm.governance.levers import GovernanceLever, LeverEffect
+from swarm.models.agent import AgentType
+from swarm.models.interaction import SoftInteraction
+
+
+@dataclass
+class DiversityMetrics:
+    """Snapshot of diversity-related measurements.
+
+    Captures the state of the population mix, error correlations, and
+    rule compliance at a point in time.
+    """
+
+    # Population mix x_k for each agent type
+    population_mix: Dict[str, float] = field(default_factory=dict)
+
+    # Mean error rate across all agents
+    mean_error_rate: float = 0.0
+
+    # Mean pairwise error correlation (rho_bar)
+    mean_correlation: float = 0.0
+
+    # Per-type-pair correlation matrix rho_{k,l}
+    type_correlation_matrix: Dict[Tuple[str, str], float] = field(
+        default_factory=dict
+    )
+
+    # Shannon entropy of the population mix
+    entropy: float = 0.0
+
+    # Adversarial fraction in the mix
+    adversarial_fraction: float = 0.0
+
+    # Risk surrogate: p_bar * (1 - p_bar) * (1 + (N-1) * rho_bar)
+    risk_surrogate: float = 0.0
+
+    # Rule compliance flags
+    correlation_cap_satisfied: bool = True
+    entropy_floor_satisfied: bool = True
+    adversarial_fraction_satisfied: bool = True
+
+    # Last disagreement rate observed
+    disagreement_rate: float = 0.0
+    disagreement_audit_triggered: bool = False
+
+
+class DiversityDefenseLever(GovernanceLever):
+    """Diversity as Defense governance lever.
+
+    Tracks agent error patterns by type and enforces diversity constraints
+    to reduce correlation-amplified tail risk in swarm decisions.
+
+    The lever monitors four governance rules:
+
+    1. **Correlation cap** -- Penalises when the induced mean pairwise error
+       correlation ``rho_bar(x)`` exceeds ``rho_max``.
+    2. **Entropy floor** -- Penalises when the Shannon entropy ``H(x)`` of
+       the agent-type population mix drops below ``H_min``.
+    3. **Adversarial fraction** -- Warns when the fraction of adversarial
+       probe agents drops below ``alpha_min``.
+    4. **Disagreement-triggered audit** -- Applies an audit cost when the
+       per-interaction disagreement rate exceeds ``tau``.
+    """
+
+    def __init__(self, config: GovernanceConfig):
+        super().__init__(config)
+
+        # Per-agent binary error history (agent_id -> list of 0/1)
+        self._error_history: Dict[str, List[int]] = defaultdict(list)
+
+        # Agent-to-type mapping (populated from EnvState)
+        self._agent_types: Dict[str, str] = {}
+
+        # Most recent metrics snapshot
+        self._latest_metrics: Optional[DiversityMetrics] = None
+
+    @property
+    def name(self) -> str:
+        return "diversity_defense"
+
+    # ------------------------------------------------------------------
+    # Core math helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def compute_population_mix(
+        agent_types: Dict[str, str],
+    ) -> Dict[str, float]:
+        """Compute the population mix x_k from agent type assignments.
+
+        Args:
+            agent_types: Mapping from agent_id to type label.
+
+        Returns:
+            Dictionary mapping type label to fraction of population.
+        """
+        if not agent_types:
+            return {}
+        counts: Dict[str, int] = defaultdict(int)
+        for type_label in agent_types.values():
+            counts[type_label] += 1
+        total = len(agent_types)
+        return {k: v / total for k, v in counts.items()}
+
+    @staticmethod
+    def compute_shannon_entropy(mix: Dict[str, float]) -> float:
+        """Compute Shannon entropy H(x) = -sum x_k log x_k.
+
+        Args:
+            mix: Population mix (values must sum to 1).
+
+        Returns:
+            Shannon entropy in nats.
+        """
+        entropy = 0.0
+        for x_k in mix.values():
+            if x_k > 0:
+                entropy -= x_k * math.log(x_k)
+        return entropy
+
+    @staticmethod
+    def compute_pairwise_correlation(
+        errors_i: List[int],
+        errors_j: List[int],
+    ) -> float:
+        """Compute Pearson correlation between two binary error sequences.
+
+        Args:
+            errors_i: Binary error indicators for agent i.
+            errors_j: Binary error indicators for agent j.
+
+        Returns:
+            Pearson correlation coefficient, or 0.0 if undefined.
+        """
+        n = min(len(errors_i), len(errors_j))
+        if n < 2:
+            return 0.0
+
+        ei = errors_i[-n:]
+        ej = errors_j[-n:]
+
+        mean_i = sum(ei) / n
+        mean_j = sum(ej) / n
+
+        var_i = sum((e - mean_i) ** 2 for e in ei) / n
+        var_j = sum((e - mean_j) ** 2 for e in ej) / n
+
+        if var_i < 1e-12 or var_j < 1e-12:
+            return 0.0
+
+        cov = sum((ei[k] - mean_i) * (ej[k] - mean_j) for k in range(n)) / n
+        return cov / math.sqrt(var_i * var_j)
+
+    def compute_type_correlations(
+        self,
+        window: int,
+    ) -> Tuple[Dict[Tuple[str, str], float], float]:
+        """Compute per-type-pair and mean pairwise error correlations.
+
+        Groups agents by type and computes the average within-group and
+        cross-group pairwise correlations, then derives the mix-weighted
+        mean correlation rho_bar(x).
+
+        Args:
+            window: Number of most recent errors to use per agent.
+
+        Returns:
+            Tuple of (type-pair correlation dict, mean correlation).
+        """
+        # Group agents by type
+        type_agents: Dict[str, List[str]] = defaultdict(list)
+        for agent_id, type_label in self._agent_types.items():
+            if agent_id in self._error_history and self._error_history[agent_id]:
+                type_agents[type_label].append(agent_id)
+
+        types = sorted(type_agents.keys())
+        if not types:
+            return {}, 0.0
+
+        # Trim histories to window
+        trimmed: Dict[str, List[int]] = {}
+        for agent_id, history in self._error_history.items():
+            trimmed[agent_id] = history[-window:]
+
+        # Compute type-level correlations rho_{k,l}
+        type_corr: Dict[Tuple[str, str], float] = {}
+        for i, tk in enumerate(types):
+            for j, tl in enumerate(types):
+                if j < i:
+                    type_corr[(tk, tl)] = type_corr[(tl, tk)]
+                    continue
+                agents_k = type_agents[tk]
+                agents_l = type_agents[tl]
+                pair_corrs: List[float] = []
+                for ak in agents_k:
+                    for al in agents_l:
+                        if ak == al:
+                            continue
+                        rho = self.compute_pairwise_correlation(
+                            trimmed[ak], trimmed[al]
+                        )
+                        pair_corrs.append(rho)
+                type_corr[(tk, tl)] = (
+                    sum(pair_corrs) / len(pair_corrs)
+                    if pair_corrs
+                    else 0.0
+                )
+
+        # Mix-weighted mean: rho_bar = sum_k,l x_k x_l rho_{k,l}
+        mix = self.compute_population_mix(self._agent_types)
+        rho_bar = 0.0
+        for (tk, tl), rho_kl in type_corr.items():
+            rho_bar += mix.get(tk, 0.0) * mix.get(tl, 0.0) * rho_kl
+
+        return type_corr, rho_bar
+
+    @staticmethod
+    def compute_risk_surrogate(
+        mean_error: float,
+        mean_correlation: float,
+        n_agents: int,
+    ) -> float:
+        """Compute the risk surrogate R(x).
+
+        R(x) = p_bar * (1 - p_bar) * (1 + (N - 1) * rho_bar)
+
+        This is proportional to the variance of the sum of errors, which
+        drives the tail probability of collective failure under majority
+        vote.
+
+        Args:
+            mean_error: Average per-agent error rate (p_bar).
+            mean_correlation: Mean pairwise error correlation (rho_bar).
+            n_agents: Number of agents (N).
+
+        Returns:
+            Risk surrogate value.
+        """
+        if n_agents < 1:
+            return 0.0
+        return (
+            mean_error
+            * (1 - mean_error)
+            * (1 + (n_agents - 1) * mean_correlation)
+        )
+
+    @staticmethod
+    def compute_disagreement_rate(
+        decisions: List[int],
+    ) -> float:
+        """Compute disagreement rate D(t) for a set of agent decisions.
+
+        D(t) = 1 - max_y (1/N) sum_i 1[y_i = y]
+
+        Args:
+            decisions: List of binary decisions (0 or 1) from N agents.
+
+        Returns:
+            Disagreement rate in [0, 1].
+        """
+        if not decisions:
+            return 0.0
+        n = len(decisions)
+        count_1 = sum(decisions)
+        count_0 = n - count_1
+        majority_frac = max(count_1, count_0) / n
+        return 1.0 - majority_frac
+
+    # ------------------------------------------------------------------
+    # Lifecycle hooks
+    # ------------------------------------------------------------------
+
+    def _refresh_agent_types(self, state: EnvState) -> None:
+        """Update agent type mapping from current environment state."""
+        self._agent_types = {
+            agent_id: agent_state.agent_type.value
+            for agent_id, agent_state in state.agents.items()
+        }
+
+    def _compute_full_metrics(self, state: EnvState) -> DiversityMetrics:
+        """Compute a full metrics snapshot from current state."""
+        self._refresh_agent_types(state)
+
+        mix = self.compute_population_mix(self._agent_types)
+        entropy = self.compute_shannon_entropy(mix)
+
+        adversarial_types = {AgentType.ADVERSARIAL.value}
+        adv_fraction = sum(
+            mix.get(t, 0.0) for t in adversarial_types
+        )
+
+        window = self.config.diversity_correlation_window
+        type_corr, rho_bar = self.compute_type_correlations(window)
+
+        # Mean error rate across all agents with history
+        all_errors: List[int] = []
+        for history in self._error_history.values():
+            recent = history[-window:]
+            all_errors.extend(recent)
+        mean_error = sum(all_errors) / len(all_errors) if all_errors else 0.0
+
+        n_agents = len(state.agents)
+        risk = self.compute_risk_surrogate(mean_error, rho_bar, n_agents)
+
+        metrics = DiversityMetrics(
+            population_mix=mix,
+            mean_error_rate=mean_error,
+            mean_correlation=rho_bar,
+            type_correlation_matrix=type_corr,
+            entropy=entropy,
+            adversarial_fraction=adv_fraction,
+            risk_surrogate=risk,
+            correlation_cap_satisfied=(
+                rho_bar <= self.config.diversity_rho_max
+            ),
+            entropy_floor_satisfied=(
+                entropy >= self.config.diversity_entropy_min
+            ),
+            adversarial_fraction_satisfied=(
+                adv_fraction >= self.config.diversity_adversarial_fraction_min
+            ),
+        )
+
+        self._latest_metrics = metrics
+        return metrics
+
+    def on_epoch_start(
+        self,
+        state: EnvState,
+        epoch: int,
+    ) -> LeverEffect:
+        """Evaluate diversity rules at epoch boundary.
+
+        Computes population mix, correlation, entropy, and adversarial
+        fraction.  Applies cost penalties when correlation cap or entropy
+        floor constraints are violated.
+
+        Args:
+            state: Current environment state.
+            epoch: The epoch number starting.
+
+        Returns:
+            LeverEffect with costs for constraint violations.
+        """
+        if not self.config.diversity_enabled:
+            return LeverEffect(lever_name=self.name)
+
+        metrics = self._compute_full_metrics(state)
+
+        cost_a = 0.0
+        cost_b = 0.0
+        violations: List[str] = []
+
+        # Rule 1: Correlation cap
+        if not metrics.correlation_cap_satisfied:
+            excess = metrics.mean_correlation - self.config.diversity_rho_max
+            penalty = excess * self.config.diversity_correlation_penalty_rate
+            cost_a += penalty
+            cost_b += penalty
+            violations.append("correlation_cap")
+
+        # Rule 2: Entropy floor
+        if not metrics.entropy_floor_satisfied:
+            deficit = self.config.diversity_entropy_min - metrics.entropy
+            penalty = deficit * self.config.diversity_entropy_penalty_rate
+            cost_a += penalty
+            cost_b += penalty
+            violations.append("entropy_floor")
+
+        # Rule 3: Adversarial fraction (warning only, no cost)
+        if not metrics.adversarial_fraction_satisfied:
+            violations.append("adversarial_fraction_low")
+
+        return LeverEffect(
+            cost_a=cost_a,
+            cost_b=cost_b,
+            lever_name=self.name,
+            details={
+                "epoch": epoch,
+                "population_mix": metrics.population_mix,
+                "entropy": metrics.entropy,
+                "mean_correlation": metrics.mean_correlation,
+                "risk_surrogate": metrics.risk_surrogate,
+                "adversarial_fraction": metrics.adversarial_fraction,
+                "violations": violations,
+                "correlation_cap_satisfied": metrics.correlation_cap_satisfied,
+                "entropy_floor_satisfied": metrics.entropy_floor_satisfied,
+                "adversarial_fraction_satisfied": (
+                    metrics.adversarial_fraction_satisfied
+                ),
+            },
+        )
+
+    def on_interaction(
+        self,
+        interaction: SoftInteraction,
+        state: EnvState,
+    ) -> LeverEffect:
+        """Record errors and check disagreement rule.
+
+        Each interaction records a binary error indicator for the
+        initiator.  When ground truth is available, error = 1[p < threshold
+        and ground_truth == -1] or 1[p >= threshold and ground_truth == +1].
+        Without ground truth, error is simply 1[p < threshold].
+
+        After recording, the lever checks the disagreement rate across
+        recent agent decisions.  If the disagreement rate exceeds ``tau``,
+        an audit cost is applied (Rule 4).
+
+        Args:
+            interaction: The completed interaction.
+            state: Current environment state.
+
+        Returns:
+            LeverEffect with audit cost if disagreement threshold breached.
+        """
+        if not self.config.diversity_enabled:
+            return LeverEffect(lever_name=self.name)
+
+        # Record error for the initiator
+        threshold = self.config.diversity_error_threshold_p
+        is_error: int
+        if interaction.ground_truth is not None:
+            # With ground truth: error iff the soft label disagrees
+            predicted_positive = interaction.p >= threshold
+            actually_positive = interaction.ground_truth == 1
+            is_error = 0 if predicted_positive == actually_positive else 1
+        else:
+            # Without ground truth: low p counts as error
+            is_error = 1 if interaction.p < threshold else 0
+
+        agent_id = interaction.initiator
+        self._error_history[agent_id].append(is_error)
+
+        # Trim to window
+        window = self.config.diversity_correlation_window
+        if len(self._error_history[agent_id]) > window:
+            self._error_history[agent_id] = (
+                self._error_history[agent_id][-window:]
+            )
+
+        # Rule 4: Disagreement-triggered audit
+        # Collect most recent decisions from all agents with history
+        recent_decisions: List[int] = []
+        for _aid, history in self._error_history.items():
+            if history:
+                recent_decisions.append(history[-1])
+
+        disagreement = self.compute_disagreement_rate(recent_decisions)
+
+        cost_a = 0.0
+        audit_triggered = False
+        if disagreement >= self.config.diversity_disagreement_tau:
+            cost_a = self.config.diversity_audit_cost
+            audit_triggered = True
+
+        if self._latest_metrics is not None:
+            self._latest_metrics.disagreement_rate = disagreement
+            self._latest_metrics.disagreement_audit_triggered = audit_triggered
+
+        return LeverEffect(
+            cost_a=cost_a,
+            lever_name=self.name,
+            details={
+                "agent_id": agent_id,
+                "is_error": is_error,
+                "p": interaction.p,
+                "disagreement_rate": disagreement,
+                "audit_triggered": audit_triggered,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Accessors
+    # ------------------------------------------------------------------
+
+    def get_metrics(self) -> Optional[DiversityMetrics]:
+        """Return the most recent diversity metrics snapshot."""
+        return self._latest_metrics
+
+    def get_error_history(self) -> Dict[str, List[int]]:
+        """Return per-agent error histories (read-only copy)."""
+        return dict(self._error_history)
+
+    def get_agent_types(self) -> Dict[str, str]:
+        """Return the current agent-to-type mapping."""
+        return dict(self._agent_types)
+
+    def clear_history(self) -> None:
+        """Reset all tracked error histories."""
+        self._error_history.clear()
+        self._latest_metrics = None

--- a/tests/test_diversity.py
+++ b/tests/test_diversity.py
@@ -1,0 +1,717 @@
+"""Tests for the Diversity as Defense (DaD) governance lever."""
+
+import math
+
+import pytest
+from pydantic import ValidationError
+
+from swarm.env.state import EnvState
+from swarm.governance.config import GovernanceConfig
+from swarm.governance.diversity import DiversityDefenseLever
+from swarm.governance.engine import GovernanceEngine
+from swarm.models.agent import AgentType
+from swarm.models.interaction import SoftInteraction
+
+# ---------------------------------------------------------------------------
+# Configuration validation
+# ---------------------------------------------------------------------------
+
+
+class TestDiversityConfig:
+    """Tests for DaD configuration validation."""
+
+    def test_defaults_valid(self):
+        """Default DaD config should pass validation."""
+        config = GovernanceConfig()
+        assert config.diversity_enabled is False
+        assert config.diversity_rho_max == 0.5
+
+    def test_invalid_rho_max(self):
+        with pytest.raises(ValidationError, match="diversity_rho_max"):
+            GovernanceConfig(diversity_rho_max=1.5)
+
+    def test_invalid_rho_max_negative(self):
+        with pytest.raises(ValidationError, match="diversity_rho_max"):
+            GovernanceConfig(diversity_rho_max=-0.1)
+
+    def test_invalid_entropy_min(self):
+        with pytest.raises(ValidationError, match="diversity_entropy_min"):
+            GovernanceConfig(diversity_entropy_min=-1.0)
+
+    def test_invalid_adversarial_fraction_min(self):
+        with pytest.raises(
+            ValidationError, match="diversity_adversarial_fraction_min"
+        ):
+            GovernanceConfig(diversity_adversarial_fraction_min=1.5)
+
+    def test_invalid_disagreement_tau(self):
+        with pytest.raises(
+            ValidationError, match="diversity_disagreement_tau"
+        ):
+            GovernanceConfig(diversity_disagreement_tau=-0.1)
+
+    def test_invalid_error_threshold_p(self):
+        with pytest.raises(
+            ValidationError, match="diversity_error_threshold_p"
+        ):
+            GovernanceConfig(diversity_error_threshold_p=2.0)
+
+    def test_invalid_correlation_penalty_rate(self):
+        with pytest.raises(
+            ValidationError, match="diversity_correlation_penalty_rate"
+        ):
+            GovernanceConfig(diversity_correlation_penalty_rate=-0.1)
+
+    def test_invalid_entropy_penalty_rate(self):
+        with pytest.raises(
+            ValidationError, match="diversity_entropy_penalty_rate"
+        ):
+            GovernanceConfig(diversity_entropy_penalty_rate=-1.0)
+
+    def test_invalid_audit_cost(self):
+        with pytest.raises(ValidationError, match="diversity_audit_cost"):
+            GovernanceConfig(diversity_audit_cost=-1.0)
+
+    def test_invalid_correlation_window(self):
+        with pytest.raises(
+            ValidationError, match="diversity_correlation_window"
+        ):
+            GovernanceConfig(diversity_correlation_window=0)
+
+
+# ---------------------------------------------------------------------------
+# Static math helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPopulationMix:
+    """Tests for compute_population_mix."""
+
+    def test_empty(self):
+        mix = DiversityDefenseLever.compute_population_mix({})
+        assert mix == {}
+
+    def test_single_type(self):
+        agents = {"a1": "honest", "a2": "honest", "a3": "honest"}
+        mix = DiversityDefenseLever.compute_population_mix(agents)
+        assert mix == {"honest": pytest.approx(1.0)}
+
+    def test_uniform_two_types(self):
+        agents = {"a1": "honest", "a2": "adversarial"}
+        mix = DiversityDefenseLever.compute_population_mix(agents)
+        assert mix["honest"] == pytest.approx(0.5)
+        assert mix["adversarial"] == pytest.approx(0.5)
+
+    def test_uneven_mix(self):
+        agents = {
+            "a1": "honest",
+            "a2": "honest",
+            "a3": "honest",
+            "a4": "adversarial",
+        }
+        mix = DiversityDefenseLever.compute_population_mix(agents)
+        assert mix["honest"] == pytest.approx(0.75)
+        assert mix["adversarial"] == pytest.approx(0.25)
+
+
+class TestShannonEntropy:
+    """Tests for compute_shannon_entropy."""
+
+    def test_single_type_zero_entropy(self):
+        entropy = DiversityDefenseLever.compute_shannon_entropy({"a": 1.0})
+        assert entropy == pytest.approx(0.0)
+
+    def test_uniform_binary_max_entropy(self):
+        entropy = DiversityDefenseLever.compute_shannon_entropy(
+            {"a": 0.5, "b": 0.5}
+        )
+        assert entropy == pytest.approx(math.log(2))
+
+    def test_uniform_four_types(self):
+        mix = {"a": 0.25, "b": 0.25, "c": 0.25, "d": 0.25}
+        entropy = DiversityDefenseLever.compute_shannon_entropy(mix)
+        assert entropy == pytest.approx(math.log(4))
+
+    def test_skewed_lower_than_uniform(self):
+        uniform_entropy = DiversityDefenseLever.compute_shannon_entropy(
+            {"a": 0.5, "b": 0.5}
+        )
+        skewed_entropy = DiversityDefenseLever.compute_shannon_entropy(
+            {"a": 0.9, "b": 0.1}
+        )
+        assert skewed_entropy < uniform_entropy
+
+    def test_empty_mix(self):
+        entropy = DiversityDefenseLever.compute_shannon_entropy({})
+        assert entropy == pytest.approx(0.0)
+
+
+class TestPairwiseCorrelation:
+    """Tests for compute_pairwise_correlation."""
+
+    def test_identical_sequences_correlation_one(self):
+        errors = [1, 0, 1, 0, 1, 1, 0, 0, 1, 0]
+        rho = DiversityDefenseLever.compute_pairwise_correlation(errors, errors)
+        assert rho == pytest.approx(1.0)
+
+    def test_opposite_sequences_correlation_neg_one(self):
+        ei = [1, 0, 1, 0, 1, 1, 0, 0, 1, 0]
+        ej = [0, 1, 0, 1, 0, 0, 1, 1, 0, 1]
+        rho = DiversityDefenseLever.compute_pairwise_correlation(ei, ej)
+        assert rho == pytest.approx(-1.0)
+
+    def test_uncorrelated_near_zero(self):
+        # Large independent sequences should have correlation near 0
+        import random
+
+        rng = random.Random(42)
+        ei = [rng.randint(0, 1) for _ in range(1000)]
+        ej = [rng.randint(0, 1) for _ in range(1000)]
+        rho = DiversityDefenseLever.compute_pairwise_correlation(ei, ej)
+        assert abs(rho) < 0.15  # Should be near zero
+
+    def test_constant_sequence_returns_zero(self):
+        ei = [1, 1, 1, 1, 1]
+        ej = [0, 1, 0, 1, 0]
+        rho = DiversityDefenseLever.compute_pairwise_correlation(ei, ej)
+        assert rho == pytest.approx(0.0)
+
+    def test_too_short_returns_zero(self):
+        rho = DiversityDefenseLever.compute_pairwise_correlation([1], [0])
+        assert rho == pytest.approx(0.0)
+
+    def test_empty_returns_zero(self):
+        rho = DiversityDefenseLever.compute_pairwise_correlation([], [])
+        assert rho == pytest.approx(0.0)
+
+
+class TestRiskSurrogate:
+    """Tests for compute_risk_surrogate."""
+
+    def test_zero_error_zero_risk(self):
+        risk = DiversityDefenseLever.compute_risk_surrogate(0.0, 0.5, 10)
+        assert risk == pytest.approx(0.0)
+
+    def test_perfect_accuracy_zero_risk(self):
+        risk = DiversityDefenseLever.compute_risk_surrogate(1.0, 0.5, 10)
+        assert risk == pytest.approx(0.0)
+
+    def test_risk_increases_with_correlation(self):
+        risk_low = DiversityDefenseLever.compute_risk_surrogate(0.3, 0.1, 10)
+        risk_high = DiversityDefenseLever.compute_risk_surrogate(0.3, 0.9, 10)
+        assert risk_high > risk_low
+
+    def test_risk_formula(self):
+        # R = p(1-p)(1 + (N-1)*rho)
+        p, rho, n = 0.3, 0.5, 10
+        expected = p * (1 - p) * (1 + (n - 1) * rho)
+        actual = DiversityDefenseLever.compute_risk_surrogate(p, rho, n)
+        assert actual == pytest.approx(expected)
+
+    def test_zero_agents(self):
+        risk = DiversityDefenseLever.compute_risk_surrogate(0.3, 0.5, 0)
+        assert risk == pytest.approx(0.0)
+
+    def test_single_agent_no_correlation_effect(self):
+        # With N=1, (N-1)*rho = 0 so R = p(1-p)
+        risk = DiversityDefenseLever.compute_risk_surrogate(0.3, 0.9, 1)
+        assert risk == pytest.approx(0.3 * 0.7)
+
+
+class TestDisagreementRate:
+    """Tests for compute_disagreement_rate."""
+
+    def test_unanimous_zero_disagreement(self):
+        d = DiversityDefenseLever.compute_disagreement_rate([1, 1, 1, 1])
+        assert d == pytest.approx(0.0)
+
+    def test_split_maximum_disagreement(self):
+        d = DiversityDefenseLever.compute_disagreement_rate([1, 0, 1, 0])
+        assert d == pytest.approx(0.5)
+
+    def test_majority_partial_disagreement(self):
+        d = DiversityDefenseLever.compute_disagreement_rate([1, 1, 1, 0])
+        assert d == pytest.approx(0.25)
+
+    def test_empty(self):
+        d = DiversityDefenseLever.compute_disagreement_rate([])
+        assert d == pytest.approx(0.0)
+
+    def test_single_decision(self):
+        d = DiversityDefenseLever.compute_disagreement_rate([1])
+        assert d == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Lever lifecycle hooks
+# ---------------------------------------------------------------------------
+
+
+def _make_diverse_state() -> EnvState:
+    """Create an EnvState with a mix of agent types."""
+    state = EnvState()
+    state.add_agent("h1", agent_type=AgentType.HONEST)
+    state.add_agent("h2", agent_type=AgentType.HONEST)
+    state.add_agent("h3", agent_type=AgentType.HONEST)
+    state.add_agent("o1", agent_type=AgentType.OPPORTUNISTIC)
+    state.add_agent("a1", agent_type=AgentType.ADVERSARIAL)
+    return state
+
+
+def _make_homogeneous_state() -> EnvState:
+    """Create an EnvState with all-honest agents."""
+    state = EnvState()
+    for i in range(5):
+        state.add_agent(f"h{i}", agent_type=AgentType.HONEST)
+    return state
+
+
+class TestDiversityLeverDisabled:
+    """When disabled, the lever should be inert."""
+
+    def test_on_interaction_no_effect(self):
+        config = GovernanceConfig(diversity_enabled=False)
+        lever = DiversityDefenseLever(config)
+        state = EnvState()
+        interaction = SoftInteraction(initiator="a1", p=0.3)
+        effect = lever.on_interaction(interaction, state)
+        assert effect.cost_a == 0.0
+        assert effect.cost_b == 0.0
+
+    def test_on_epoch_start_no_effect(self):
+        config = GovernanceConfig(diversity_enabled=False)
+        lever = DiversityDefenseLever(config)
+        state = _make_diverse_state()
+        effect = lever.on_epoch_start(state, epoch=1)
+        assert effect.cost_a == 0.0
+        assert effect.cost_b == 0.0
+
+
+class TestDiversityLeverErrorTracking:
+    """Tests for error recording in on_interaction."""
+
+    def test_records_error_without_ground_truth(self):
+        config = GovernanceConfig(
+            diversity_enabled=True,
+            diversity_error_threshold_p=0.5,
+            diversity_disagreement_tau=1.0,  # No audit triggers
+        )
+        lever = DiversityDefenseLever(config)
+        state = _make_diverse_state()
+
+        # Low p → error
+        interaction = SoftInteraction(initiator="h1", p=0.3)
+        lever.on_interaction(interaction, state)
+
+        history = lever.get_error_history()
+        assert history["h1"] == [1]
+
+    def test_records_non_error_without_ground_truth(self):
+        config = GovernanceConfig(
+            diversity_enabled=True,
+            diversity_error_threshold_p=0.5,
+            diversity_disagreement_tau=1.0,
+        )
+        lever = DiversityDefenseLever(config)
+        state = _make_diverse_state()
+
+        # High p → no error
+        interaction = SoftInteraction(initiator="h1", p=0.8)
+        lever.on_interaction(interaction, state)
+
+        history = lever.get_error_history()
+        assert history["h1"] == [0]
+
+    def test_records_error_with_ground_truth_mismatch(self):
+        config = GovernanceConfig(
+            diversity_enabled=True,
+            diversity_error_threshold_p=0.5,
+            diversity_disagreement_tau=1.0,
+        )
+        lever = DiversityDefenseLever(config)
+        state = _make_diverse_state()
+
+        # p >= 0.5 predicts positive, but ground truth is -1 → error
+        interaction = SoftInteraction(initiator="h1", p=0.7, ground_truth=-1)
+        lever.on_interaction(interaction, state)
+
+        history = lever.get_error_history()
+        assert history["h1"] == [1]
+
+    def test_records_non_error_with_ground_truth_match(self):
+        config = GovernanceConfig(
+            diversity_enabled=True,
+            diversity_error_threshold_p=0.5,
+            diversity_disagreement_tau=1.0,
+        )
+        lever = DiversityDefenseLever(config)
+        state = _make_diverse_state()
+
+        # p >= 0.5 predicts positive, ground truth is +1 → correct
+        interaction = SoftInteraction(initiator="h1", p=0.7, ground_truth=1)
+        lever.on_interaction(interaction, state)
+
+        history = lever.get_error_history()
+        assert history["h1"] == [0]
+
+    def test_window_trimming(self):
+        config = GovernanceConfig(
+            diversity_enabled=True,
+            diversity_correlation_window=5,
+            diversity_disagreement_tau=1.0,
+        )
+        lever = DiversityDefenseLever(config)
+        state = _make_diverse_state()
+
+        for i in range(10):
+            interaction = SoftInteraction(
+                initiator="h1", p=0.3 if i % 2 == 0 else 0.8
+            )
+            lever.on_interaction(interaction, state)
+
+        history = lever.get_error_history()
+        assert len(history["h1"]) == 5
+
+
+class TestDiversityLeverDisagreementAudit:
+    """Tests for Rule 4: disagreement-triggered audit."""
+
+    def test_audit_triggered_on_high_disagreement(self):
+        config = GovernanceConfig(
+            diversity_enabled=True,
+            diversity_disagreement_tau=0.3,
+            diversity_audit_cost=0.2,
+        )
+        lever = DiversityDefenseLever(config)
+        state = _make_diverse_state()
+
+        # First, seed diverse error patterns so disagreement is high
+        # Agent h1 gets error, h2 no error → disagreement = 0.5
+        lever.on_interaction(
+            SoftInteraction(initiator="h1", p=0.3), state
+        )
+        effect = lever.on_interaction(
+            SoftInteraction(initiator="h2", p=0.8), state
+        )
+
+        # Disagreement rate should be 0.5 (1 error, 1 non-error)
+        assert effect.details["disagreement_rate"] == pytest.approx(0.5)
+        assert effect.details["audit_triggered"] is True
+        assert effect.cost_a == pytest.approx(0.2)
+
+    def test_no_audit_when_below_tau(self):
+        config = GovernanceConfig(
+            diversity_enabled=True,
+            diversity_disagreement_tau=0.8,
+            diversity_audit_cost=0.2,
+        )
+        lever = DiversityDefenseLever(config)
+        state = _make_diverse_state()
+
+        # All agents make the same decision (all errors)
+        lever.on_interaction(
+            SoftInteraction(initiator="h1", p=0.3), state
+        )
+        effect = lever.on_interaction(
+            SoftInteraction(initiator="h2", p=0.3), state
+        )
+
+        assert effect.details["audit_triggered"] is False
+        assert effect.cost_a == 0.0
+
+
+class TestDiversityLeverEpochStart:
+    """Tests for epoch-start diversity constraint checks."""
+
+    def test_correlation_cap_violation_adds_cost(self):
+        config = GovernanceConfig(
+            diversity_enabled=True,
+            diversity_rho_max=0.1,
+            diversity_correlation_penalty_rate=1.0,
+            diversity_entropy_min=0.0,  # No entropy constraint
+        )
+        lever = DiversityDefenseLever(config)
+        state = _make_homogeneous_state()
+
+        # Seed highly correlated errors for all agents
+        for _ in range(20):
+            for agent_id in state.agents:
+                lever._error_history[agent_id].append(1)
+        for _ in range(20):
+            for agent_id in state.agents:
+                lever._error_history[agent_id].append(0)
+
+        effect = lever.on_epoch_start(state, epoch=1)
+
+        # With identical error patterns, rho should be ~1.0
+        # Excess = rho - 0.1 ≈ 0.9, penalty = 0.9 * 1.0 = 0.9
+        assert effect.cost_a > 0
+        assert effect.cost_b > 0
+        assert "correlation_cap" in effect.details["violations"]
+
+    def test_entropy_floor_violation_adds_cost(self):
+        config = GovernanceConfig(
+            diversity_enabled=True,
+            diversity_entropy_min=1.0,  # High entropy requirement
+            diversity_entropy_penalty_rate=1.0,
+            diversity_rho_max=1.0,  # No correlation constraint
+        )
+        lever = DiversityDefenseLever(config)
+        state = _make_homogeneous_state()  # All honest → entropy = 0
+
+        effect = lever.on_epoch_start(state, epoch=1)
+
+        assert effect.cost_a > 0
+        assert "entropy_floor" in effect.details["violations"]
+
+    def test_no_violations_no_cost(self):
+        config = GovernanceConfig(
+            diversity_enabled=True,
+            diversity_rho_max=1.0,  # Very permissive
+            diversity_entropy_min=0.0,  # No entropy requirement
+            diversity_adversarial_fraction_min=0.0,
+        )
+        lever = DiversityDefenseLever(config)
+        state = _make_diverse_state()
+
+        effect = lever.on_epoch_start(state, epoch=1)
+
+        assert effect.cost_a == 0.0
+        assert effect.cost_b == 0.0
+        assert effect.details["violations"] == []
+
+    def test_adversarial_fraction_warning(self):
+        config = GovernanceConfig(
+            diversity_enabled=True,
+            diversity_adversarial_fraction_min=0.3,  # Need 30% adversarial
+            diversity_rho_max=1.0,
+            diversity_entropy_min=0.0,
+        )
+        lever = DiversityDefenseLever(config)
+        state = _make_diverse_state()  # 1/5 = 20% adversarial
+
+        effect = lever.on_epoch_start(state, epoch=1)
+
+        # Warning only, no cost
+        assert "adversarial_fraction_low" in effect.details["violations"]
+        # Cost comes only from correlation and entropy violations
+        assert effect.details["adversarial_fraction_satisfied"] is False
+
+    def test_adversarial_fraction_satisfied(self):
+        config = GovernanceConfig(
+            diversity_enabled=True,
+            diversity_adversarial_fraction_min=0.1,  # Need 10%
+            diversity_rho_max=1.0,
+            diversity_entropy_min=0.0,
+        )
+        lever = DiversityDefenseLever(config)
+        state = _make_diverse_state()  # 1/5 = 20% adversarial
+
+        effect = lever.on_epoch_start(state, epoch=1)
+
+        assert effect.details["adversarial_fraction_satisfied"] is True
+
+    def test_metrics_snapshot_populated(self):
+        config = GovernanceConfig(
+            diversity_enabled=True,
+            diversity_rho_max=1.0,
+            diversity_entropy_min=0.0,
+        )
+        lever = DiversityDefenseLever(config)
+        state = _make_diverse_state()
+
+        lever.on_epoch_start(state, epoch=1)
+
+        metrics = lever.get_metrics()
+        assert metrics is not None
+        assert "honest" in metrics.population_mix
+        assert metrics.population_mix["honest"] == pytest.approx(0.6)
+        assert metrics.entropy > 0
+        assert metrics.risk_surrogate >= 0
+
+
+class TestDiversityLeverMetrics:
+    """Tests for the DiversityMetrics dataclass and full computation."""
+
+    def test_diverse_population_higher_entropy(self):
+        config = GovernanceConfig(
+            diversity_enabled=True,
+            diversity_rho_max=1.0,
+            diversity_entropy_min=0.0,
+        )
+        lever_diverse = DiversityDefenseLever(config)
+        lever_homo = DiversityDefenseLever(config)
+
+        state_diverse = _make_diverse_state()
+        state_homo = _make_homogeneous_state()
+
+        lever_diverse.on_epoch_start(state_diverse, epoch=1)
+        lever_homo.on_epoch_start(state_homo, epoch=1)
+
+        m_diverse = lever_diverse.get_metrics()
+        m_homo = lever_homo.get_metrics()
+
+        assert m_diverse.entropy > m_homo.entropy
+        assert m_homo.entropy == pytest.approx(0.0)
+
+    def test_correlated_errors_increase_risk(self):
+        config = GovernanceConfig(
+            diversity_enabled=True,
+            diversity_rho_max=1.0,
+            diversity_entropy_min=0.0,
+        )
+        lever = DiversityDefenseLever(config)
+        state = _make_diverse_state()
+
+        # Correlated errors: all agents err on same tasks
+        for _ in range(20):
+            for agent_id in state.agents:
+                lever._error_history[agent_id].append(1)
+        for _ in range(20):
+            for agent_id in state.agents:
+                lever._error_history[agent_id].append(0)
+
+        lever.on_epoch_start(state, epoch=1)
+        metrics_corr = lever.get_metrics()
+
+        # Independent errors
+        lever2 = DiversityDefenseLever(config)
+        import random
+
+        rng = random.Random(42)
+        for _ in range(40):
+            for agent_id in state.agents:
+                lever2._error_history[agent_id].append(rng.randint(0, 1))
+
+        lever2.on_epoch_start(state, epoch=1)
+        metrics_indep = lever2.get_metrics()
+
+        assert metrics_corr.mean_correlation > metrics_indep.mean_correlation
+        assert metrics_corr.risk_surrogate > metrics_indep.risk_surrogate
+
+
+class TestDiversityLeverClearHistory:
+    """Tests for clear_history."""
+
+    def test_clears_all_state(self):
+        config = GovernanceConfig(diversity_enabled=True)
+        lever = DiversityDefenseLever(config)
+        state = _make_diverse_state()
+
+        lever.on_interaction(
+            SoftInteraction(initiator="h1", p=0.3), state
+        )
+        lever.on_epoch_start(state, epoch=1)
+
+        assert lever.get_metrics() is not None
+        assert len(lever.get_error_history()) > 0
+
+        lever.clear_history()
+
+        assert lever.get_metrics() is None
+        assert len(lever.get_error_history()) == 0
+
+
+# ---------------------------------------------------------------------------
+# Engine integration
+# ---------------------------------------------------------------------------
+
+
+class TestDiversityEngineIntegration:
+    """Tests for DaD lever integration with GovernanceEngine."""
+
+    def test_lever_registered_in_engine(self):
+        config = GovernanceConfig(diversity_enabled=True)
+        engine = GovernanceEngine(config)
+        names = engine.get_registered_lever_names()
+        assert "diversity_defense" in names
+
+    def test_engine_diversity_lever_accessor(self):
+        config = GovernanceConfig(diversity_enabled=True)
+        engine = GovernanceEngine(config)
+        lever = engine.get_diversity_lever()
+        assert lever is not None
+        assert isinstance(lever, DiversityDefenseLever)
+
+    def test_engine_diversity_metrics_accessor(self):
+        config = GovernanceConfig(diversity_enabled=True)
+        engine = GovernanceEngine(config)
+        state = _make_diverse_state()
+
+        # Before any epoch, metrics should be None
+        assert engine.get_diversity_metrics() is None
+
+        # After epoch start, metrics should be populated
+        engine.apply_epoch_start(state, epoch=1)
+        metrics = engine.get_diversity_metrics()
+        assert metrics is not None
+
+    def test_engine_applies_diversity_on_interaction(self):
+        config = GovernanceConfig(
+            diversity_enabled=True,
+            diversity_disagreement_tau=0.3,
+            diversity_audit_cost=0.5,
+        )
+        engine = GovernanceEngine(config)
+        state = _make_diverse_state()
+
+        # Create disagreement by feeding different error patterns
+        engine.apply_interaction(
+            SoftInteraction(initiator="h1", p=0.3, accepted=True), state
+        )
+        effect = engine.apply_interaction(
+            SoftInteraction(initiator="h2", p=0.8, accepted=True), state
+        )
+
+        # The diversity lever should contribute audit cost
+        assert effect.cost_a > 0
+
+    def test_engine_applies_diversity_on_epoch_start(self):
+        config = GovernanceConfig(
+            diversity_enabled=True,
+            diversity_entropy_min=2.0,  # Very high, will violate
+            diversity_entropy_penalty_rate=1.0,
+            diversity_rho_max=1.0,
+        )
+        engine = GovernanceEngine(config)
+        state = _make_homogeneous_state()
+
+        effect = engine.apply_epoch_start(state, epoch=1)
+
+        # Should have entropy violation cost
+        assert effect.cost_a > 0
+
+
+# ---------------------------------------------------------------------------
+# Governance corollary tests: diversity beats scaling
+# ---------------------------------------------------------------------------
+
+
+class TestDiversityBeatsScaling:
+    """Tests verifying the core governance corollary.
+
+    With constant high correlation, adding more identical agents does not
+    reduce risk.  But reducing correlation (via diversity) does.
+    """
+
+    def test_risk_grows_with_n_when_rho_constant(self):
+        """Var(S) ~ N^2 * rho * p(1-p) when rho is high and constant."""
+        p = 0.3
+        rho = 0.8
+        risk_10 = DiversityDefenseLever.compute_risk_surrogate(p, rho, 10)
+        risk_100 = DiversityDefenseLever.compute_risk_surrogate(p, rho, 100)
+        # Risk should increase with N when rho is constant
+        assert risk_100 > risk_10
+
+    def test_risk_controlled_when_rho_decreases(self):
+        """If rho ~ 0, Var(S) ~ N * p(1-p); risk grows linearly."""
+        p = 0.3
+        # Compare: 100 agents with rho=0.01 vs 10 agents with rho=0.8
+        risk_100_diverse = DiversityDefenseLever.compute_risk_surrogate(
+            p, 0.01, 100
+        )
+        risk_10_homo = DiversityDefenseLever.compute_risk_surrogate(
+            p, 0.8, 10
+        )
+        # 100 diverse agents should have lower risk than 10 homogeneous ones
+        assert risk_100_diverse < risk_10_homo


### PR DESCRIPTION
Implement the DaD governance principle: maintain sufficient agent heterogeneity to keep error correlations below a controlled threshold, minimizing correlation-amplified tail risk rather than mean error.

The lever tracks pairwise error correlations across agent types and enforces four governance rules:
  Rule 1 - Correlation cap: rho_bar(x) <= rho_max
  Rule 2 - Entropy floor: H(x) >= H_min
  Rule 3 - Adversarial fraction: sum of adversarial weights >= alpha_min
  Rule 4 - Disagreement-triggered audit: D(t) >= tau triggers audit

Includes risk surrogate R(x) = p_bar(1-p_bar)(1+(N-1)*rho_bar) which captures the variance term driving tail failure probability under majority-vote aggregation.

https://claude.ai/code/session_01BiBYHUzc94muu1CiGq5Ng2

## Summary

Brief description of the changes.

## Changes

- ...
- ...

## Test Plan

- [ ] Existing tests pass (`pytest tests/ -v`)
- [ ] Lint passes (`ruff check src/ tests/`)
- [ ] Type check passes (`mypy src/`)
- [ ] New tests added (if applicable)

## Related Issues

Closes #
