### PR TITLE
Add tests for low-coverage modules to reach 70% coverage threshold

### DIFF
--- a/tests/test_governance_memory.py
+++ b/tests/test_governance_memory.py
@@ -1,0 +1,317 @@
+"""Tests for swarm.governance.memory levers."""
+
+import pytest
+
+from swarm.env.state import EnvState
+from swarm.governance.config import GovernanceConfig
+from swarm.governance.memory import (
+    CrossVerificationLever,
+    ProvenanceLever,
+    PromotionGateLever,
+    WriteRateLimitLever,
+)
+from swarm.models.interaction import SoftInteraction
+
+
+def _make_state() -> EnvState:
+    state = EnvState()
+    state.add_agent("agent_a")
+    state.add_agent("agent_b")
+    return state
+
+
+class TestPromotionGateLever:
+    def test_disabled(self):
+        config = GovernanceConfig(memory_promotion_gate_enabled=False)
+        lever = PromotionGateLever(config)
+        interaction = SoftInteraction(
+            metadata={"memory_promotion": True, "quality_score": 0.1}
+        )
+        effect = lever.on_interaction(interaction, _make_state())
+        assert effect.cost_a == 0.0
+
+    def test_non_promotion_interaction(self):
+        config = GovernanceConfig(memory_promotion_gate_enabled=True)
+        lever = PromotionGateLever(config)
+        interaction = SoftInteraction(metadata={})
+        effect = lever.on_interaction(interaction, _make_state())
+        assert effect.cost_a == 0.0
+
+    def test_blocks_low_quality(self):
+        config = GovernanceConfig(
+            memory_promotion_gate_enabled=True,
+            memory_promotion_min_quality=0.7,
+            memory_promotion_min_verifications=0,
+        )
+        lever = PromotionGateLever(config)
+        interaction = SoftInteraction(
+            metadata={
+                "memory_promotion": True,
+                "quality_score": 0.3,
+                "verified_by": [],
+            }
+        )
+        effect = lever.on_interaction(interaction, _make_state())
+        assert effect.cost_a == 1.0
+        assert effect.details["blocked"] is True
+
+    def test_blocks_insufficient_verifications(self):
+        config = GovernanceConfig(
+            memory_promotion_gate_enabled=True,
+            memory_promotion_min_quality=0.0,
+            memory_promotion_min_verifications=3,
+        )
+        lever = PromotionGateLever(config)
+        interaction = SoftInteraction(
+            metadata={
+                "memory_promotion": True,
+                "quality_score": 0.9,
+                "verified_by": ["v1"],
+            }
+        )
+        effect = lever.on_interaction(interaction, _make_state())
+        assert effect.cost_a == 1.0
+        assert "verifications" in str(effect.details["reasons"])
+
+    def test_allows_valid_promotion(self):
+        config = GovernanceConfig(
+            memory_promotion_gate_enabled=True,
+            memory_promotion_min_quality=0.5,
+            memory_promotion_min_verifications=1,
+        )
+        lever = PromotionGateLever(config)
+        interaction = SoftInteraction(
+            metadata={
+                "memory_promotion": True,
+                "quality_score": 0.8,
+                "verified_by": ["v1", "v2"],
+            }
+        )
+        effect = lever.on_interaction(interaction, _make_state())
+        assert effect.cost_a == 0.0
+
+    def test_name(self):
+        config = GovernanceConfig()
+        lever = PromotionGateLever(config)
+        assert lever.name == "memory_promotion_gate"
+
+
+class TestWriteRateLimitLever:
+    def test_disabled(self):
+        config = GovernanceConfig(memory_write_rate_limit_enabled=False)
+        lever = WriteRateLimitLever(config)
+        interaction = SoftInteraction(
+            initiator="agent_a",
+            metadata={"memory_write": True},
+        )
+        effect = lever.on_interaction(interaction, _make_state())
+        assert effect.cost_a == 0.0
+
+    def test_non_write_interaction(self):
+        config = GovernanceConfig(memory_write_rate_limit_enabled=True)
+        lever = WriteRateLimitLever(config)
+        interaction = SoftInteraction(initiator="agent_a", metadata={})
+        effect = lever.on_interaction(interaction, _make_state())
+        assert effect.cost_a == 0.0
+
+    def test_within_limit(self):
+        config = GovernanceConfig(
+            memory_write_rate_limit_enabled=True,
+            memory_write_rate_limit_per_epoch=5,
+        )
+        lever = WriteRateLimitLever(config)
+        state = _make_state()
+        interaction = SoftInteraction(
+            initiator="agent_a",
+            metadata={"memory_write": True},
+        )
+        effect = lever.on_interaction(interaction, state)
+        assert effect.cost_a == 0.0
+
+    def test_exceeds_limit(self):
+        config = GovernanceConfig(
+            memory_write_rate_limit_enabled=True,
+            memory_write_rate_limit_per_epoch=2,
+        )
+        lever = WriteRateLimitLever(config)
+        state = _make_state()
+        interaction = SoftInteraction(
+            initiator="agent_a",
+            metadata={"memory_write": True},
+        )
+        # Write 1 and 2 are OK
+        lever.on_interaction(interaction, state)
+        lever.on_interaction(interaction, state)
+        # Write 3 exceeds limit
+        effect = lever.on_interaction(interaction, state)
+        assert effect.cost_a == 1.0
+        assert effect.details["writes"] == 3
+        assert effect.details["cap"] == 2
+
+    def test_epoch_reset(self):
+        config = GovernanceConfig(
+            memory_write_rate_limit_enabled=True,
+            memory_write_rate_limit_per_epoch=1,
+        )
+        lever = WriteRateLimitLever(config)
+        state = _make_state()
+        interaction = SoftInteraction(
+            initiator="agent_a",
+            metadata={"memory_write": True},
+        )
+        lever.on_interaction(interaction, state)
+        # Exceeds limit
+        effect = lever.on_interaction(interaction, state)
+        assert effect.cost_a == 1.0
+        # Reset on new epoch
+        lever.on_epoch_start(state, epoch=1)
+        effect = lever.on_interaction(interaction, state)
+        assert effect.cost_a == 0.0
+
+    def test_get_remaining_writes(self):
+        config = GovernanceConfig(
+            memory_write_rate_limit_enabled=True,
+            memory_write_rate_limit_per_epoch=5,
+        )
+        lever = WriteRateLimitLever(config)
+        assert lever.get_remaining_writes("agent_a") == 5
+        state = _make_state()
+        interaction = SoftInteraction(
+            initiator="agent_a",
+            metadata={"memory_write": True},
+        )
+        lever.on_interaction(interaction, state)
+        assert lever.get_remaining_writes("agent_a") == 4
+
+    def test_name(self):
+        config = GovernanceConfig()
+        lever = WriteRateLimitLever(config)
+        assert lever.name == "memory_write_rate_limit"
+
+
+class TestCrossVerificationLever:
+    def test_disabled(self):
+        config = GovernanceConfig(memory_cross_verification_enabled=False)
+        lever = CrossVerificationLever(config)
+        interaction = SoftInteraction(
+            initiator="verifier",
+            metadata={"memory_verification": True, "entry_author": "author"},
+        )
+        effect = lever.on_interaction(interaction, _make_state())
+        assert effect.cost_a == 0.0
+
+    def test_non_verification_interaction(self):
+        config = GovernanceConfig(memory_cross_verification_enabled=True)
+        lever = CrossVerificationLever(config)
+        interaction = SoftInteraction(initiator="verifier", metadata={})
+        effect = lever.on_interaction(interaction, _make_state())
+        assert effect.cost_a == 0.0
+
+    def test_no_author(self):
+        config = GovernanceConfig(memory_cross_verification_enabled=True)
+        lever = CrossVerificationLever(config)
+        interaction = SoftInteraction(
+            initiator="verifier",
+            metadata={"memory_verification": True},
+        )
+        effect = lever.on_interaction(interaction, _make_state())
+        assert effect.cost_a == 0.0
+
+    def test_normal_verification(self):
+        config = GovernanceConfig(memory_cross_verification_enabled=True)
+        lever = CrossVerificationLever(config)
+        state = _make_state()
+        interaction = SoftInteraction(
+            initiator="verifier",
+            metadata={"memory_verification": True, "entry_author": "author"},
+        )
+        effect = lever.on_interaction(interaction, state)
+        assert effect.cost_a == 0.0
+
+    def test_collusion_detected(self):
+        config = GovernanceConfig(memory_cross_verification_enabled=True)
+        lever = CrossVerificationLever(config)
+        state = _make_state()
+        interaction = SoftInteraction(
+            initiator="verifier",
+            metadata={"memory_verification": True, "entry_author": "author"},
+        )
+        # First 3 are OK
+        for _ in range(3):
+            lever.on_interaction(interaction, state)
+        # 4th triggers collusion
+        effect = lever.on_interaction(interaction, state)
+        assert effect.cost_a == 0.5
+        assert "verifier" in effect.reputation_deltas
+        assert effect.reputation_deltas["verifier"] == pytest.approx(-0.05)
+
+    def test_epoch_reset_clears_pairs(self):
+        config = GovernanceConfig(memory_cross_verification_enabled=True)
+        lever = CrossVerificationLever(config)
+        state = _make_state()
+        interaction = SoftInteraction(
+            initiator="verifier",
+            metadata={"memory_verification": True, "entry_author": "author"},
+        )
+        for _ in range(3):
+            lever.on_interaction(interaction, state)
+        lever.on_epoch_start(state, epoch=1)
+        # After reset, should be OK again
+        effect = lever.on_interaction(interaction, state)
+        assert effect.cost_a == 0.0
+
+    def test_name(self):
+        config = GovernanceConfig()
+        lever = CrossVerificationLever(config)
+        assert lever.name == "memory_cross_verification"
+
+
+class TestProvenanceLever:
+    def test_disabled(self):
+        config = GovernanceConfig(memory_provenance_enabled=False)
+        lever = ProvenanceLever(config)
+        interaction = SoftInteraction(
+            metadata={"memory_revert": True, "entry_author": "author"},
+        )
+        effect = lever.on_interaction(interaction, _make_state())
+        assert effect.cost_a == 0.0
+
+    def test_non_revert_interaction(self):
+        config = GovernanceConfig(memory_provenance_enabled=True)
+        lever = ProvenanceLever(config)
+        interaction = SoftInteraction(metadata={})
+        effect = lever.on_interaction(interaction, _make_state())
+        assert effect.cost_a == 0.0
+
+    def test_no_author(self):
+        config = GovernanceConfig(memory_provenance_enabled=True)
+        lever = ProvenanceLever(config)
+        interaction = SoftInteraction(
+            metadata={"memory_revert": True},
+        )
+        effect = lever.on_interaction(interaction, _make_state())
+        assert effect.cost_a == 0.0
+
+    def test_revert_penalty(self):
+        config = GovernanceConfig(
+            memory_provenance_enabled=True,
+            memory_provenance_revert_penalty=0.2,
+        )
+        lever = ProvenanceLever(config)
+        interaction = SoftInteraction(
+            metadata={
+                "memory_revert": True,
+                "entry_author": "bad_author",
+                "entry_id": "entry123",
+            },
+        )
+        effect = lever.on_interaction(interaction, _make_state())
+        assert "bad_author" in effect.reputation_deltas
+        assert effect.reputation_deltas["bad_author"] == pytest.approx(-0.2)
+        assert effect.details["reverted_author"] == "bad_author"
+        assert effect.details["entry_id"] == "entry123"
+
+    def test_name(self):
+        config = GovernanceConfig()
+        lever = ProvenanceLever(config)
+        assert lever.name == "memory_provenance"

