### PR TITLE
Potential fix for code scanning alert no. 14: Clear-text logging of sensitive information

### DIFF
--- a/swarm/bridges/live_swe/client.py
+++ b/swarm/bridges/live_swe/client.py
@@ -350,9 +350,8 @@ class LiveSWEClient:
                 allowed_dir = Path(self.config.trajectory_dir).resolve()
                 if not traj_path.is_relative_to(allowed_dir):
                     logger.warning(
-                        "Trajectory path %s is outside configured "
+                        "Rejected trajectory path outside configured "
                         "trajectory_dir %s — skipping",
-                        traj_path,
                         allowed_dir,
                     )
                     traj_path = None  # type: ignore[assignment]


### PR DESCRIPTION
Potential fix for [https://github.com/swarm-ai-safety/swarm/security/code-scanning/14](https://github.com/swarm-ai-safety/swarm/security/code-scanning/14)

In general, to fix clear‑text logging of sensitive information, either (1) avoid logging potentially sensitive data altogether, or (2) sanitize/redact it before logging so that secrets and precise locations are not exposed.

Here, the problematic logging is the warning when a trajectory file path lies outside the configured `trajectory_dir`. We can keep the warning but remove the direct logging of the full `traj_path`, since that path can be derived from untrusted subprocess output and may point at sensitive files. The `allowed_dir` is a locally configured directory and is not derived from untrusted data, so logging it is safe and useful for debugging. The minimal, non‑functional change is therefore:

- Change the log message to omit the full rejected path, or replace it with a generic placeholder.
- Keep the logic that sets `traj_path = None` so behavior is unchanged apart from log content.

Concretely in `swarm/bridges/live_swe/client.py`, lines 352–356 will be updated so that `logger.warning` only mentions that a trajectory path was outside the configured directory and logs `allowed_dir` (and optionally a short, non‑revealing description), but not the raw `traj_path`. No new imports or helper methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
