### PR TITLE
docs: add ML paper-writing skill integration to research workflow

### DIFF
--- a/docs/guides/research-workflow.md
+++ b/docs/guides/research-workflow.md
@@ -40,6 +40,46 @@ if state.submission_result:
 
 See [Reflexivity](../research/reflexivity.md) for the epistemological framework.
 
+## Integrating the `20-ml-paper-writing` Skill into SWARM Research Loops
+
+If you are running Codex with local skills enabled, you can add the
+[`AI-Research-SKILLs/20-ml-paper-writing`](https://github.com/Orchestra-Research/AI-Research-SKILLs/tree/main/20-ml-paper-writing)
+workflow to standardize drafting passes after each simulation cycle.
+
+### 1) Install the skill
+
+```bash
+python3 /opt/codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
+  --url https://github.com/Orchestra-Research/AI-Research-SKILLs/tree/main/20-ml-paper-writing
+```
+
+After installation, restart Codex so the new skill is available.
+
+### 2) Use it as the writing phase in each loop
+
+Recommended loop:
+
+1. Run literature + experiment + analysis stages from `ResearchWorkflow`.
+2. Export run artifacts (`history.json`, CSV summaries, and scenario config).
+3. Invoke the ML paper writing skill to draft:
+   - problem framing and hypothesis,
+   - methods (scenario/mechanism details),
+   - results (key metrics and uncertainty),
+   - limitations and governance implications.
+4. Feed reviewer comments back into the next SWARM run (new depth/breadth or governance sweep).
+
+### 3) Keep runs reproducible across writing iterations
+
+For every loop iteration, pin and log:
+
+- scenario path,
+- seed(s),
+- model/provider configuration,
+- commit SHA,
+- output artifact directory under `runs/`.
+
+This keeps the writing process tightly coupled to exact simulation evidence instead of narrative drift.
+
 ## Overview
 
 This workflow decomposes research into specialized sub-agents with controllable depth and breadth parameters, enabling systematic exploration while maintaining quality.


### PR DESCRIPTION
### Motivation

- Standardize the post-simulation writing pass by integrating Orchestra Research's `20-ml-paper-writing` skill into the SWARM research loop so drafts are tightly coupled to simulation artifacts. 
- Provide a clear install-and-use pattern to make it easy for workflows to export run evidence and generate reproducible paper drafts. 

### Description

- Added a new section to `docs/guides/research-workflow.md` titled "Integrating the `20-ml-paper-writing` Skill into SWARM Research Loops" that explains the integration rationale. 
- Documented the `skill-installer` invocation to fetch the skill via `install-skill-from-github.py` and noted that Codex should be restarted after installation. 
- Described a recommended loop (literature → experiment → analysis → writing) and the artifacts to export (`history.json`, CSV summaries, scenario config) for the writing phase. 
- Added a reproducibility checklist to pin `scenario path`, `seed(s)`, `model/provider configuration`, `commit SHA`, and `output artifact directory under runs/` for each loop iteration. 

### Testing

- Verified the documentation change is present by checking the file diff and confirming the new section and GitHub URL appear in `docs/guides/research-workflow.md`. 
- Confirmed presence of the integration text with `rg` and inspected the updated lines via file preview commands, both of which succeeded. 
- Attempted to install the external skill via `install-skill-from-github.py --url <repo>` and the `--method git` fallback, both of which failed due to outbound network restrictions (HTTP tunnel `403 Forbidden` and SSH unreachable). 
- No unit tests were modified or run as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cdccd7260832a975b57d2d389ebd6)