### PR TITLE
Potential fix for code scanning alert no. 16: Clear-text logging of sensitive information

### DIFF
--- a/research/papers/submit_batch.py
+++ b/research/papers/submit_batch.py
@@ -310,7 +310,7 @@ def main():
         try:
             api_key = load_credentials("clawxiv")
             clx_client = ClawxivClient(api_key=api_key)
-            print(f"ClawXiv client ready (key: {api_key[:8]}...)")
+            print("ClawXiv client ready")
         except FileNotFoundError as e:
             print(f"WARNING: {e} — skipping ClawXiv submissions")
             do_clawxiv = False
@@ -319,7 +319,7 @@ def main():
         try:
             api_key = load_credentials("agentxiv")
             ax_client = AgentxivClient(api_key=api_key)
-            print(f"AgentXiv client ready (key: {api_key[:8]}...)")
+            print("AgentXiv client ready")
         except FileNotFoundError as e:
             print(f"WARNING: {e} — skipping AgentXiv submissions")
             do_agentxiv = False


### PR DESCRIPTION
Potential fix for [https://github.com/swarm-ai-safety/swarm/security/code-scanning/16](https://github.com/swarm-ai-safety/swarm/security/code-scanning/16)

In general, to fix clear-text logging of sensitive data, ensure that secrets (passwords, API keys, tokens, etc.) are never included in log messages, even partially. Instead, log only non-sensitive metadata (e.g., whether a client was initialized, which platform, maybe a stable non-secret identifier or a generic “credentials loaded” message).

For this code, the minimal, non-breaking fix is to change the log message at line 322 (and symmetrically at 313 for ClawXiv, which uses the same pattern) so that it does not interpolate `api_key` at all. We can keep the informational logging that the client is ready, but drop the key prefix. No additional imports or functions are needed; we only need to update the literal strings where the key prefix is used. Functionality of the script (loading credentials, submitting papers) is unchanged; only the text written to stdout changes.

Concretely:

- In `research/papers/submit_batch.py`, within `main()`:
  - Replace `print(f"ClawXiv client ready (key: {api_key[:8]}...)")` with a message like `print("ClawXiv client ready")` that contains no key material.
  - Replace `print(f"AgentXiv client ready (key: {api_key[:8]}...)")` with `print("AgentXiv client ready")` for the same reason.

This single change eliminates all three variants, because no data from `api_key` flows into the logging sink anymore.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
