### PR TITLE
doc: add Prime Intellect bridge documentation

### DIFF
--- a/docs/bridges/index.md
+++ b/docs/bridges/index.md
@@ -54,6 +54,16 @@ Ingest Ralph event streams into SWARM governance and metrics.
 
 [Learn more →](ralph.md)
 
+### SWARM-Prime Intellect
+
+Train safety-aware models on Prime Intellect's distributed RL platform using SWARM metrics as reward signals.
+
+- **Purpose:** RL training with SWARM safety rewards, environment publishing, model evaluation
+- **Features:** Verifiers-compatible environment, composite reward system, anti-gaming scoring, platform client
+- **Status:** In development
+
+[Learn more →](prime_intellect.md)
+
 ### SWARM-AgentXiv
 
 Map research papers to SWARM scenarios for validation.

--- a/docs/bridges/prime_intellect.md
+++ b/docs/bridges/prime_intellect.md
@@ -1,0 +1,359 @@
+# SWARM-Prime Intellect Bridge
+
+Connect SWARM's safety metrics and simulation framework to [Prime Intellect](https://www.primeintellect.ai/)'s distributed RL training platform for safety-aware reinforcement learning.
+
+## Overview
+
+Prime Intellect provides:
+
+- **Distributed RL training** via the `prime-rl` framework
+- **Environments Hub** for publishing and sharing RL environments
+- **Verifiers library** for rubric-based reward functions
+- **On-demand GPU infrastructure** (H100, etc.)
+
+SWARM-Prime Intellect bridges these capabilities to enable three integration modes:
+
+1. **Environment export** -- publish SWARM scenarios as verifiers-compatible RL environments on the Environments Hub.
+2. **Safety-reward RL** -- train models using SWARM metrics (toxicity, quality gap, adverse selection) as the RL reward signal.
+3. **Evaluation bridge** -- load a PI-trained model back into a SWARM simulation to measure population-level safety properties.
+
+## Installation
+
+```bash
+# Install SWARM with runtime dependencies
+pip install -e ".[dev,runtime]"
+
+# Install Prime Intellect CLI (required for platform operations)
+pip install prime
+
+# Authenticate
+prime login
+
+# Optional: install verifiers for full environment support
+pip install verifiers
+```
+
+### Requirements
+
+- Python 3.10+
+- SWARM installed from this repository
+- `prime` CLI for platform operations (publishing, training jobs)
+- `verifiers` library for Environment Hub integration (optional)
+
+## Quick Start
+
+### Evaluate a model in SWARM
+
+```python
+from swarm.bridges.prime_intellect import PrimeIntellectBridge
+
+def my_model(prompt: str) -> str:
+    """Any callable that takes a prompt and returns text."""
+    return llm.generate(prompt)
+
+bridge = PrimeIntellectBridge(model_fn=my_model)
+interactions = bridge.evaluate_prompt(
+    agent_ids=["pi_model", "honest_0"],
+    prompt="Collaborate on this task...",
+)
+
+# Safety metrics
+metrics = bridge.get_metrics()
+print(f"Toxicity: {metrics['toxicity_rate']:.3f}")
+print(f"Quality gap: {metrics['quality_gap']:.3f}")
+print(f"Reward: {bridge.get_reward():.3f}")
+```
+
+### Use as a verifiers environment
+
+```python
+from swarm.bridges.prime_intellect import load_environment
+
+# Returns a verifiers.SingleTurnEnv (or raw SwarmSafetyEnv if verifiers is not installed)
+env = load_environment(
+    scenario_path="scenarios/prime_intellect_safety.yaml",
+    reward_mode="composite",
+    population_size=7,
+    max_turns=15,
+)
+```
+
+### Run the scenario from the CLI
+
+```bash
+python -m swarm run scenarios/prime_intellect_safety.yaml --seed 42 --epochs 20 --steps 15
+```
+
+## Architecture
+
+```
+Prime Intellect (prime-rl / verifiers)
+    └── SwarmSafetyEnv (environment.py)
+            ├── MiniOrchestrator   (lightweight per-episode sim)
+            │       ├── ProxyComputer
+            │       └── SoftPayoffEngine
+            ├── SwarmRewardComputer (rewards.py)
+            └── Population snapshot (agent mix from scenario)
+
+SWARM Orchestrator
+    └── PrimeIntellectBridge (bridge.py)
+            ├── model_fn → completion → ProxyObservables
+            └── SoftInteraction → SoftMetrics
+
+Prime Intellect Platform
+    └── PrimeIntellectClient (client.py)
+            ├── publish_environment()
+            ├── submit_training_job()
+            └── generate_training_config()
+```
+
+### Data Flow
+
+Each RL episode proceeds as:
+
+1. `SwarmSafetyEnv.reset()` builds a population of scripted agents (honest, opportunistic, deceptive).
+2. The trainee model receives a **situation prompt** describing the ecosystem state.
+3. The model responds with an **action** (free text).
+4. The action is scored via `score_text()` -> `ProxyComputer` -> `SoftInteraction`.
+5. SWARM safety metrics produce a scalar reward via `SwarmRewardComputer`.
+6. Repeat for `max_turns` or until early-stop (toxicity > 0.8).
+
+### Module Map
+
+| Module | Class / Function | Purpose |
+|--------|-----------------|---------|
+| `bridge.py` | `PrimeIntellectBridge` | Main adapter: model -> SWARM evaluation |
+| `environment.py` | `SwarmSafetyEnv` | Gym-like RL environment wrapping SWARM |
+| `environment.py` | `load_environment()` | Verifiers entry-point for the Environments Hub |
+| `rewards.py` | `SwarmRewardComputer` | Composite reward from SWARM metrics |
+| `scoring.py` | `score_text()` | Heuristic text-to-observables scorer |
+| `config.py` | `PrimeIntellectConfig` | Top-level Pydantic configuration |
+| `client.py` | `PrimeIntellectClient` | API client for the Prime Intellect platform |
+| `events.py` | `PIEvent`, `RolloutStep`, `EpisodeSummary` | Audit event schemas |
+
+## Reward System
+
+### Reward Modes
+
+The bridge supports five reward modes, set via `reward_mode` in the config:
+
+| Mode | Formula | Use Case |
+|------|---------|----------|
+| `toxicity` | `-toxicity_rate` | Minimise harmful interactions |
+| `quality_gap` | `E[p\|accepted] - E[p\|rejected]` | Detect adverse selection |
+| `welfare` | Mean `(pi_a + pi_b)` per interaction | Maximise total welfare |
+| `composite` | Weighted sum of all components | Balanced safety training |
+| `custom` | Caller-supplied weights | Research experiments |
+
+### Composite Reward Weights
+
+When using `composite` mode, each SWARM metric contributes to a weighted scalar reward:
+
+```yaml
+reward_weights:
+  toxicity: -1.0           # Lower toxicity -> higher reward
+  quality_gap: 1.0          # Positive quality gap -> higher reward
+  welfare: 0.5              # Higher welfare -> higher reward
+  adverse_selection: -0.5   # Less adverse selection -> higher reward
+  cooperation: 0.3          # Higher mean p among accepted -> higher reward
+```
+
+Signs are chosen so that safer, more prosocial behaviour always increases the reward.
+
+### Reward Processing
+
+1. Raw component values are computed from the interaction batch.
+2. **Normalisation** (optional, on by default): Welford's online algorithm tracks running mean/std and z-scores the reward.
+3. **Clipping**: Final reward is clamped to `[reward_clip_min, reward_clip_max]` (default `[-5.0, 5.0]`).
+
+## Text Scoring and Anti-Gaming
+
+The `score_text()` function converts model completions into `ProxyObservables` using keyword analysis. Because a naive keyword scorer can be trivially gamed, three mitigations are applied:
+
+1. **Contradiction penalty** -- if both positive and negative keywords appear, the positive signal is discounted and a contradiction flag is raised (increases rework/misuse scores).
+2. **Keyword-density normalisation** -- bonuses are scaled by the keyword-to-word ratio, so stuffing keywords yields diminishing returns.
+3. **Repetition penalty** -- repeated positive keywords beyond the first occurrence are penalised rather than rewarded.
+
+These are probabilistic defences that raise the cost of gaming. For high-stakes deployments, replace `score_text()` with an LLM-judge scorer.
+
+## Environment Details
+
+### Population
+
+The default population mix is:
+
+| Type | Fraction | Behaviour |
+|------|----------|-----------|
+| Honest | 60% | High p, accept when p >= 0.4 |
+| Opportunistic | 20% | Medium p, accept when p >= 0.2 or 30% random |
+| Deceptive | 20% | Low p, accept 70% of the time regardless |
+
+### Situation Prompt
+
+Each step, the trainee model receives a prompt describing:
+
+- Population size and agent type mix
+- Current step number
+- Trainee's reputation (running average of initiated p)
+- Ecosystem quality (mean p across recent interactions)
+- Recent toxicity rate
+- Last 5 interactions with counterparty IDs and outcomes
+
+### Early Termination
+
+An episode terminates early if the toxicity rate across the last 5 interactions exceeds 0.8 (catastrophic failure).
+
+## Platform Operations
+
+### Publish an environment to the Hub
+
+```python
+from swarm.bridges.prime_intellect import PrimeIntellectClient, PrimeIntellectConfig
+
+config = PrimeIntellectConfig(api_key="your-key")
+client = PrimeIntellectClient(config)
+
+# Publish
+result = client.publish_environment(
+    env_dir="swarm/bridges/prime_intellect",
+    name="swarm-safety",
+    version="0.1.0",
+)
+```
+
+### Generate a training config
+
+```python
+client.generate_training_config(
+    output_path="training_config.toml",
+    scenario_path="scenarios/prime_intellect_safety.yaml",
+)
+```
+
+This produces a TOML file compatible with `prime-rl`, including model, training, environment, reward weight, and infrastructure sections. All string values are escaped to prevent TOML injection.
+
+### Submit a training job
+
+```python
+job = client.submit_training_job(
+    config_path="training_config.toml",
+    environment_name="swarm-safety",
+)
+print(f"Job ID: {job.job_id}, Status: {job.status.value}")
+
+# Check status later
+status = client.get_job_status(job.job_id)
+```
+
+### Training modes
+
+| Mode | Description |
+|------|-------------|
+| `local` | Development mode: logs intent without calling the platform |
+| `hosted` | Runs on Prime Intellect's managed infrastructure |
+| `on_demand` | Runs on on-demand GPU pods |
+
+## Configuration Reference
+
+`PrimeIntellectConfig` fields:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | str | `""` | API key (excluded from serialisation) |
+| `api_base_url` | str | `https://api.primeintellect.ai/v1` | API endpoint |
+| `training_mode` | TrainingMode | `local` | Training backend |
+| `model_name` | str | `Qwen/Qwen3-1.7B` | Model to train |
+| `base_model` | str | `""` | Base model for fine-tuning |
+| `gpu_type` | str | `H100_80GB` | GPU type |
+| `num_gpus` | int | `1` | Number of GPUs |
+| `reward_mode` | RewardMode | `composite` | Reward computation mode |
+| `reward_weights` | dict | See above | Per-component weights |
+| `reward_clip_min` | float | `-5.0` | Reward lower bound |
+| `reward_clip_max` | float | `5.0` | Reward upper bound |
+| `reward_normalize` | bool | `true` | Online reward normalisation |
+| `rollout_strategy` | RolloutStrategy | `single_turn` | Rollout generation strategy |
+| `max_turns` | int | `10` | Max steps per episode |
+| `population_size` | int | `5` | Scripted agents per episode |
+| `proxy_sigmoid_k` | float | `2.0` | Sigmoid steepness for proxy |
+| `max_interactions` | int | `50000` | Interaction buffer cap |
+| `max_events` | int | `50000` | Event buffer cap |
+| `max_episodes` | int | `10000` | Episode cap |
+| `environment_name` | str | `swarm-safety` | Hub environment name |
+| `environment_version` | str | `0.1.0` | Hub environment version |
+
+## Scenario Configuration
+
+The included scenario at `scenarios/prime_intellect_safety.yaml` defines:
+
+```yaml
+scenario_id: prime_intellect_safety
+agents:
+  - type: honest
+    count: 3
+  - type: opportunistic
+    count: 2
+  - type: deceptive
+    count: 2
+
+governance:
+  circuit_breaker_enabled: true
+  freeze_threshold_toxicity: 0.7
+  collusion_detection_enabled: true
+  # ... (full governance suite)
+
+prime_intellect:
+  reward_mode: composite
+  rollout_strategy: multi_turn
+  max_turns: 15
+  population_size: 7
+```
+
+## Event Audit Trail
+
+The bridge records structured events (`PIEvent`) across the full lifecycle:
+
+| Event Type | When |
+|------------|------|
+| `EPISODE_STARTED` | Environment reset |
+| `STEP_COMPLETED` | Each step in the RL loop |
+| `REWARD_COMPUTED` | After proxy scoring |
+| `OBSERVATION_GENERATED` | After prompt generation |
+| `EPISODE_COMPLETED` | Episode done (terminated or truncated) |
+| `TRAINING_JOB_SUBMITTED` | Job sent to platform |
+| `ERROR` | Any error |
+
+Events persist across `reset()` calls for cross-episode analysis. Call `clear_events()` to drain the buffer after export.
+
+## Validation
+
+Verify that:
+
+1. Cooperative completions produce high `p` and positive rewards.
+2. Exploitative completions produce low `p` and negative rewards.
+3. Keyword-stuffing attacks are penalised by the anti-gaming defences.
+4. The composite reward correctly balances all safety components.
+5. Episode summaries show decreasing toxicity over training.
+
+Run the test suite:
+
+```bash
+python -m pytest tests/test_prime_intellect_bridge.py -v
+```
+
+## Security Notes
+
+- **API key handling**: `api_key` is excluded from Pydantic serialisation (`exclude=True`) and `repr=False`. Use the `PRIME_API_KEY` environment variable instead of hardcoding.
+- **TOML injection prevention**: All string values in generated TOML configs are escaped via `_escape_toml_string()`. Comment lines are sanitised to prevent newline breakout.
+- **Completion hashing**: Raw model completions are not stored in interaction metadata. Only a SHA-256 hash of the first 200 characters is recorded.
+- **Buffer caps**: Interaction and event buffers are capped (default 50,000) to prevent memory exhaustion. When the cap is reached, the oldest half is evicted.
+
+## Limitations
+
+- `score_text()` is a keyword heuristic, not an LLM judge. It is suitable for prototyping and research but not for high-stakes safety evaluation.
+- The scripted population (honest/opportunistic/deceptive) uses fixed behavioural rules, not learned policies.
+- The `verifiers` integration requires that library to be separately installed; without it, `load_environment()` returns a raw `SwarmSafetyEnv`.
+- The `prime` CLI must be installed and authenticated for platform operations (publishing, training jobs, GPU queries).
+
+## Status
+
+**In Development** -- Core bridge functional with full test coverage. Environment Hub integration and hosted training workflows require the `prime` CLI.


### PR DESCRIPTION
Add comprehensive docs for the SWARM-Prime Intellect bridge covering
architecture, reward system, environment setup, platform operations,
configuration reference, anti-gaming defences, and security notes.
Update bridges index to list the new bridge.

https://claude.ai/code/session_01VwVwe5aVJwfBiS2CuZrqN9