### PR TITLE
Prepare package for PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v6
         with:
           name: dist
           path: dist/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-dev lint lint-fix typecheck test coverage ci clean docs docs-serve test-changes test-parallel test-durations test-no-network claude-code-demo run-alignment-scenarios run-alignment-analyze run-alignment-all
+.PHONY: install install-dev lint lint-fix typecheck test coverage ci clean docs docs-serve test-changes test-parallel test-durations test-no-network claude-code-demo run-alignment-scenarios run-alignment-analyze run-alignment-all build-dist publish-test publish
 
 PYTHON ?= python
 
@@ -58,7 +58,18 @@ run-alignment-analyze:
 
 run-alignment-all: run-alignment-scenarios run-alignment-analyze
 
+build-dist: clean
+	$(PYTHON) -m pip install build
+	$(PYTHON) -m build
+	$(PYTHON) -m twine check dist/*
+
+publish-test: build-dist
+	$(PYTHON) -m twine upload --repository testpypi dist/*
+
+publish: build-dist
+	$(PYTHON) -m twine upload dist/*
+
 clean:
-	rm -rf .mypy_cache .pytest_cache .ruff_cache htmlcov .coverage site/
+	rm -rf .mypy_cache .pytest_cache .ruff_cache htmlcov .coverage site/ dist/ build/
 	find . -type d -name __pycache__ -exec rm -rf {} +
 	find . -type d -name "*.egg-info" -exec rm -rf {} +

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=61.0,<75", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,7 +8,7 @@ version = "1.0.0"
 description = "SWARM: System-Wide Assessment of Risk in Multi-agent systems - A Distributional AGI Safety framework"
 readme = "README.md"
 requires-python = ">=3.10"
-license = "MIT"
+license = {text = "MIT"}
 authors = [
     {name = "Raeli Savitt"}
 ]


### PR DESCRIPTION
- Fix license format in pyproject.toml for twine compatibility
  (use PEP 621 table format instead of PEP 639 string)
- Pin setuptools<75 in build-system to avoid Metadata-Version 2.4
  which current twine cannot validate
- Fix download-artifact version mismatch in release workflow
- Add build-dist, publish-test, and publish Make targets
- Include dist/ and build/ in clean target

https://claude.ai/code/session_01NbcUYysxcqgmF1R2VXhQAC