### PR TITLE
feat: Add agent interaction dashboard with SVG flow visualization

### DIFF
--- a/swarm/__main__.py
+++ b/swarm/__main__.py
@@ -213,6 +213,18 @@ def cmd_list(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_dashboard(args: argparse.Namespace) -> int:
+    """Launch the agent interaction dashboard."""
+    from swarm.dashboard.server import run_dashboard
+
+    run_dashboard(
+        base_dir=args.dir,
+        port=args.port,
+        no_open=args.no_open,
+    )
+    return 0
+
+
 def cmd_agentrxiv(args: argparse.Namespace) -> int:
     """Handle AgentRxiv subcommands."""
     subcmd = args.agentrxiv_cmd
@@ -418,12 +430,35 @@ def main() -> int:
     arxiv_status = arxiv_subparsers.add_parser("status", help="Check AgentRxiv server status")
     arxiv_status.add_argument("--url", help="AgentRxiv server URL (default: http://127.0.0.1:5000)")
 
+    # dashboard
+    dash_parser = subparsers.add_parser(
+        "dashboard", help="Launch agent interaction dashboard"
+    )
+    dash_parser.add_argument(
+        "--dir",
+        default=".",
+        help="Root directory to scan for sessions (default: current directory)",
+    )
+    dash_parser.add_argument(
+        "--port",
+        type=int,
+        default=3339,
+        help="Port to serve dashboard on (default: 3339)",
+    )
+    dash_parser.add_argument(
+        "--no-open",
+        action="store_true",
+        help="Don't auto-open browser",
+    )
+
     args = parser.parse_args()
 
     if args.command == "run":
         return cmd_run(args)
     elif args.command == "list":
         return cmd_list(args)
+    elif args.command == "dashboard":
+        return cmd_dashboard(args)
     elif args.command == "agentrxiv":
         if args.agentrxiv_cmd:
             return cmd_agentrxiv(args)

--- a/swarm/dashboard/__init__.py
+++ b/swarm/dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""Agent interaction dashboard for visualizing simulation sessions."""

--- a/swarm/dashboard/server.py
+++ b/swarm/dashboard/server.py
@@ -1,0 +1,145 @@
+"""Lightweight HTTP server for the agent interaction dashboard."""
+
+import json
+import mimetypes
+import sys
+import webbrowser
+from functools import partial
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.parse import parse_qs, urlparse
+
+from swarm.dashboard.session_parser import discover_sessions, parse_session
+
+# Directory containing web assets (index.html, app.js, styles.css)
+WEB_DIR = Path(__file__).parent / "web"
+
+
+class DashboardHandler(SimpleHTTPRequestHandler):
+    """Request handler for the dashboard API and static file serving."""
+
+    base_dir: Path  # set by server factory
+
+    def do_GET(self) -> None:
+        parsed = urlparse(self.path)
+        path = parsed.path
+
+        # API routes
+        if path == "/api/sessions":
+            self._handle_sessions_list()
+        elif path.startswith("/api/sessions/"):
+            # /api/sessions/<encoded_path>
+            session_path = path[len("/api/sessions/"):]
+            # URL-decode the path
+            from urllib.parse import unquote
+            session_path = unquote(session_path)
+            self._handle_session_detail(session_path)
+        elif path == "/api/health":
+            self._json_response({"status": "ok"})
+        else:
+            # Serve static files from web directory
+            self._serve_static(path)
+
+    def _handle_sessions_list(self) -> None:
+        """Return list of discovered sessions."""
+        sessions = discover_sessions(self.base_dir)
+        self._json_response({"sessions": sessions})
+
+    def _handle_session_detail(self, session_path: str) -> None:
+        """Return fully parsed session data."""
+        # Validate the path exists
+        p = Path(session_path)
+        if not p.exists():
+            # Try relative to base_dir
+            p = self.base_dir / session_path
+        if not p.exists():
+            self._json_response({"error": "Session file not found"}, status=404)
+            return
+
+        data = parse_session(str(p))
+        self._json_response(data)
+
+    def _json_response(
+        self, data: Any, status: int = 200
+    ) -> None:
+        """Send a JSON response."""
+        body = json.dumps(data, default=str).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _serve_static(self, path: str) -> None:
+        """Serve static files from the web/ directory."""
+        if path == "/" or path == "":
+            path = "/index.html"
+
+        file_path = WEB_DIR / path.lstrip("/")
+
+        if not file_path.exists() or not file_path.is_file():
+            # Fall back to index.html for SPA routing
+            file_path = WEB_DIR / "index.html"
+
+        if not file_path.exists():
+            self.send_error(404, "File not found")
+            return
+
+        content_type, _ = mimetypes.guess_type(str(file_path))
+        if content_type is None:
+            content_type = "application/octet-stream"
+
+        body = file_path.read_bytes()
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        """Suppress default request logging to keep output clean."""
+        pass
+
+
+def run_dashboard(
+    base_dir: Optional[str] = None,
+    port: int = 3339,
+    no_open: bool = False,
+) -> None:
+    """Launch the dashboard web server.
+
+    Args:
+        base_dir: Root directory to scan for sessions (default: cwd)
+        port: Port to serve on (default: 3339)
+        no_open: If True, don't auto-open browser
+    """
+    resolved_dir = Path(base_dir) if base_dir else Path.cwd()
+    if not resolved_dir.is_dir():
+        print(f"Error: directory not found: {resolved_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    # Inject base_dir into handler class
+    DashboardHandler.base_dir = resolved_dir
+
+    server = HTTPServer(("127.0.0.1", port), DashboardHandler)
+    url = f"http://127.0.0.1:{port}"
+
+    print("=" * 50)
+    print("  SWARM Agent Dashboard")
+    print("=" * 50)
+    print(f"  Scanning:  {resolved_dir}")
+    print(f"  Dashboard: {url}")
+    print()
+    print("  Press Ctrl+C to stop.")
+    print("=" * 50)
+
+    if not no_open:
+        webbrowser.open(url)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nShutting down dashboard server.")
+        server.shutdown()

--- a/swarm/dashboard/session_parser.py
+++ b/swarm/dashboard/session_parser.py
@@ -1,0 +1,455 @@
+"""Discovers and parses simulation sessions from runs/ and logs/ directories."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+def discover_sessions(base_dir: Path) -> List[Dict[str, Any]]:
+    """Discover simulation sessions from runs/ and logs/ directories.
+
+    Scans for:
+    - runs/<name>/history.json  (exported JSON histories)
+    - logs/*.jsonl              (event log files)
+    - logs/*.json               (exported JSON files)
+
+    Returns list of session metadata dicts (lightweight, no full parse).
+    """
+    sessions: List[Dict[str, Any]] = []
+
+    # Scan runs/ directory for history.json files
+    runs_dir = base_dir / "runs"
+    if runs_dir.is_dir():
+        for run_dir in sorted(runs_dir.iterdir()):
+            if not run_dir.is_dir():
+                continue
+            history_file = run_dir / "history.json"
+            if history_file.exists():
+                meta = _extract_json_metadata(history_file)
+                if meta:
+                    meta["source"] = "runs"
+                    meta["path"] = str(history_file)
+                    meta["run_dir"] = str(run_dir)
+                    sessions.append(meta)
+
+    # Scan logs/ directory for JSONL event logs and JSON exports
+    logs_dir = base_dir / "logs"
+    if logs_dir.is_dir():
+        for f in sorted(logs_dir.iterdir()):
+            if f.suffix == ".jsonl":
+                meta = _extract_jsonl_metadata(f)
+                if meta:
+                    meta["source"] = "logs"
+                    meta["path"] = str(f)
+                    sessions.append(meta)
+            elif f.suffix == ".json":
+                meta = _extract_json_metadata(f)
+                if meta:
+                    meta["source"] = "logs"
+                    meta["path"] = str(f)
+                    sessions.append(meta)
+
+    return sessions
+
+
+def parse_session(path: str) -> Dict[str, Any]:
+    """Fully parse a session file and return structured data for the dashboard.
+
+    Handles both JSON history files and JSONL event logs.
+    """
+    p = Path(path)
+    if p.suffix == ".json":
+        return _parse_json_session(p)
+    elif p.suffix == ".jsonl":
+        return _parse_jsonl_session(p)
+    return {"error": f"Unsupported file type: {p.suffix}"}
+
+
+def _extract_json_metadata(path: Path) -> Optional[Dict[str, Any]]:
+    """Extract lightweight metadata from a JSON history file."""
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        return {
+            "session_id": data.get("simulation_id", path.stem),
+            "n_epochs": data.get("n_epochs", 0),
+            "n_agents": data.get("n_agents", 0),
+            "seed": data.get("seed"),
+            "started_at": data.get("started_at"),
+            "ended_at": data.get("ended_at"),
+            "file_type": "json",
+        }
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _extract_jsonl_metadata(path: Path) -> Optional[Dict[str, Any]]:
+    """Extract lightweight metadata from a JSONL event log (first/last lines)."""
+    try:
+        first_event = None
+        last_event = None
+        event_count = 0
+        agent_ids: set = set()
+        scenario_id = None
+
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                event = json.loads(line)
+                event_count += 1
+                if first_event is None:
+                    first_event = event
+                last_event = event
+
+                # Collect agent IDs
+                for key in ("agent_id", "initiator_id", "counterparty_id"):
+                    aid = event.get(key)
+                    if aid:
+                        agent_ids.add(aid)
+
+                if event.get("scenario_id"):
+                    scenario_id = event["scenario_id"]
+
+        if first_event is None:
+            return None
+
+        # Derive epoch count from last event
+        max_epoch = 0
+        if last_event and last_event.get("epoch") is not None:
+            max_epoch = last_event["epoch"] + 1
+
+        return {
+            "session_id": scenario_id or path.stem,
+            "n_epochs": max_epoch,
+            "n_agents": len(agent_ids),
+            "seed": first_event.get("seed"),
+            "started_at": first_event.get("timestamp"),
+            "ended_at": last_event.get("timestamp") if last_event else None,
+            "event_count": event_count,
+            "file_type": "jsonl",
+        }
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _parse_json_session(path: Path) -> Dict[str, Any]:
+    """Parse a JSON history file into dashboard-ready data."""
+    with open(path) as f:
+        data = json.load(f)
+
+    # Build agent map from agent_snapshots
+    agents: Dict[str, Dict[str, Any]] = {}
+    for snap in data.get("agent_snapshots", []):
+        aid = snap["agent_id"]
+        if aid not in agents:
+            agents[aid] = {
+                "agent_id": aid,
+                "name": snap.get("name", aid),
+                "type": _infer_agent_type(snap.get("name", aid)),
+                "epochs": [],
+            }
+        agents[aid]["epochs"].append({
+            "epoch": snap.get("epoch", 0),
+            "reputation": snap.get("reputation", 0.0),
+            "resources": snap.get("resources", 100.0),
+            "interactions_initiated": snap.get("interactions_initiated", 0),
+            "interactions_received": snap.get("interactions_received", 0),
+            "avg_p_initiated": snap.get("avg_p_initiated", 0.5),
+            "avg_p_received": snap.get("avg_p_received", 0.5),
+            "total_payoff": snap.get("total_payoff", 0.0),
+            "is_frozen": snap.get("is_frozen", False),
+            "is_quarantined": snap.get("is_quarantined", False),
+        })
+
+    # Build epoch metrics timeline
+    epochs = []
+    for snap in data.get("epoch_snapshots", []):
+        epochs.append({
+            "epoch": snap.get("epoch", 0),
+            "total_interactions": snap.get("total_interactions", 0),
+            "accepted_interactions": snap.get("accepted_interactions", 0),
+            "toxicity_rate": snap.get("toxicity_rate", 0.0),
+            "quality_gap": snap.get("quality_gap", 0.0),
+            "avg_p": snap.get("avg_p", 0.5),
+            "total_welfare": snap.get("total_welfare", 0.0),
+            "avg_payoff": snap.get("avg_payoff", 0.0),
+            "gini_coefficient": snap.get("gini_coefficient", 0.0),
+            "n_agents": snap.get("n_agents", 0),
+            "ecosystem_threat_level": snap.get("ecosystem_threat_level", 0.0),
+            "ecosystem_collusion_risk": snap.get("ecosystem_collusion_risk", 0.0),
+        })
+
+    # Build interaction edges (aggregate agent-to-agent flows)
+    edges = _build_edges_from_agent_snapshots(agents)
+
+    return {
+        "session_id": data.get("simulation_id", path.stem),
+        "n_epochs": data.get("n_epochs", 0),
+        "n_agents": data.get("n_agents", 0),
+        "seed": data.get("seed"),
+        "started_at": data.get("started_at"),
+        "ended_at": data.get("ended_at"),
+        "agents": agents,
+        "epochs": epochs,
+        "edges": edges,
+    }
+
+
+def _parse_jsonl_session(path: Path) -> Dict[str, Any]:
+    """Parse a JSONL event log into dashboard-ready data."""
+    agents: Dict[str, Dict[str, Any]] = {}
+    interactions: List[Dict[str, Any]] = []
+    epoch_data: Dict[int, Dict[str, Any]] = {}
+    scenario_id = None
+    seed = None
+    started_at = None
+    ended_at = None
+
+    # Per-agent-per-epoch accumulators
+    agent_epoch_stats: Dict[str, Dict[int, Dict[str, Any]]] = {}
+
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            event = json.loads(line)
+            etype = event.get("event_type", "")
+            epoch = event.get("epoch")
+            ts = event.get("timestamp")
+
+            if scenario_id is None and event.get("scenario_id"):
+                scenario_id = event["scenario_id"]
+            if seed is None and event.get("seed") is not None:
+                seed = event["seed"]
+            if started_at is None:
+                started_at = ts
+            ended_at = ts
+
+            # Track agents
+            for key in ("initiator_id", "counterparty_id", "agent_id"):
+                aid = event.get(key)
+                if aid and aid not in agents:
+                    agents[aid] = {
+                        "agent_id": aid,
+                        "name": aid,
+                        "type": "unknown",
+                        "events": 0,
+                    }
+                if aid and aid in agents:
+                    agents[aid]["events"] = agents[aid].get("events", 0) + 1
+
+            # Track interactions
+            payload = event.get("payload", {})
+            if etype == "interaction_proposed":
+                iid = event.get("interaction_id")
+                init_id = event.get("initiator_id", "")
+                cp_id = event.get("counterparty_id", "")
+                interactions.append({
+                    "interaction_id": iid,
+                    "initiator": init_id,
+                    "counterparty": cp_id,
+                    "epoch": epoch,
+                    "p": payload.get("p", 0.5),
+                    "v_hat": payload.get("v_hat", 0.0),
+                    "accepted": None,
+                })
+
+            elif etype in ("interaction_accepted", "interaction_rejected"):
+                iid = event.get("interaction_id")
+                for ix in reversed(interactions):
+                    if ix["interaction_id"] == iid:
+                        ix["accepted"] = etype == "interaction_accepted"
+                        break
+
+            elif etype == "payoff_computed":
+                iid = event.get("interaction_id")
+                for ix in reversed(interactions):
+                    if ix["interaction_id"] == iid:
+                        comps = payload.get("components", {})
+                        ix["payoff_initiator"] = payload.get("payoff_initiator", 0.0)
+                        ix["payoff_counterparty"] = payload.get("payoff_counterparty", 0.0)
+                        ix["tau"] = comps.get("tau", 0.0)
+                        break
+
+            elif etype == "reputation_updated":
+                aid = event.get("agent_id")
+                if aid and aid in agents:
+                    agents[aid]["reputation"] = payload.get("new_reputation", 0.0)
+
+            elif etype == "agent_created":
+                aid = event.get("agent_id")
+                if aid:
+                    agent_type = payload.get("agent_type", "unknown")
+                    name = payload.get("name", aid)
+                    agents[aid] = {
+                        "agent_id": aid,
+                        "name": name,
+                        "type": agent_type,
+                        "events": agents.get(aid, {}).get("events", 0),
+                    }
+
+            # Accumulate per-epoch stats
+            if epoch is not None:
+                if epoch not in epoch_data:
+                    epoch_data[epoch] = {
+                        "epoch": epoch,
+                        "total_interactions": 0,
+                        "accepted_interactions": 0,
+                        "p_values": [],
+                        "accepted_p": [],
+                        "rejected_p": [],
+                        "payoffs": [],
+                    }
+                ed = epoch_data[epoch]
+                if etype == "interaction_proposed":
+                    ed["total_interactions"] += 1
+                    ed["p_values"].append(payload.get("p", 0.5))
+                elif etype == "interaction_accepted":
+                    ed["accepted_interactions"] += 1
+                    # Find p for this interaction
+                    iid = event.get("interaction_id")
+                    for ix in reversed(interactions):
+                        if ix["interaction_id"] == iid:
+                            ed["accepted_p"].append(ix["p"])
+                            break
+                elif etype == "interaction_rejected":
+                    iid = event.get("interaction_id")
+                    for ix in reversed(interactions):
+                        if ix["interaction_id"] == iid:
+                            ed["rejected_p"].append(ix["p"])
+                            break
+
+    # Build epoch summaries
+    epochs = []
+    for ep_num in sorted(epoch_data.keys()):
+        ed = epoch_data[ep_num]
+        p_vals = ed["p_values"]
+        acc_p = ed["accepted_p"]
+        rej_p = ed["rejected_p"]
+        avg_p = sum(p_vals) / len(p_vals) if p_vals else 0.5
+        toxicity = 1.0 - (sum(acc_p) / len(acc_p)) if acc_p else 0.0
+        quality_gap = 0.0
+        if acc_p and rej_p:
+            quality_gap = (sum(acc_p) / len(acc_p)) - (sum(rej_p) / len(rej_p))
+
+        epochs.append({
+            "epoch": ep_num,
+            "total_interactions": ed["total_interactions"],
+            "accepted_interactions": ed["accepted_interactions"],
+            "toxicity_rate": toxicity,
+            "quality_gap": quality_gap,
+            "avg_p": avg_p,
+        })
+
+    # Build edges from interactions
+    edges = _build_edges_from_interactions(interactions)
+
+    return {
+        "session_id": scenario_id or path.stem,
+        "n_epochs": len(epoch_data),
+        "n_agents": len(agents),
+        "seed": seed,
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "agents": agents,
+        "epochs": epochs,
+        "edges": edges,
+        "interactions": interactions,
+    }
+
+
+def _build_edges_from_interactions(
+    interactions: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Aggregate interactions into directional edges between agents."""
+    edge_map: Dict[tuple, Dict[str, Any]] = {}
+
+    for ix in interactions:
+        init_id = ix.get("initiator", "")
+        cp_id = ix.get("counterparty", "")
+        if not init_id or not cp_id:
+            continue
+        key = (init_id, cp_id)
+        if key not in edge_map:
+            edge_map[key] = {
+                "source": init_id,
+                "target": cp_id,
+                "count": 0,
+                "accepted": 0,
+                "avg_p": 0.0,
+                "p_sum": 0.0,
+            }
+        edge_map[key]["count"] += 1
+        edge_map[key]["p_sum"] += ix.get("p", 0.5)
+        if ix.get("accepted"):
+            edge_map[key]["accepted"] += 1
+
+    edges = []
+    for e in edge_map.values():
+        e["avg_p"] = e["p_sum"] / e["count"] if e["count"] > 0 else 0.5
+        del e["p_sum"]
+        edges.append(e)
+
+    return edges
+
+
+def _build_edges_from_agent_snapshots(
+    agents: Dict[str, Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Build approximate edges from agent snapshot data.
+
+    JSON histories don't store per-interaction detail, so we create
+    edges based on which agents had interactions in the same epochs.
+    """
+    edges = []
+    agent_ids = list(agents.keys())
+    for i, a_id in enumerate(agent_ids):
+        for b_id in agent_ids[i + 1:]:
+            a_data = agents[a_id]
+            b_data = agents[b_id]
+            # Check if agents overlapped (both had activity)
+            a_epochs = {e["epoch"] for e in a_data.get("epochs", [])}
+            b_epochs = {e["epoch"] for e in b_data.get("epochs", [])}
+            overlap = a_epochs & b_epochs
+            if overlap:
+                a_initiated = sum(
+                    e.get("interactions_initiated", 0)
+                    for e in a_data.get("epochs", [])
+                )
+                b_initiated = sum(
+                    e.get("interactions_initiated", 0)
+                    for e in b_data.get("epochs", [])
+                )
+                if a_initiated > 0 or b_initiated > 0:
+                    edges.append({
+                        "source": a_id,
+                        "target": b_id,
+                        "count": len(overlap),
+                        "bidirectional": True,
+                    })
+    return edges
+
+
+def _infer_agent_type(name: str) -> str:
+    """Infer agent type from name string."""
+    name_lower = name.lower() if name else ""
+    type_keywords = {
+        "honest": "honest",
+        "opportunistic": "opportunistic",
+        "deceptive": "deceptive",
+        "adversarial": "adversarial",
+        "adaptive": "adaptive_adversary",
+        "diligent": "diligent",
+        "spam": "spam_bot",
+        "collusi": "collusive",
+        "vandal": "vandal",
+        "llm": "llm",
+    }
+    for keyword, agent_type in type_keywords.items():
+        if keyword in name_lower:
+            return agent_type
+    return "unknown"

--- a/swarm/dashboard/web/app.js
+++ b/swarm/dashboard/web/app.js
@@ -1,0 +1,658 @@
+/**
+ * SWARM Agent Dashboard - Frontend Application
+ *
+ * Renders agent interaction networks as SVG flow diagrams
+ * with timeline charts and detail panels.
+ */
+
+class SwarmDashboard {
+  constructor() {
+    this.sessions = [];
+    this.activeSession = null;
+    this.activeAgent = null;
+
+    // Agent type → color mapping
+    this.agentColors = {
+      honest:             '#3fb950',
+      opportunistic:      '#d29922',
+      deceptive:          '#bc8cff',
+      adversarial:        '#f85149',
+      adaptive_adversary: '#ff7b72',
+      diligent:           '#39d353',
+      spam_bot:           '#f0883e',
+      collusive:          '#db61a2',
+      vandal:             '#f85149',
+      llm:                '#58a6ff',
+      unknown:            '#8b949e',
+    };
+
+    this.init();
+  }
+
+  async init() {
+    this.bindUI();
+    await this.loadSessions();
+  }
+
+  bindUI() {
+    document.getElementById('panel-close').addEventListener('click', () => {
+      this.closePanel();
+    });
+  }
+
+  // ── Session loading ──────────────────────────────────────
+
+  async loadSessions() {
+    const listEl = document.getElementById('sessions-list');
+    try {
+      const resp = await fetch('/api/sessions');
+      const data = await resp.json();
+      this.sessions = data.sessions || [];
+
+      if (this.sessions.length === 0) {
+        listEl.innerHTML = '<div class="loading">No sessions found.<br>Run a simulation first.</div>';
+        return;
+      }
+
+      listEl.innerHTML = '';
+      for (const s of this.sessions) {
+        const card = document.createElement('div');
+        card.className = 'session-card';
+        card.dataset.path = s.path;
+        card.innerHTML = `
+          <div class="session-name">${this.escHtml(s.session_id)}</div>
+          <div class="session-meta">
+            ${s.n_agents || '?'} agents &middot; ${s.n_epochs || '?'} epochs
+            ${s.seed != null ? ' &middot; seed ' + s.seed : ''}
+          </div>
+        `;
+        card.addEventListener('click', () => this.selectSession(s, card));
+        listEl.appendChild(card);
+      }
+    } catch (err) {
+      listEl.innerHTML = `<div class="loading">Error loading sessions.</div>`;
+      console.error('Failed to load sessions:', err);
+    }
+  }
+
+  async selectSession(meta, cardEl) {
+    // Highlight active card
+    document.querySelectorAll('.session-card').forEach(c => c.classList.remove('active'));
+    cardEl.classList.add('active');
+
+    // Fetch full session data
+    const encoded = encodeURIComponent(meta.path);
+    try {
+      const resp = await fetch(`/api/sessions/${encoded}`);
+      this.activeSession = await resp.json();
+    } catch (err) {
+      console.error('Failed to load session:', err);
+      return;
+    }
+
+    // Update topbar
+    document.getElementById('topbar-title').textContent = this.activeSession.session_id || 'Session';
+    const metaStr = [
+      this.activeSession.n_agents ? `${this.activeSession.n_agents} agents` : '',
+      this.activeSession.n_epochs ? `${this.activeSession.n_epochs} epochs` : '',
+      this.activeSession.seed != null ? `seed ${this.activeSession.seed}` : '',
+    ].filter(Boolean).join(' · ');
+    document.getElementById('topbar-meta').textContent = metaStr;
+
+    // Render
+    this.closePanel();
+    this.renderFlow();
+    this.renderTimeline();
+  }
+
+  // ── SVG Flow Visualization ───────────────────────────────
+
+  renderFlow() {
+    const session = this.activeSession;
+    if (!session || !session.agents) return;
+
+    const emptyState = document.getElementById('empty-state');
+    const svg = document.getElementById('flow-svg');
+    emptyState.style.display = 'none';
+    svg.classList.add('visible');
+
+    const agents = session.agents;
+    const edges = session.edges || [];
+    const agentList = Object.values(agents);
+
+    if (agentList.length === 0) {
+      emptyState.style.display = 'block';
+      emptyState.textContent = 'No agents found in this session.';
+      svg.classList.remove('visible');
+      return;
+    }
+
+    // Layout parameters
+    const nodeRadius = 28;
+    const hSpacing = 160;
+    const vSpacing = 100;
+    const padding = 60;
+
+    // Group agents by type for layout
+    const typeGroups = {};
+    for (const agent of agentList) {
+      const t = agent.type || 'unknown';
+      if (!typeGroups[t]) typeGroups[t] = [];
+      typeGroups[t].push(agent);
+    }
+
+    const typeOrder = [
+      'honest', 'diligent', 'llm', 'unknown',
+      'opportunistic', 'deceptive', 'collusive',
+      'adversarial', 'adaptive_adversary', 'spam_bot', 'vandal',
+    ];
+    const sortedTypes = typeOrder.filter(t => typeGroups[t]);
+
+    // Position nodes in columns by type
+    const positions = {};
+    let col = 0;
+    for (const t of sortedTypes) {
+      const group = typeGroups[t];
+      for (let row = 0; row < group.length; row++) {
+        const agent = group[row];
+        const aid = agent.agent_id;
+        positions[aid] = {
+          x: padding + col * hSpacing + hSpacing / 2,
+          y: padding + row * vSpacing + vSpacing / 2,
+        };
+      }
+      col++;
+    }
+
+    // Compute SVG dimensions
+    const maxX = Math.max(...Object.values(positions).map(p => p.x)) + padding + nodeRadius;
+    const maxY = Math.max(...Object.values(positions).map(p => p.y)) + padding + nodeRadius;
+    const width = Math.max(maxX + padding, 600);
+    const height = Math.max(maxY + padding, 400);
+
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    svg.innerHTML = '';
+
+    // Define arrowhead marker
+    const defs = this.svgEl('defs');
+    const marker = this.svgEl('marker', {
+      id: 'arrowhead', markerWidth: 8, markerHeight: 6,
+      refX: 8, refY: 3, orient: 'auto', markerUnits: 'strokeWidth',
+    });
+    marker.appendChild(this.svgEl('polygon', {
+      points: '0 0, 8 3, 0 6',
+      class: 'edge-arrow',
+    }));
+    defs.appendChild(marker);
+    svg.appendChild(defs);
+
+    // Draw edges
+    const edgeGroup = this.svgEl('g', { class: 'edges-group' });
+    for (const edge of edges) {
+      const srcPos = positions[edge.source];
+      const tgtPos = positions[edge.target];
+      if (!srcPos || !tgtPos) continue;
+
+      const dx = tgtPos.x - srcPos.x;
+      const dy = tgtPos.y - srcPos.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      if (dist === 0) continue;
+
+      // Offset start/end by node radius
+      const ux = dx / dist;
+      const uy = dy / dist;
+      const sx = srcPos.x + ux * (nodeRadius + 2);
+      const sy = srcPos.y + uy * (nodeRadius + 2);
+      const ex = tgtPos.x - ux * (nodeRadius + 6);
+      const ey = tgtPos.y - uy * (nodeRadius + 6);
+
+      // Cubic bezier for curved edges
+      const cx1 = sx + dx * 0.3 + dy * 0.15;
+      const cy1 = sy + dy * 0.3 - dx * 0.15;
+      const cx2 = ex - dx * 0.3 + dy * 0.15;
+      const cy2 = ey - dy * 0.3 - dx * 0.15;
+
+      const avgP = edge.avg_p != null ? edge.avg_p : 0.5;
+      const strokeColor = this.pToColor(avgP);
+
+      const path = this.svgEl('path', {
+        d: `M ${sx} ${sy} C ${cx1} ${cy1}, ${cx2} ${cy2}, ${ex} ${ey}`,
+        class: 'edge-path',
+        stroke: strokeColor,
+        'marker-end': 'url(#arrowhead)',
+        'data-source': edge.source,
+        'data-target': edge.target,
+      });
+      edgeGroup.appendChild(path);
+
+      // Edge label with count
+      if (edge.count > 1) {
+        const mx = (sx + ex) / 2;
+        const my = (sy + ey) / 2 - 8;
+        const label = this.svgEl('text', {
+          x: mx, y: my, class: 'edge-label',
+          'data-source': edge.source, 'data-target': edge.target,
+        });
+        label.textContent = `${edge.count}`;
+        edgeGroup.appendChild(label);
+      }
+    }
+    svg.appendChild(edgeGroup);
+
+    // Draw nodes
+    const nodeGroup = this.svgEl('g', { class: 'nodes-group' });
+    for (const agent of agentList) {
+      const aid = agent.agent_id;
+      const pos = positions[aid];
+      if (!pos) continue;
+
+      const color = this.agentColors[agent.type] || this.agentColors.unknown;
+      const g = this.svgEl('g', { class: 'node-group', 'data-agent': aid });
+
+      // Circle
+      const circle = this.svgEl('circle', {
+        cx: pos.x, cy: pos.y, r: nodeRadius,
+        fill: color + '22', stroke: color, 'stroke-width': 2,
+        class: 'node-circle',
+      });
+      g.appendChild(circle);
+
+      // Label (short name)
+      const displayName = this.shortName(agent.name || aid);
+      const label = this.svgEl('text', {
+        x: pos.x, y: pos.y + 1, class: 'node-label',
+      });
+      label.textContent = displayName;
+      g.appendChild(label);
+
+      // Sub-label (type)
+      const sublabel = this.svgEl('text', {
+        x: pos.x, y: pos.y + nodeRadius + 14, class: 'node-sublabel',
+      });
+      sublabel.textContent = agent.type || '';
+      g.appendChild(sublabel);
+
+      // Hover/click events
+      g.addEventListener('mouseenter', () => this.highlightAgent(aid));
+      g.addEventListener('mouseleave', () => this.clearHighlight());
+      g.addEventListener('click', () => this.openAgentPanel(aid));
+
+      nodeGroup.appendChild(g);
+    }
+    svg.appendChild(nodeGroup);
+  }
+
+  highlightAgent(agentId) {
+    // Dim all, highlight connected
+    const svg = document.getElementById('flow-svg');
+
+    svg.querySelectorAll('.node-group').forEach(g => {
+      g.classList.toggle('dimmed', g.dataset.agent !== agentId);
+      g.classList.toggle('highlighted', g.dataset.agent === agentId);
+    });
+
+    svg.querySelectorAll('.edge-path').forEach(p => {
+      const isConnected = p.dataset.source === agentId || p.dataset.target === agentId;
+      p.classList.toggle('dimmed', !isConnected);
+      p.classList.toggle('highlighted', isConnected);
+
+      // Undim connected nodes
+      if (isConnected) {
+        const otherId = p.dataset.source === agentId ? p.dataset.target : p.dataset.source;
+        const otherNode = svg.querySelector(`.node-group[data-agent="${otherId}"]`);
+        if (otherNode) {
+          otherNode.classList.remove('dimmed');
+        }
+      }
+    });
+
+    svg.querySelectorAll('.edge-label').forEach(l => {
+      const isConnected = l.dataset.source === agentId || l.dataset.target === agentId;
+      l.classList.toggle('dimmed', !isConnected);
+    });
+  }
+
+  clearHighlight() {
+    const svg = document.getElementById('flow-svg');
+    svg.querySelectorAll('.dimmed').forEach(el => el.classList.remove('dimmed'));
+    svg.querySelectorAll('.highlighted').forEach(el => el.classList.remove('highlighted'));
+  }
+
+  // ── Timeline Chart ───────────────────────────────────────
+
+  renderTimeline() {
+    const session = this.activeSession;
+    if (!session || !session.epochs || session.epochs.length === 0) {
+      document.getElementById('timeline-container').classList.remove('visible');
+      return;
+    }
+
+    const container = document.getElementById('timeline-container');
+    const svg = document.getElementById('timeline-svg');
+    container.classList.add('visible');
+
+    const epochs = session.epochs;
+    const rect = container.getBoundingClientRect();
+    const width = Math.max(rect.width || 800, 400);
+    const height = 180;
+    const margin = { top: 24, right: 20, bottom: 30, left: 50 };
+    const plotW = width - margin.left - margin.right;
+    const plotH = height - margin.top - margin.bottom;
+
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+    svg.innerHTML = '';
+
+    // Metrics to plot
+    const series = [
+      { key: 'toxicity_rate', label: 'Toxicity', color: '#f85149' },
+      { key: 'avg_p', label: 'Avg p', color: '#58a6ff' },
+      { key: 'quality_gap', label: 'Quality Gap', color: '#d29922' },
+    ];
+
+    // Compute scales
+    const xMin = Math.min(...epochs.map(e => e.epoch));
+    const xMax = Math.max(...epochs.map(e => e.epoch));
+    const xRange = xMax - xMin || 1;
+
+    // Y range: find min/max across all series
+    let yMin = 0, yMax = 1;
+    for (const s of series) {
+      for (const ep of epochs) {
+        const v = ep[s.key];
+        if (v != null) {
+          if (v < yMin) yMin = v;
+          if (v > yMax) yMax = v;
+        }
+      }
+    }
+    const yPad = (yMax - yMin) * 0.1 || 0.1;
+    yMin -= yPad;
+    yMax += yPad;
+    const yRange = yMax - yMin || 1;
+
+    const xScale = (v) => margin.left + ((v - xMin) / xRange) * plotW;
+    const yScale = (v) => margin.top + plotH - ((v - yMin) / yRange) * plotH;
+
+    // Grid lines
+    const gridGroup = this.svgEl('g', { class: 'timeline-grid' });
+    for (let i = 0; i <= 4; i++) {
+      const yVal = yMin + (yRange * i) / 4;
+      const y = yScale(yVal);
+      gridGroup.appendChild(this.svgEl('line', {
+        x1: margin.left, x2: width - margin.right, y1: y, y2: y,
+      }));
+    }
+    svg.appendChild(gridGroup);
+
+    // Axes
+    const axisGroup = this.svgEl('g', { class: 'timeline-axis' });
+
+    // X axis
+    axisGroup.appendChild(this.svgEl('line', {
+      x1: margin.left, x2: width - margin.right,
+      y1: height - margin.bottom, y2: height - margin.bottom,
+    }));
+    // X labels (every N epochs)
+    const xStep = Math.max(1, Math.ceil(epochs.length / 10));
+    for (let i = 0; i < epochs.length; i += xStep) {
+      const ep = epochs[i];
+      const x = xScale(ep.epoch);
+      const label = this.svgEl('text', {
+        x, y: height - margin.bottom + 14, 'text-anchor': 'middle',
+      });
+      label.textContent = ep.epoch;
+      axisGroup.appendChild(label);
+    }
+
+    // Y axis
+    axisGroup.appendChild(this.svgEl('line', {
+      x1: margin.left, x2: margin.left,
+      y1: margin.top, y2: height - margin.bottom,
+    }));
+    for (let i = 0; i <= 4; i++) {
+      const yVal = yMin + (yRange * i) / 4;
+      const y = yScale(yVal);
+      const label = this.svgEl('text', {
+        x: margin.left - 6, y: y + 3, 'text-anchor': 'end',
+      });
+      label.textContent = yVal.toFixed(2);
+      axisGroup.appendChild(label);
+    }
+    svg.appendChild(axisGroup);
+
+    // Plot lines
+    for (const s of series) {
+      const points = epochs
+        .filter(e => e[s.key] != null)
+        .map(e => `${xScale(e.epoch)},${yScale(e[s.key])}`);
+
+      if (points.length < 2) continue;
+
+      const line = this.svgEl('polyline', {
+        points: points.join(' '),
+        class: 'timeline-line',
+        stroke: s.color,
+      });
+      svg.appendChild(line);
+    }
+
+    // Legend
+    const legendGroup = this.svgEl('g', { class: 'timeline-legend' });
+    let lx = margin.left + 8;
+    for (const s of series) {
+      const rect2 = this.svgEl('rect', {
+        x: lx, y: 6, width: 12, height: 3, rx: 1, fill: s.color,
+      });
+      legendGroup.appendChild(rect2);
+      const label = this.svgEl('text', { x: lx + 16, y: 12 });
+      label.textContent = s.label;
+      legendGroup.appendChild(label);
+      lx += 16 + s.label.length * 6.5 + 14;
+    }
+    svg.appendChild(legendGroup);
+  }
+
+  // ── Agent Detail Panel ───────────────────────────────────
+
+  openAgentPanel(agentId) {
+    const session = this.activeSession;
+    if (!session) return;
+
+    const agent = session.agents[agentId];
+    if (!agent) return;
+
+    this.activeAgent = agentId;
+    const panel = document.getElementById('detail-panel');
+    const title = document.getElementById('panel-title');
+    const body = document.getElementById('panel-body');
+
+    title.textContent = agent.name || agentId;
+    panel.classList.add('open');
+
+    const color = this.agentColors[agent.type] || this.agentColors.unknown;
+    const badgeClass = `badge-${agent.type || 'unknown'}`;
+
+    let html = '';
+
+    // Identity section
+    html += `<div class="panel-section">
+      <div class="panel-section-header expanded" onclick="dashboard.toggleSection(this)">
+        Identity <span class="chevron">&#9654;</span>
+      </div>
+      <div class="panel-section-body expanded">
+        <div class="kv-row"><span class="kv-key">ID</span><span class="kv-val">${this.escHtml(agentId)}</span></div>
+        <div class="kv-row"><span class="kv-key">Name</span><span class="kv-val">${this.escHtml(agent.name || agentId)}</span></div>
+        <div class="kv-row"><span class="kv-key">Type</span><span class="badge ${badgeClass}">${this.escHtml(agent.type || 'unknown')}</span></div>
+      </div>
+    </div>`;
+
+    // Connections section
+    const edges = (session.edges || []).filter(
+      e => e.source === agentId || e.target === agentId
+    );
+    if (edges.length > 0) {
+      let connHtml = '';
+      for (const e of edges) {
+        const otherId = e.source === agentId ? e.target : e.source;
+        const direction = e.source === agentId ? 'sent' : 'received';
+        const otherAgent = session.agents[otherId];
+        const otherName = otherAgent ? (otherAgent.name || otherId) : otherId;
+        const otherColor = this.agentColors[(otherAgent || {}).type] || this.agentColors.unknown;
+        const pClass = (e.avg_p || 0.5) >= 0.5 ? 'good' : 'bad';
+
+        connHtml += `<div class="interaction-item">
+          <span class="agent-dot" style="background:${otherColor}"></span>
+          <span class="ix-parties">${this.escHtml(otherName)}</span>
+          <span style="color:var(--text-muted)"> (${direction})</span>
+          <div class="ix-meta">
+            ${e.count} interaction${e.count !== 1 ? 's' : ''}
+            ${e.avg_p != null ? ` · avg p = <span class="${pClass}">${e.avg_p.toFixed(3)}</span>` : ''}
+            ${e.accepted != null ? ` · ${e.accepted} accepted` : ''}
+          </div>
+        </div>`;
+      }
+
+      html += `<div class="panel-section">
+        <div class="panel-section-header expanded" onclick="dashboard.toggleSection(this)">
+          Connections (${edges.length}) <span class="chevron">&#9654;</span>
+        </div>
+        <div class="panel-section-body expanded">${connHtml}</div>
+      </div>`;
+    }
+
+    // Epoch trajectory section (if agent has epoch data)
+    const epochData = agent.epochs;
+    if (epochData && epochData.length > 0) {
+      let trajHtml = '';
+      const lastEp = epochData[epochData.length - 1];
+      const firstEp = epochData[0];
+
+      trajHtml += `<div class="kv-row"><span class="kv-key">Reputation</span>
+        <span class="kv-val">${(lastEp.reputation || 0).toFixed(2)}</span></div>`;
+      trajHtml += `<div class="kv-row"><span class="kv-key">Resources</span>
+        <span class="kv-val">${(lastEp.resources || 0).toFixed(1)}</span></div>`;
+      trajHtml += `<div class="kv-row"><span class="kv-key">Total Payoff</span>
+        <span class="kv-val ${lastEp.total_payoff >= 0 ? 'good' : 'bad'}">${(lastEp.total_payoff || 0).toFixed(2)}</span></div>`;
+      trajHtml += `<div class="kv-row"><span class="kv-key">Avg p (initiated)</span>
+        <span class="kv-val ${(lastEp.avg_p_initiated || 0.5) >= 0.5 ? 'good' : 'bad'}">${(lastEp.avg_p_initiated || 0.5).toFixed(3)}</span></div>`;
+
+      if (lastEp.is_frozen) {
+        trajHtml += `<div class="kv-row"><span class="kv-key">Status</span>
+          <span class="kv-val bad">FROZEN</span></div>`;
+      } else if (lastEp.is_quarantined) {
+        trajHtml += `<div class="kv-row"><span class="kv-key">Status</span>
+          <span class="kv-val warn">QUARANTINED</span></div>`;
+      }
+
+      // Mini reputation trajectory
+      if (epochData.length > 1) {
+        trajHtml += '<div style="margin-top:8px">';
+        trajHtml += '<div style="font-size:10px;color:var(--text-muted);margin-bottom:4px">Reputation over epochs:</div>';
+        const maxRep = Math.max(...epochData.map(e => Math.abs(e.reputation || 0)), 1);
+        for (const ep of epochData) {
+          const pct = Math.max(0, ((ep.reputation || 0) / maxRep) * 100);
+          const barColor = (ep.reputation || 0) >= 0 ? 'var(--green)' : 'var(--red)';
+          trajHtml += `<div class="epoch-bar">
+            <span style="width:24px;color:var(--text-muted)">${ep.epoch}</span>
+            <div class="epoch-bar-fill">
+              <div class="fill" style="width:${pct}%;background:${barColor}"></div>
+            </div>
+            <span style="width:40px;text-align:right">${(ep.reputation || 0).toFixed(1)}</span>
+          </div>`;
+        }
+        trajHtml += '</div>';
+      }
+
+      html += `<div class="panel-section">
+        <div class="panel-section-header expanded" onclick="dashboard.toggleSection(this)">
+          Trajectory <span class="chevron">&#9654;</span>
+        </div>
+        <div class="panel-section-body expanded">${trajHtml}</div>
+      </div>`;
+    }
+
+    // Raw interactions section (for JSONL sessions)
+    const interactions = (session.interactions || []).filter(
+      ix => ix.initiator === agentId || ix.counterparty === agentId
+    );
+    if (interactions.length > 0) {
+      const shown = interactions.slice(0, 20);
+      let ixHtml = '';
+      for (const ix of shown) {
+        const role = ix.initiator === agentId ? 'initiator' : 'counterparty';
+        const otherId = role === 'initiator' ? ix.counterparty : ix.initiator;
+        const pClass = (ix.p || 0.5) >= 0.5 ? 'good' : 'bad';
+        const acceptStr = ix.accepted === true ? 'accepted' : ix.accepted === false ? 'rejected' : 'pending';
+
+        ixHtml += `<div class="interaction-item">
+          <span class="ix-parties">${role} → ${this.escHtml(otherId)}</span>
+          <div class="ix-meta">
+            p = <span class="${pClass}">${(ix.p || 0.5).toFixed(3)}</span>
+            · ${acceptStr}
+            ${ix.epoch != null ? ` · epoch ${ix.epoch}` : ''}
+          </div>
+        </div>`;
+      }
+      if (interactions.length > 20) {
+        ixHtml += `<div style="color:var(--text-muted);font-size:10px;padding:4px">
+          ... and ${interactions.length - 20} more
+        </div>`;
+      }
+
+      html += `<div class="panel-section">
+        <div class="panel-section-header" onclick="dashboard.toggleSection(this)">
+          Interactions (${interactions.length}) <span class="chevron">&#9654;</span>
+        </div>
+        <div class="panel-section-body">${ixHtml}</div>
+      </div>`;
+    }
+
+    body.innerHTML = html;
+  }
+
+  closePanel() {
+    document.getElementById('detail-panel').classList.remove('open');
+    this.activeAgent = null;
+  }
+
+  toggleSection(headerEl) {
+    headerEl.classList.toggle('expanded');
+    const body = headerEl.nextElementSibling;
+    body.classList.toggle('expanded');
+  }
+
+  // ── Helpers ──────────────────────────────────────────────
+
+  svgEl(tag, attrs = {}) {
+    const el = document.createElementNS('http://www.w3.org/2000/svg', tag);
+    for (const [k, v] of Object.entries(attrs)) {
+      el.setAttribute(k, v);
+    }
+    return el;
+  }
+
+  pToColor(p) {
+    // Map p ∈ [0,1] to a red→yellow→green gradient
+    if (p >= 0.7) return '#3fb950';
+    if (p >= 0.5) return '#d29922';
+    if (p >= 0.3) return '#f0883e';
+    return '#f85149';
+  }
+
+  shortName(name) {
+    if (!name) return '?';
+    // Truncate to 10 chars
+    if (name.length <= 10) return name;
+    return name.substring(0, 9) + '…';
+  }
+
+  escHtml(str) {
+    if (!str) return '';
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+}
+
+// Initialize
+const dashboard = new SwarmDashboard();

--- a/swarm/dashboard/web/index.html
+++ b/swarm/dashboard/web/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SWARM Agent Dashboard</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="layout">
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar-header">
+        <h1 class="logo">SWARM Dashboard</h1>
+        <p class="logo-sub">Agent Interaction Visualizer</p>
+      </div>
+      <div class="sessions-section">
+        <h3 class="section-title">Sessions</h3>
+        <div id="sessions-list" class="sessions-list">
+          <div class="loading">Scanning for sessions...</div>
+        </div>
+      </div>
+      <div class="sidebar-footer">
+        <a href="https://github.com/swarm-ai-safety/swarm" target="_blank">GitHub</a>
+      </div>
+    </aside>
+
+    <!-- Main content -->
+    <main class="main">
+      <div class="topbar">
+        <div class="topbar-title" id="topbar-title">Select a session</div>
+        <div class="topbar-meta" id="topbar-meta"></div>
+      </div>
+      <div class="content-area">
+        <!-- Flow visualization -->
+        <div class="flow-container" id="flow-container">
+          <div class="empty-state" id="empty-state">
+            Select a simulation session from the sidebar to visualize agent interactions.
+          </div>
+          <svg id="flow-svg" class="flow-svg"></svg>
+        </div>
+        <!-- Timeline chart below flow -->
+        <div class="timeline-container" id="timeline-container">
+          <svg id="timeline-svg" class="timeline-svg"></svg>
+        </div>
+      </div>
+    </main>
+
+    <!-- Detail panel -->
+    <div class="detail-panel" id="detail-panel">
+      <div class="panel-header">
+        <h3 id="panel-title">Agent Details</h3>
+        <button class="panel-close" id="panel-close">&times;</button>
+      </div>
+      <div class="panel-body" id="panel-body"></div>
+    </div>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/swarm/dashboard/web/styles.css
+++ b/swarm/dashboard/web/styles.css
@@ -1,0 +1,542 @@
+/* SWARM Agent Dashboard - Dark theme */
+
+:root {
+  --bg-primary: #0d1117;
+  --bg-secondary: #161b22;
+  --bg-tertiary: #21262d;
+  --border: #30363d;
+  --text-primary: #e6edf3;
+  --text-secondary: #8b949e;
+  --text-muted: #484f58;
+  --accent: #d57455;
+  --accent-hover: #e08060;
+  --blue: #58a6ff;
+  --green: #3fb950;
+  --red: #f85149;
+  --yellow: #d29922;
+  --purple: #bc8cff;
+  --cyan: #39d353;
+  --sidebar-width: 260px;
+  --panel-width: 360px;
+  --topbar-height: 48px;
+  --timeline-height: 180px;
+  --font-mono: 'SF Mono', 'Fira Code', 'Cascadia Code', Consolas, monospace;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  overflow: hidden;
+  height: 100vh;
+}
+
+/* Layout */
+.layout {
+  display: flex;
+  height: 100vh;
+  width: 100vw;
+}
+
+/* Sidebar */
+.sidebar {
+  width: var(--sidebar-width);
+  min-width: var(--sidebar-width);
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.sidebar-header {
+  padding: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.logo {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: -0.5px;
+}
+
+.logo-sub {
+  font-size: 10px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.sessions-section {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+}
+
+.section-title {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+}
+
+.sessions-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.session-card {
+  padding: 10px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s;
+  border: 1px solid transparent;
+}
+
+.session-card:hover {
+  background: var(--bg-tertiary);
+}
+
+.session-card.active {
+  background: var(--bg-tertiary);
+  border-color: var(--accent);
+}
+
+.session-card .session-name {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-card .session-meta {
+  font-size: 10px;
+  color: var(--text-secondary);
+  margin-top: 3px;
+}
+
+.loading {
+  color: var(--text-muted);
+  font-size: 11px;
+  padding: 12px;
+  text-align: center;
+}
+
+.sidebar-footer {
+  padding: 12px;
+  border-top: 1px solid var(--border);
+  text-align: center;
+}
+
+.sidebar-footer a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 11px;
+}
+
+.sidebar-footer a:hover {
+  color: var(--text-secondary);
+}
+
+/* Main */
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.topbar {
+  height: var(--topbar-height);
+  min-height: var(--topbar-height);
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+}
+
+.topbar-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.topbar-meta {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.content-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Flow visualization */
+.flow-container {
+  flex: 1;
+  position: relative;
+  overflow: auto;
+  background: var(--bg-primary);
+}
+
+.empty-state {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: var(--text-muted);
+  font-size: 14px;
+  text-align: center;
+  max-width: 300px;
+  line-height: 1.6;
+}
+
+.flow-svg {
+  display: none;
+  width: 100%;
+  height: 100%;
+}
+
+.flow-svg.visible {
+  display: block;
+}
+
+/* SVG node styles */
+.node-group { cursor: pointer; }
+.node-group:hover .node-circle { filter: brightness(1.3); }
+.node-group.dimmed { opacity: 0.2; transition: opacity 0.2s; }
+.node-group.highlighted .node-circle { stroke-width: 3; }
+
+.node-circle {
+  transition: filter 0.15s;
+}
+
+.node-label {
+  fill: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-anchor: middle;
+  pointer-events: none;
+}
+
+.node-sublabel {
+  fill: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  text-anchor: middle;
+  pointer-events: none;
+}
+
+/* SVG edge styles */
+.edge-path {
+  fill: none;
+  stroke-width: 1.5;
+  transition: opacity 0.2s, stroke-width 0.2s;
+}
+
+.edge-path.dimmed { opacity: 0.08; }
+.edge-path.highlighted { stroke-width: 3; opacity: 1; }
+
+.edge-label {
+  fill: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  text-anchor: middle;
+  pointer-events: none;
+}
+
+.edge-label.dimmed { opacity: 0.1; }
+
+/* Edge arrow markers */
+.edge-arrow { fill: var(--text-muted); }
+
+/* Timeline chart */
+.timeline-container {
+  height: var(--timeline-height);
+  min-height: var(--timeline-height);
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border);
+  display: none;
+  overflow: hidden;
+}
+
+.timeline-container.visible {
+  display: block;
+}
+
+.timeline-svg {
+  width: 100%;
+  height: 100%;
+}
+
+.timeline-axis text {
+  fill: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.timeline-axis line,
+.timeline-axis path {
+  stroke: var(--border);
+}
+
+.timeline-line {
+  fill: none;
+  stroke-width: 2;
+}
+
+.timeline-dot {
+  r: 3;
+  cursor: pointer;
+}
+
+.timeline-label {
+  fill: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.timeline-legend {
+  cursor: pointer;
+}
+
+.timeline-legend text {
+  fill: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.timeline-grid line {
+  stroke: var(--bg-tertiary);
+  stroke-dasharray: 2,4;
+}
+
+/* Detail panel */
+.detail-panel {
+  width: 0;
+  overflow: hidden;
+  background: var(--bg-secondary);
+  border-left: 1px solid var(--border);
+  transition: width 0.25s ease;
+  display: flex;
+  flex-direction: column;
+}
+
+.detail-panel.open {
+  width: var(--panel-width);
+  min-width: var(--panel-width);
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  min-height: 48px;
+}
+
+.panel-header h3 {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.panel-close {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 20px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  line-height: 1;
+}
+
+.panel-close:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+.panel-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+/* Panel accordion sections */
+.panel-section {
+  margin-bottom: 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.panel-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  background: var(--bg-tertiary);
+  cursor: pointer;
+  user-select: none;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+}
+
+.panel-section-header:hover {
+  color: var(--text-primary);
+}
+
+.panel-section-header .chevron {
+  transition: transform 0.2s;
+  font-size: 12px;
+}
+
+.panel-section-header.expanded .chevron {
+  transform: rotate(90deg);
+}
+
+.panel-section-body {
+  display: none;
+  padding: 12px;
+}
+
+.panel-section-body.expanded {
+  display: block;
+}
+
+/* Key-value rows in panel */
+.kv-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 0;
+  border-bottom: 1px solid var(--bg-tertiary);
+  font-size: 11px;
+}
+
+.kv-row:last-child { border-bottom: none; }
+
+.kv-key {
+  color: var(--text-secondary);
+}
+
+.kv-val {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.kv-val.good { color: var(--green); }
+.kv-val.bad { color: var(--red); }
+.kv-val.warn { color: var(--yellow); }
+
+/* Interaction list in panel */
+.interaction-item {
+  padding: 8px;
+  border-radius: 4px;
+  background: var(--bg-primary);
+  margin-bottom: 6px;
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.interaction-item .ix-parties {
+  color: var(--blue);
+  font-weight: 600;
+}
+
+.interaction-item .ix-meta {
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+/* Badge for agent types */
+.badge {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.badge-honest { background: #1a3a2a; color: var(--green); }
+.badge-adversarial { background: #3a1a1a; color: var(--red); }
+.badge-opportunistic { background: #3a2a1a; color: var(--yellow); }
+.badge-deceptive { background: #2a1a3a; color: var(--purple); }
+.badge-llm { background: #1a2a3a; color: var(--blue); }
+.badge-unknown { background: var(--bg-tertiary); color: var(--text-muted); }
+
+/* Agent color indicators */
+.agent-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+/* Epoch mini-bar in panel */
+.epoch-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 0;
+  font-size: 10px;
+}
+
+.epoch-bar-fill {
+  height: 4px;
+  border-radius: 2px;
+  flex: 1;
+  background: var(--bg-tertiary);
+  position: relative;
+  overflow: hidden;
+}
+
+.epoch-bar-fill .fill {
+  height: 100%;
+  border-radius: 2px;
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+/* Scrollbar styling */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--bg-tertiary);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--border);
+}

--- a/tests/test_dashboard_web.py
+++ b/tests/test_dashboard_web.py
@@ -1,0 +1,375 @@
+"""Tests for the web-based agent interaction dashboard."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from swarm.dashboard.session_parser import (
+    _build_edges_from_interactions,
+    _infer_agent_type,
+    discover_sessions,
+    parse_session,
+)
+
+
+@pytest.fixture
+def tmp_project(tmp_path):
+    """Create a temporary project directory with sample run/log data."""
+    # Create runs directory with a JSON history
+    runs_dir = tmp_path / "runs" / "20260101_baseline_seed42"
+    runs_dir.mkdir(parents=True)
+    history = {
+        "simulation_id": "baseline",
+        "started_at": "2026-01-01T00:00:00",
+        "ended_at": "2026-01-01T00:01:00",
+        "n_epochs": 3,
+        "steps_per_epoch": 5,
+        "n_agents": 2,
+        "seed": 42,
+        "epoch_snapshots": [
+            {
+                "epoch": 0,
+                "timestamp": "2026-01-01T00:00:10",
+                "total_interactions": 5,
+                "accepted_interactions": 3,
+                "rejected_interactions": 2,
+                "toxicity_rate": 0.15,
+                "quality_gap": 0.1,
+                "avg_p": 0.65,
+                "total_welfare": 10.0,
+                "avg_payoff": 5.0,
+                "gini_coefficient": 0.2,
+                "n_agents": 2,
+            },
+            {
+                "epoch": 1,
+                "timestamp": "2026-01-01T00:00:20",
+                "total_interactions": 6,
+                "accepted_interactions": 4,
+                "rejected_interactions": 2,
+                "toxicity_rate": 0.12,
+                "quality_gap": 0.15,
+                "avg_p": 0.7,
+                "total_welfare": 12.0,
+                "avg_payoff": 6.0,
+                "gini_coefficient": 0.18,
+                "n_agents": 2,
+            },
+            {
+                "epoch": 2,
+                "timestamp": "2026-01-01T00:00:30",
+                "total_interactions": 7,
+                "accepted_interactions": 5,
+                "rejected_interactions": 2,
+                "toxicity_rate": 0.1,
+                "quality_gap": 0.2,
+                "avg_p": 0.75,
+                "total_welfare": 15.0,
+                "avg_payoff": 7.5,
+                "gini_coefficient": 0.15,
+                "n_agents": 2,
+            },
+        ],
+        "agent_snapshots": [
+            {
+                "agent_id": "honest_0",
+                "epoch": 0,
+                "name": "honest_0",
+                "reputation": 1.0,
+                "resources": 100.0,
+                "interactions_initiated": 3,
+                "interactions_received": 2,
+                "avg_p_initiated": 0.8,
+                "avg_p_received": 0.7,
+                "total_payoff": 6.0,
+                "is_frozen": False,
+                "is_quarantined": False,
+            },
+            {
+                "agent_id": "adversarial_0",
+                "epoch": 0,
+                "name": "adversarial_0",
+                "reputation": 0.3,
+                "resources": 90.0,
+                "interactions_initiated": 2,
+                "interactions_received": 3,
+                "avg_p_initiated": 0.3,
+                "avg_p_received": 0.6,
+                "total_payoff": 4.0,
+                "is_frozen": False,
+                "is_quarantined": False,
+            },
+        ],
+    }
+    (runs_dir / "history.json").write_text(json.dumps(history))
+
+    # Create logs directory with JSONL events
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    events = [
+        {
+            "event_id": "e1",
+            "timestamp": "2026-01-01T00:00:01",
+            "event_type": "interaction_proposed",
+            "interaction_id": "ix1",
+            "initiator_id": "agent_a",
+            "counterparty_id": "agent_b",
+            "payload": {"interaction_type": "reply", "v_hat": 0.6, "p": 0.73},
+            "epoch": 0,
+            "step": 1,
+            "scenario_id": "test_scenario",
+            "seed": 42,
+        },
+        {
+            "event_id": "e2",
+            "timestamp": "2026-01-01T00:00:02",
+            "event_type": "interaction_accepted",
+            "interaction_id": "ix1",
+            "epoch": 0,
+            "step": 1,
+        },
+        {
+            "event_id": "e3",
+            "timestamp": "2026-01-01T00:00:03",
+            "event_type": "payoff_computed",
+            "interaction_id": "ix1",
+            "initiator_id": "agent_a",
+            "counterparty_id": "agent_b",
+            "payload": {
+                "payoff_initiator": 1.5,
+                "payoff_counterparty": 0.8,
+                "components": {
+                    "tau": 0.2,
+                    "c_a": 0.1,
+                    "c_b": 0.05,
+                    "r_a": 0.3,
+                    "r_b": 0.1,
+                },
+            },
+            "epoch": 0,
+            "step": 1,
+        },
+        {
+            "event_id": "e4",
+            "timestamp": "2026-01-01T00:00:04",
+            "event_type": "interaction_proposed",
+            "interaction_id": "ix2",
+            "initiator_id": "agent_b",
+            "counterparty_id": "agent_a",
+            "payload": {"interaction_type": "reply", "v_hat": -0.2, "p": 0.35},
+            "epoch": 0,
+            "step": 2,
+        },
+        {
+            "event_id": "e5",
+            "timestamp": "2026-01-01T00:00:05",
+            "event_type": "interaction_rejected",
+            "interaction_id": "ix2",
+            "epoch": 0,
+            "step": 2,
+        },
+    ]
+    jsonl_path = logs_dir / "test_events.jsonl"
+    with open(jsonl_path, "w") as f:
+        for event in events:
+            f.write(json.dumps(event) + "\n")
+
+    return tmp_path
+
+
+class TestDiscoverSessions:
+    def test_discovers_json_and_jsonl(self, tmp_project):
+        sessions = discover_sessions(tmp_project)
+        assert len(sessions) == 2
+
+        sources = {s["source"] for s in sessions}
+        assert "runs" in sources
+        assert "logs" in sources
+
+    def test_json_session_metadata(self, tmp_project):
+        sessions = discover_sessions(tmp_project)
+        json_sessions = [s for s in sessions if s["file_type"] == "json"]
+        assert len(json_sessions) == 1
+
+        s = json_sessions[0]
+        assert s["session_id"] == "baseline"
+        assert s["n_epochs"] == 3
+        assert s["n_agents"] == 2
+        assert s["seed"] == 42
+
+    def test_jsonl_session_metadata(self, tmp_project):
+        sessions = discover_sessions(tmp_project)
+        jsonl_sessions = [s for s in sessions if s["file_type"] == "jsonl"]
+        assert len(jsonl_sessions) == 1
+
+        s = jsonl_sessions[0]
+        assert s["session_id"] == "test_scenario"
+        assert s["n_agents"] == 2  # agent_a and agent_b
+        assert s["event_count"] == 5
+        assert s["seed"] == 42
+
+    def test_empty_directory(self, tmp_path):
+        sessions = discover_sessions(tmp_path)
+        assert sessions == []
+
+    def test_no_runs_or_logs_dirs(self, tmp_path):
+        """Handles missing runs/ and logs/ gracefully."""
+        sessions = discover_sessions(tmp_path)
+        assert sessions == []
+
+
+class TestParseJsonSession:
+    def test_parse_json(self, tmp_project):
+        path = str(tmp_project / "runs" / "20260101_baseline_seed42" / "history.json")
+        data = parse_session(path)
+
+        assert data["session_id"] == "baseline"
+        assert data["n_epochs"] == 3
+        assert data["n_agents"] == 2
+        assert len(data["agents"]) == 2
+        assert len(data["epochs"]) == 3
+
+    def test_agents_have_epoch_data(self, tmp_project):
+        path = str(tmp_project / "runs" / "20260101_baseline_seed42" / "history.json")
+        data = parse_session(path)
+
+        honest = data["agents"]["honest_0"]
+        assert honest["name"] == "honest_0"
+        assert honest["type"] == "honest"
+        assert len(honest["epochs"]) == 1
+        assert honest["epochs"][0]["reputation"] == 1.0
+
+    def test_epoch_metrics(self, tmp_project):
+        path = str(tmp_project / "runs" / "20260101_baseline_seed42" / "history.json")
+        data = parse_session(path)
+
+        ep0 = data["epochs"][0]
+        assert ep0["epoch"] == 0
+        assert ep0["toxicity_rate"] == 0.15
+        assert ep0["total_welfare"] == 10.0
+
+    def test_edges_generated(self, tmp_project):
+        path = str(tmp_project / "runs" / "20260101_baseline_seed42" / "history.json")
+        data = parse_session(path)
+        # Both agents have activity in epoch 0 -> should be an edge
+        assert len(data["edges"]) > 0
+
+
+class TestParseJsonlSession:
+    def test_parse_jsonl(self, tmp_project):
+        path = str(tmp_project / "logs" / "test_events.jsonl")
+        data = parse_session(path)
+
+        assert data["session_id"] == "test_scenario"
+        assert data["n_agents"] == 2
+        assert data["seed"] == 42
+
+    def test_interactions_parsed(self, tmp_project):
+        path = str(tmp_project / "logs" / "test_events.jsonl")
+        data = parse_session(path)
+
+        interactions = data["interactions"]
+        assert len(interactions) == 2
+
+        ix1 = interactions[0]
+        assert ix1["initiator"] == "agent_a"
+        assert ix1["counterparty"] == "agent_b"
+        assert ix1["p"] == 0.73
+        assert ix1["accepted"] is True
+
+        ix2 = interactions[1]
+        assert ix2["accepted"] is False
+
+    def test_edges_from_interactions(self, tmp_project):
+        path = str(tmp_project / "logs" / "test_events.jsonl")
+        data = parse_session(path)
+
+        edges = data["edges"]
+        assert len(edges) == 2  # a->b and b->a
+
+    def test_epoch_metrics_computed(self, tmp_project):
+        path = str(tmp_project / "logs" / "test_events.jsonl")
+        data = parse_session(path)
+
+        epochs = data["epochs"]
+        assert len(epochs) == 1  # all events in epoch 0
+
+        ep = epochs[0]
+        assert ep["total_interactions"] == 2
+        assert ep["accepted_interactions"] == 1
+
+    def test_payoff_attached_to_interaction(self, tmp_project):
+        path = str(tmp_project / "logs" / "test_events.jsonl")
+        data = parse_session(path)
+
+        ix1 = data["interactions"][0]
+        assert ix1["payoff_initiator"] == 1.5
+        assert ix1["payoff_counterparty"] == 0.8
+        assert ix1["tau"] == 0.2
+
+
+class TestBuildEdges:
+    def test_aggregate_interactions(self):
+        interactions = [
+            {"initiator": "a", "counterparty": "b", "p": 0.8, "accepted": True},
+            {"initiator": "a", "counterparty": "b", "p": 0.6, "accepted": False},
+            {"initiator": "b", "counterparty": "a", "p": 0.5, "accepted": True},
+        ]
+        edges = _build_edges_from_interactions(interactions)
+
+        assert len(edges) == 2
+
+        ab = [e for e in edges if e["source"] == "a" and e["target"] == "b"]
+        assert len(ab) == 1
+        assert ab[0]["count"] == 2
+        assert ab[0]["accepted"] == 1
+        assert abs(ab[0]["avg_p"] - 0.7) < 0.001  # (0.8+0.6)/2
+
+    def test_empty_interactions(self):
+        edges = _build_edges_from_interactions([])
+        assert edges == []
+
+    def test_single_direction(self):
+        interactions = [
+            {"initiator": "x", "counterparty": "y", "p": 0.9, "accepted": True},
+        ]
+        edges = _build_edges_from_interactions(interactions)
+        assert len(edges) == 1
+        assert edges[0]["source"] == "x"
+        assert edges[0]["target"] == "y"
+        assert edges[0]["count"] == 1
+
+
+class TestInferAgentType:
+    def test_honest(self):
+        assert _infer_agent_type("honest_0") == "honest"
+
+    def test_adversarial(self):
+        assert _infer_agent_type("adversarial_agent_1") == "adversarial"
+
+    def test_llm(self):
+        assert _infer_agent_type("llm_claude_0") == "llm"
+
+    def test_unknown(self):
+        assert _infer_agent_type("agent_42") == "unknown"
+
+    def test_deceptive(self):
+        assert _infer_agent_type("deceptive_0") == "deceptive"
+
+    def test_opportunistic(self):
+        assert _infer_agent_type("opportunistic_1") == "opportunistic"
+
+    def test_empty_string(self):
+        assert _infer_agent_type("") == "unknown"
+
+    def test_case_insensitive(self):
+        assert _infer_agent_type("HONEST_Agent") == "honest"
+
+
+class TestUnsupportedFileType:
+    def test_unsupported_extension(self, tmp_path):
+        p = tmp_path / "test.txt"
+        p.write_text("hello")
+        data = parse_session(str(p))
+        assert "error" in data


### PR DESCRIPTION
Implement a lightweight web dashboard for visualizing simulation sessions, inspired by the claude-code-templates teams dashboard pattern. Scans runs/ and logs/ directories for JSON history and JSONL event log files, parses agent interactions and epoch metrics, and serves an interactive SVG flow diagram with timeline charts and detail panels.

- swarm/dashboard/session_parser.py: discovers and parses sessions
- swarm/dashboard/server.py: standalone HTTP server on port 3339
- swarm/dashboard/web/: dark-themed SPA (index.html, app.js, styles.css)
- CLI: `python -m swarm dashboard [--dir .] [--port 3339] [--no-open]`
- 26 tests covering session discovery, JSON/JSONL parsing, edge building

https://claude.ai/code/session_01Gn7p6kZAPt5NBfovhzMpYZ

## Summary

Brief description of the changes.

## Changes

- ...
- ...

## Test Plan

- [ ] Existing tests pass (`pytest tests/ -v`)
- [ ] Lint passes (`ruff check swarm/ tests/`)
- [ ] Type check passes (`mypy swarm/`)
- [ ] New tests added (if applicable)

## Results (SWARM)

If this change affects scenarios, metrics, agents, governance, or evaluation, include a reproducible run folder and the headline deltas.

**Reproduce**
- Scenario: `scenarios/<name>.yaml`
- Command: `python -m swarm run scenarios/<name>.yaml --seed <seed> --epochs <n> --steps <n> --export-json runs/<run_id>/history.json --export-csv runs/<run_id>/csv`
- Plots: `python examples/plot_run.py runs/<run_id>`

**Artifacts**
- `runs/<run_id>/history.json`
- `runs/<run_id>/csv/`
- `runs/<run_id>/plots/`

**Headline metrics**
- Total interactions:
- Accepted interactions:
- Avg toxicity:
- Final welfare:

**Invariants**
- [ ] `p ∈ [0, 1]` everywhere it is surfaced/logged
- [ ] Event logs remain replayable (append-only JSONL)

## Related Issues

Closes #