--- a/tests/test_moltbook_metrics.py
+++ b/tests/test_moltbook_metrics.py
@@ -1,0 +1,135 @@
+"""Tests for swarm.metrics.moltbook_metrics."""
+
+import pytest
+
+from swarm.metrics.moltbook_metrics import (
+    captcha_effectiveness,
+    challenge_pass_rate,
+    content_throughput,
+    karma_concentration,
+    rate_limit_governance_impact,
+    rate_limit_hit_rate,
+    verification_latency_distribution,
+    wasted_action_rate,
+)
+
+
+class TestChallengePassRate:
+    def test_empty(self):
+        assert challenge_pass_rate([]) == 0.0
+
+    def test_all_pass(self):
+        assert challenge_pass_rate([True, True, True]) == 1.0
+
+    def test_all_fail(self):
+        assert challenge_pass_rate([False, False]) == 0.0
+
+    def test_mixed(self):
+        assert challenge_pass_rate([True, False, True, False]) == pytest.approx(0.5)
+
+
+class TestRateLimitHitRate:
+    def test_zero_attempts(self):
+        assert rate_limit_hit_rate(5, 0) == 0.0
+
+    def test_negative_attempts(self):
+        assert rate_limit_hit_rate(5, -1) == 0.0
+
+    def test_normal(self):
+        assert rate_limit_hit_rate(3, 10) == pytest.approx(0.3)
+
+
+class TestContentThroughput:
+    def test_zero_epochs(self):
+        assert content_throughput(10, 0) == 0.0
+
+    def test_negative_epochs(self):
+        assert content_throughput(10, -1) == 0.0
+
+    def test_normal(self):
+        assert content_throughput(20, 4) == pytest.approx(5.0)
+
+
+class TestVerificationLatencyDistribution:
+    def test_empty(self):
+        result = verification_latency_distribution([])
+        assert result == {"mean": 0.0, "p50": 0.0, "p90": 0.0}
+
+    def test_single_value(self):
+        result = verification_latency_distribution([5])
+        assert result["mean"] == pytest.approx(5.0)
+        assert result["p50"] == pytest.approx(5.0)
+        assert result["p90"] == pytest.approx(5.0)
+
+    def test_multiple_values(self):
+        result = verification_latency_distribution([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        assert result["mean"] == pytest.approx(5.5)
+        assert result["p50"] == 6
+        assert result["p90"] == 9
+
+
+class TestKarmaConcentration:
+    def test_empty(self):
+        assert karma_concentration({}) == 0.0
+
+    def test_equal_distribution(self):
+        result = karma_concentration({"a": 10.0, "b": 10.0, "c": 10.0})
+        assert result == pytest.approx(0.0, abs=0.01)
+
+    def test_all_zero(self):
+        assert karma_concentration({"a": 0.0, "b": 0.0}) == 0.0
+
+    def test_unequal_distribution(self):
+        result = karma_concentration({"a": 100.0, "b": 1.0, "c": 1.0})
+        assert result > 0.0
+
+    def test_negative_values_clamped(self):
+        # Negative karma should be treated as 0
+        result = karma_concentration({"a": -5.0, "b": -3.0})
+        assert result == 0.0
+
+
+class TestWastedActionRate:
+    def test_zero_total(self):
+        assert wasted_action_rate(5, 0) == 0.0
+
+    def test_negative_total(self):
+        assert wasted_action_rate(5, -1) == 0.0
+
+    def test_normal(self):
+        assert wasted_action_rate(2, 10) == pytest.approx(0.2)
+
+
+class TestCaptchaEffectiveness:
+    def test_zero_bot_success(self):
+        assert captcha_effectiveness(0.1, 0.0) == 0.0
+
+    def test_negative_bot_success(self):
+        assert captcha_effectiveness(0.1, -0.5) == 0.0
+
+    def test_normal(self):
+        assert captcha_effectiveness(0.2, 0.5) == pytest.approx(0.4)
+
+
+class TestRateLimitGovernanceImpact:
+    def test_zero_without_limits(self):
+        assert rate_limit_governance_impact(5.0, 0.0) == 0.0
+
+    def test_negative_without_limits(self):
+        assert rate_limit_governance_impact(5.0, -1.0) == 0.0
+
+    def test_no_reduction(self):
+        assert rate_limit_governance_impact(10.0, 10.0) == pytest.approx(0.0)
+
+    def test_partial_reduction(self):
+        result = rate_limit_governance_impact(5.0, 10.0)
+        assert result == pytest.approx(0.5)
+
+    def test_full_reduction(self):
+        result = rate_limit_governance_impact(0.0, 10.0)
+        assert result == pytest.approx(1.0)
+
+    def test_clamped_at_one(self):
+        # with_limits > without_limits could give negative, clamped to 0
+        result = rate_limit_governance_impact(15.0, 10.0)
+        assert result == pytest.approx(0.0)

--- a/tests/test_moltipedia_metrics.py
+++ b/tests/test_moltipedia_metrics.py
@@ -1,0 +1,161 @@
+"""Tests for swarm.metrics.moltipedia_metrics."""
+
+import pytest
+
+from swarm.metrics.moltipedia_metrics import (
+    content_quality_trend,
+    governance_effectiveness,
+    pair_farming_rate,
+    point_concentration,
+    policy_fix_exploitation_rate,
+)
+from swarm.models.interaction import SoftInteraction
+
+
+class TestPointConcentration:
+    def test_empty(self):
+        assert point_concentration({}) == 0.0
+
+    def test_equal(self):
+        result = point_concentration({"a": 5.0, "b": 5.0, "c": 5.0})
+        assert result == pytest.approx(0.0, abs=0.01)
+
+    def test_all_zero(self):
+        assert point_concentration({"a": 0.0, "b": 0.0}) == 0.0
+
+    def test_concentrated(self):
+        result = point_concentration({"a": 100.0, "b": 0.0, "c": 0.0})
+        assert result > 0.5
+
+    def test_negative_values_clamped(self):
+        result = point_concentration({"a": -1.0, "b": -2.0})
+        assert result == 0.0
+
+
+class TestPairFarmingRate:
+    def test_empty(self):
+        assert pair_farming_rate([]) == 0.0
+
+    def test_no_moltipedia_interactions(self):
+        interactions = [SoftInteraction(metadata={})]
+        assert pair_farming_rate(interactions) == 0.0
+
+    def test_no_repeated_pairs(self):
+        interactions = [
+            SoftInteraction(
+                initiator="a", counterparty="b",
+                metadata={"moltipedia": True, "points": 1},
+            ),
+            SoftInteraction(
+                initiator="c", counterparty="d",
+                metadata={"moltipedia": True, "points": 2},
+            ),
+        ]
+        assert pair_farming_rate(interactions) == pytest.approx(0.0)
+
+    def test_repeated_pairs(self):
+        interactions = [
+            SoftInteraction(
+                initiator="a", counterparty="b",
+                metadata={"moltipedia": True, "points": 1},
+            ),
+            SoftInteraction(
+                initiator="a", counterparty="b",
+                metadata={"moltipedia": True, "points": 2},
+            ),
+            SoftInteraction(
+                initiator="c", counterparty="d",
+                metadata={"moltipedia": True, "points": 3},
+            ),
+        ]
+        # 2 repeated out of 3 total scored
+        result = pair_farming_rate(interactions)
+        assert result == pytest.approx(2 / 3)
+
+    def test_reversed_pair_order(self):
+        interactions = [
+            SoftInteraction(
+                initiator="b", counterparty="a",
+                metadata={"moltipedia": True, "points": 1},
+            ),
+            SoftInteraction(
+                initiator="a", counterparty="b",
+                metadata={"moltipedia": True, "points": 2},
+            ),
+        ]
+        result = pair_farming_rate(interactions)
+        assert result == pytest.approx(2 / 2)
+
+
+class TestPolicyFixExploitationRate:
+    def test_empty(self):
+        assert policy_fix_exploitation_rate([]) == 0.0
+
+    def test_no_policy_fixes(self):
+        interactions = [SoftInteraction(metadata={"moltipedia": True})]
+        assert policy_fix_exploitation_rate(interactions) == 0.0
+
+    def test_no_exploitation(self):
+        interactions = [
+            SoftInteraction(
+                task_progress_delta=0.5,
+                metadata={"moltipedia": True, "edit_type": "policy_fix"},
+            ),
+        ]
+        assert policy_fix_exploitation_rate(interactions) == pytest.approx(0.0)
+
+    def test_all_exploited(self):
+        interactions = [
+            SoftInteraction(
+                task_progress_delta=0.01,
+                metadata={"moltipedia": True, "edit_type": "policy_fix"},
+            ),
+            SoftInteraction(
+                task_progress_delta=0.0,
+                metadata={"moltipedia": True, "edit_type": "policy_fix"},
+            ),
+        ]
+        assert policy_fix_exploitation_rate(interactions) == pytest.approx(1.0)
+
+    def test_mixed(self):
+        interactions = [
+            SoftInteraction(
+                task_progress_delta=0.01,
+                metadata={"moltipedia": True, "edit_type": "policy_fix"},
+            ),
+            SoftInteraction(
+                task_progress_delta=0.5,
+                metadata={"moltipedia": True, "edit_type": "policy_fix"},
+            ),
+        ]
+        assert policy_fix_exploitation_rate(interactions) == pytest.approx(0.5)
+
+
+class TestContentQualityTrend:
+    def test_empty(self):
+        assert content_quality_trend([]) == 0.0
+
+    def test_single(self):
+        assert content_quality_trend([0.8]) == pytest.approx(0.8)
+
+    def test_average(self):
+        assert content_quality_trend([0.6, 0.8, 1.0]) == pytest.approx(0.8)
+
+
+class TestGovernanceEffectiveness:
+    def test_zero_total(self):
+        assert governance_effectiveness(0.0, 5.0) == 0.0
+
+    def test_negative_total(self):
+        assert governance_effectiveness(-1.0, 5.0) == 0.0
+
+    def test_normal(self):
+        assert governance_effectiveness(100.0, 30.0) == pytest.approx(0.3)
+
+    def test_clamped_at_one(self):
+        result = governance_effectiveness(10.0, 50.0)
+        assert result == pytest.approx(1.0)
+
+    def test_clamped_at_zero(self):
+        result = governance_effectiveness(10.0, -5.0)
+        assert result == pytest.approx(0.0)

--- a/tests/test_time_horizons.py
+++ b/tests/test_time_horizons.py
@@ -1,0 +1,235 @@
+"""Tests for swarm.metrics.time_horizons."""
+
+import pytest
+
+from swarm.metrics.time_horizons import (
+    CAPABILITY_PROFILES,
+    AgentCapabilityProfile,
+    ComputeConstraints,
+    TimeHorizonBucket,
+    TimeHorizonMetrics,
+)
+
+
+class TestTimeHorizonBucket:
+    def test_defaults(self):
+        b = TimeHorizonBucket(horizon_minutes=10)
+        assert b.total_tasks == 0
+        assert b.successful_tasks == 0
+        assert b.reliability == 0.0
+        assert b.mean_quality == 0.0
+        assert b.mean_duration == 0.0
+
+    def test_record_success(self):
+        b = TimeHorizonBucket(horizon_minutes=10)
+        b.record(success=True, duration_minutes=8.0, quality=0.9)
+        assert b.total_tasks == 1
+        assert b.successful_tasks == 1
+        assert b.reliability == pytest.approx(1.0)
+        assert b.mean_quality == pytest.approx(0.9)
+        assert b.mean_duration == pytest.approx(8.0)
+
+    def test_record_failure(self):
+        b = TimeHorizonBucket(horizon_minutes=10)
+        b.record(success=False, duration_minutes=5.0)
+        assert b.total_tasks == 1
+        assert b.successful_tasks == 0
+        assert b.reliability == pytest.approx(0.0)
+        assert b.mean_quality == 0.0  # No quality scores added for failures
+
+    def test_mixed_records(self):
+        b = TimeHorizonBucket(horizon_minutes=10)
+        b.record(success=True, duration_minutes=8.0, quality=0.8)
+        b.record(success=False, duration_minutes=9.0)
+        b.record(success=True, duration_minutes=7.0, quality=1.0)
+        assert b.total_tasks == 3
+        assert b.successful_tasks == 2
+        assert b.reliability == pytest.approx(2 / 3)
+        assert b.mean_quality == pytest.approx(0.9)
+        assert b.mean_duration == pytest.approx(24.0 / 3)
+
+
+class TestTimeHorizonMetrics:
+    def test_initialization(self):
+        m = TimeHorizonMetrics()
+        assert len(m.buckets) == len(TimeHorizonMetrics.HORIZON_BUCKETS)
+        for horizon in TimeHorizonMetrics.HORIZON_BUCKETS:
+            assert horizon in m.buckets
+
+    def test_record_task_short(self):
+        m = TimeHorizonMetrics()
+        m.record_task(duration_minutes=3.0, success=True, quality=0.9)
+        assert m.buckets[5].total_tasks == 1
+
+    def test_record_task_long(self):
+        m = TimeHorizonMetrics()
+        m.record_task(duration_minutes=2000.0, success=True)
+        # Should go to the largest bucket (1440)
+        assert m.buckets[1440].total_tasks == 1
+
+    def test_reliability_curve_empty(self):
+        m = TimeHorizonMetrics()
+        assert m.reliability_curve() == {}
+
+    def test_reliability_curve(self):
+        m = TimeHorizonMetrics()
+        m.record_task(duration_minutes=3.0, success=True)
+        m.record_task(duration_minutes=3.0, success=True)
+        m.record_task(duration_minutes=50.0, success=True)
+        m.record_task(duration_minutes=50.0, success=False)
+        curve = m.reliability_curve()
+        assert curve[5] == pytest.approx(1.0)
+        assert curve[60] == pytest.approx(0.5)
+
+    def test_effective_horizon_none(self):
+        m = TimeHorizonMetrics()
+        assert m.effective_horizon() is None
+
+    def test_effective_horizon(self):
+        m = TimeHorizonMetrics()
+        # Record 100% success for short tasks
+        for _ in range(5):
+            m.record_task(duration_minutes=3.0, success=True)
+        # Record 100% success for 10min tasks
+        for _ in range(5):
+            m.record_task(duration_minutes=8.0, success=True)
+        # Record 50% success for 30min tasks
+        for i in range(4):
+            m.record_task(duration_minutes=25.0, success=(i < 2))
+        result = m.effective_horizon(threshold=0.8)
+        assert result == 10
+
+    def test_horizon_gap_no_effective(self):
+        m = TimeHorizonMetrics()
+        assert m.horizon_gap() == 0.0
+
+    def test_horizon_gap(self):
+        m = TimeHorizonMetrics()
+        for _ in range(10):
+            m.record_task(duration_minutes=3.0, success=True)
+        for _ in range(10):
+            m.record_task(duration_minutes=8.0, success=True)
+        # effective_horizon should be 10 min, target is 480 min
+        gap = m.horizon_gap(target_horizon=480)
+        assert gap == pytest.approx(10 / 480)
+
+    def test_to_dict(self):
+        m = TimeHorizonMetrics()
+        m.record_task(duration_minutes=3.0, success=True, quality=0.95)
+        d = m.to_dict()
+        assert "reliability_curve" in d
+        assert "effective_horizon_80" in d
+        assert "effective_horizon_90" in d
+        assert "horizon_gap" in d
+        assert "buckets" in d
+        assert 5 in d["buckets"]
+
+
+class TestAgentCapabilityProfile:
+    def test_defaults(self):
+        p = AgentCapabilityProfile()
+        assert p.capability_level == 1.0
+        assert p.base_reliability_10min == 0.8
+
+    def test_reliability_at_zero(self):
+        p = AgentCapabilityProfile()
+        assert p.reliability_at_horizon(0) == p.base_reliability_10min
+
+    def test_reliability_at_10min(self):
+        p = AgentCapabilityProfile()
+        result = p.reliability_at_horizon(10)
+        # At 10 min, log10(10/10) = 0, so no decay
+        assert result == pytest.approx(p.base_reliability_10min * p.capability_level)
+
+    def test_reliability_decreases_with_duration(self):
+        p = AgentCapabilityProfile()
+        r10 = p.reliability_at_horizon(10)
+        r60 = p.reliability_at_horizon(60)
+        r480 = p.reliability_at_horizon(480)
+        assert r10 > r60
+        assert r60 > r480
+
+    def test_reliability_clamped(self):
+        p = AgentCapabilityProfile(
+            base_reliability_10min=0.1, horizon_decay_rate=0.5
+        )
+        result = p.reliability_at_horizon(100000)
+        assert result >= 0.0
+
+    def test_expected_quality(self):
+        p = AgentCapabilityProfile()
+        q = p.expected_quality(10)
+        r = p.reliability_at_horizon(10)
+        assert q == pytest.approx(r ** 1.2)
+
+    def test_compute_cost(self):
+        p = AgentCapabilityProfile(compute_cost_per_minute=2.0)
+        assert p.compute_cost(30) == pytest.approx(60.0)
+
+
+class TestCapabilityProfiles:
+    def test_profiles_exist(self):
+        assert "frontier" in CAPABILITY_PROFILES
+        assert "standard" in CAPABILITY_PROFILES
+        assert "distilled" in CAPABILITY_PROFILES
+        assert "edge" in CAPABILITY_PROFILES
+
+    def test_frontier_best(self):
+        f = CAPABILITY_PROFILES["frontier"]
+        e = CAPABILITY_PROFILES["edge"]
+        assert f.reliability_at_horizon(60) > e.reliability_at_horizon(60)
+
+
+class TestComputeConstraints:
+    def test_defaults(self):
+        c = ComputeConstraints()
+        assert c.total_capacity == 125_000.0
+        assert c.allocated == 0.0
+
+    def test_available(self):
+        c = ComputeConstraints(total_capacity=100.0, allocated=30.0)
+        assert c.available() == pytest.approx(70.0)
+
+    def test_available_clamped(self):
+        c = ComputeConstraints(total_capacity=10.0, allocated=20.0)
+        assert c.available() == 0.0
+
+    def test_utilization(self):
+        c = ComputeConstraints(total_capacity=100.0, allocated=25.0)
+        assert c.utilization() == pytest.approx(0.25)
+
+    def test_can_allocate(self):
+        c = ComputeConstraints(total_capacity=100.0, allocated=90.0)
+        assert c.can_allocate(10.0)
+        assert not c.can_allocate(11.0)
+
+    def test_allocate_success(self):
+        c = ComputeConstraints(total_capacity=100.0, allocated=0.0)
+        assert c.allocate(50.0)
+        assert c.allocated == pytest.approx(50.0)
+
+    def test_allocate_fail(self):
+        c = ComputeConstraints(total_capacity=100.0, allocated=95.0)
+        assert not c.allocate(10.0)
+        assert c.allocated == pytest.approx(95.0)
+
+    def test_release(self):
+        c = ComputeConstraints(total_capacity=100.0, allocated=50.0)
+        c.release(20.0)
+        assert c.allocated == pytest.approx(30.0)
+
+    def test_release_clamped(self):
+        c = ComputeConstraints(total_capacity=100.0, allocated=10.0)
+        c.release(50.0)
+        assert c.allocated == 0.0
+
+    def test_max_concurrent_agents(self):
+        c = ComputeConstraints(total_capacity=1000.0)
+        p = AgentCapabilityProfile(compute_cost_per_minute=1.0)
+        # 1000 / (1.0 * 60) = 16
+        assert c.max_concurrent_agents(p, task_minutes=60) == 16
+
+    def test_max_concurrent_agents_zero_cost(self):
+        c = ComputeConstraints(total_capacity=1000.0)
+        p = AgentCapabilityProfile(compute_cost_per_minute=0.0)
+        assert c.max_concurrent_agents(p, task_minutes=60) == 0


### PR DESCRIPTION
Tests added for:
- swarm/metrics/moltbook_metrics.py (14% -> 100%)
- swarm/metrics/moltipedia_metrics.py (11% -> 100%)
- swarm/metrics/time_horizons.py (36% -> ~95%)
- swarm/governance/memory.py (39% -> ~95%)

112 new tests, overall coverage: 69.12% -> 70.30%

https://claude.ai/code/session_0141Tbvs7smhSUcHzVjnRdXf