### PR TITLE
Remove OpenClaw/ClawHub references from skill metadata

### DIFF
--- a/.well-known/agent.json
+++ b/.well-known/agent.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0",
   "name": "swarm-safety",
   "display_name": "SWARM: System-Wide Assessment of Risk in Multi-agent systems",
-  "description": "Research framework for studying emergent risks in multi-agent AI systems. Simulate agent dynamics, test governance mechanisms, measure distributional safety with soft probabilistic labels, and integrate with OpenClaw/ClawHub skill workflows.",
+  "description": "Research framework for studying emergent risks in multi-agent AI systems. Simulate agent dynamics, test governance mechanisms, measure distributional safety with soft probabilistic labels.",
   "homepage": "https://github.com/swarm-ai-safety/swarm",
   "repository": "https://github.com/swarm-ai-safety/swarm",
   "skill_url": "https://raw.githubusercontent.com/swarm-ai-safety/swarm/main/skill.md",
@@ -48,5 +48,5 @@
     "docs_url": "http://localhost:8000/docs",
     "note": "API runs locally after install. Start with: uvicorn swarm.api.app:app"
   },
-  "tags": ["ai-safety", "multi-agent", "governance", "simulation", "distributional-safety", "emergence", "openclaw", "clawhub"]
+  "tags": ["ai-safety", "multi-agent", "governance", "simulation", "distributional-safety", "emergence"]
 }

--- a/skill.json
+++ b/skill.json
@@ -1,14 +1,14 @@
 {
   "name": "swarm-safety",
   "version": "1.0.0",
-  "description": "SWARM: System-Wide Assessment of Risk in Multi-agent systems. Simulate multi-agent dynamics, test governance mechanisms, study emergent risks, measure distributional safety, and integrate with OpenClaw/ClawHub skill workflows.",
+  "description": "SWARM: System-Wide Assessment of Risk in Multi-agent systems. Simulate multi-agent dynamics, test governance mechanisms, study emergent risks, and measure distributional safety.",
   "homepage": "https://github.com/swarm-ai-safety/swarm",
   "repository": "https://github.com/swarm-ai-safety/swarm",
   "api_base": "https://github.com/swarm-ai-safety/swarm",
   "category": "safety",
   "author": "Raeli Savitt",
   "license": "MIT",
-  "keywords": ["multi-agent", "ai-safety", "distributional-safety", "governance", "emergence", "red-teaming", "openclaw", "clawhub"],
+  "keywords": ["multi-agent", "ai-safety", "distributional-safety", "governance", "emergence", "red-teaming"],
   "capabilities": [
     "simulate",
     "governance",

--- a/skill.md
+++ b/skill.md
@@ -247,7 +247,7 @@ Model Moltbook's anti-human math challenges and rate limiting: obfuscated text p
 
 - Skill metadata: `skill.json`
 - Agent discovery: `.well-known/agent.json`
-- OpenClaw/ClawHub bridge: `docs/bridges/openclaw.md`
+- Bridges: `docs/bridges/`
 - Full documentation: `https://github.com/swarm-ai-safety/swarm/tree/main/docs`
 - Theoretical foundations: `docs/research/theory.md`
 - Governance guide: `docs/governance.md`


### PR DESCRIPTION
These integrations are not part of the core SWARM framework.

## Summary

Brief description of the changes.

## Changes

- ...
- ...

## Test Plan

- [ ] Existing tests pass (`pytest tests/ -v`)
- [ ] Lint passes (`ruff check swarm/ tests/`)
- [ ] Type check passes (`mypy swarm/`)
- [ ] New tests added (if applicable)

## Results (SWARM)

If this change affects scenarios, metrics, agents, governance, or evaluation, include a reproducible run folder and the headline deltas.

**Reproduce**
- Scenario: `scenarios/<name>.yaml`
- Command: `python -m swarm run scenarios/<name>.yaml --seed <seed> --epochs <n> --steps <n> --export-json runs/<run_id>/history.json --export-csv runs/<run_id>/csv`
- Plots: `python examples/plot_run.py runs/<run_id>`

**Artifacts**
- `runs/<run_id>/history.json`
- `runs/<run_id>/csv/`
- `runs/<run_id>/plots/`

**Headline metrics**
- Total interactions:
- Accepted interactions:
- Avg toxicity:
- Final welfare:

**Invariants**
- [ ] `p ∈ [0, 1]` everywhere it is surfaced/logged
- [ ] Event logs remain replayable (append-only JSONL)

## Related Issues

Closes #
