### PR TITLE
Remove unused variable `poison_b` in test_memory_metrics.py

### DIFF
--- a/tests/test_memory_metrics.py
+++ b/tests/test_memory_metrics.py
@@ -82,7 +82,7 @@ def test_governance_filter_rate_and_tier_metrics() -> None:
         epoch=0,
         step=0,
     )
-    poison_b = store.write(
+    store.write(
         agent_id="b",
         content="poison-b",
         quality_score=0.2,


### PR DESCRIPTION
The return value of store.write() was assigned to `poison_b` but never
used, triggering ruff F841. The call is kept for its side effect.

https://claude.ai/code/session_01NchqzNEWrNJ8kVQYgo3UHj