### PR TITLE
Add bootstrap helper for installing AI-Research skills

### DIFF
--- a/docs/guides/research-workflow.md
+++ b/docs/guides/research-workflow.md
@@ -40,6 +40,17 @@ if state.submission_result:
 
 See [Reflexivity](../research/reflexivity.md) for the epistemological framework.
 
+
+## Research Skill Loop Bootstrap
+
+To run this workflow with external Codex research skills, bootstrap them with:
+
+```bash
+./scripts/install_research_skills.sh
+```
+
+This helper discovers every `SKILL.md` in `Orchestra-Research/AI-Research-SKILLs` and installs each one into `${CODEX_HOME:-~/.codex}/skills` via Codex's installer script. If your environment blocks GitHub access, rerun in a network-enabled shell and restart Codex afterward.
+
 ## Overview
 
 This workflow decomposes research into specialized sub-agents with controllable depth and breadth parameters, enabling systematic exploration while maintaining quality.

--- a/scripts/install_research_skills.sh
+++ b/scripts/install_research_skills.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="Orchestra-Research/AI-Research-SKILLs"
+REF="main"
+DEST="${CODEX_HOME:-$HOME/.codex}/skills"
+TMP_DIR=""
+
+usage() {
+  cat <<USAGE
+Install every SKILL.md in ${REPO} into Codex skills.
+
+Usage: $(basename "$0") [--ref <git-ref>] [--dest <skills-dir>] [--repo <owner/repo>]
+
+Examples:
+  $(basename "$0")
+  $(basename "$0") --ref dev
+  $(basename "$0") --dest ~/.codex/skills
+USAGE
+}
+
+cleanup() {
+  if [[ -n "${TMP_DIR}" && -d "${TMP_DIR}" ]]; then
+    rm -rf "${TMP_DIR}"
+  fi
+}
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ref)
+      REF="$2"
+      shift 2
+      ;;
+    --dest)
+      DEST="$2"
+      shift 2
+      ;;
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+mkdir -p "$DEST"
+TMP_DIR="$(mktemp -d)"
+REPO_DIR="$TMP_DIR/repo"
+
+echo "Cloning https://github.com/${REPO} (ref=${REF}) ..."
+git clone --depth 1 --branch "$REF" "https://github.com/${REPO}.git" "$REPO_DIR"
+
+mapfile -t SKILL_DIRS < <(find "$REPO_DIR" -type f -name SKILL.md -exec dirname {} \; | sed "s#^$REPO_DIR/##" | sort -u)
+
+if [[ ${#SKILL_DIRS[@]} -eq 0 ]]; then
+  echo "No SKILL.md files found in ${REPO}@${REF}."
+  exit 1
+fi
+
+echo "Discovered ${#SKILL_DIRS[@]} skill(s):"
+printf '  - %s\n' "${SKILL_DIRS[@]}"
+
+echo
+python /opt/codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
+  --repo "$REPO" \
+  --ref "$REF" \
+  --dest "$DEST" \
+  --path "${SKILL_DIRS[@]}"
+
+echo
+echo "Installed skills into: $DEST"
+echo "Restart Codex to pick up new skills."


### PR DESCRIPTION
### Motivation
- Provide an easy way to populate Codex's `skills` directory with the research skills from `Orchestra-Research/AI-Research-SKILLs` so the SWARM research workflow can leverage external skill personas.
- Make the bootstrap step discoverable and reproducible by documenting it in the research workflow guide.

### Description
- Add `scripts/install_research_skills.sh`, a robust installer that clones a given GitHub repo, discovers every directory containing `SKILL.md`, and invokes Codex's `install-skill-from-github.py` to install each skill into `${CODEX_HOME:-~/.codex}/skills`.
- The script supports `--repo`, `--ref`, and `--dest` overrides, creates a temp working directory with cleanup, prints discovered skills, and exits with clear messages when no skills are found.
- Update `docs/guides/research-workflow.md` with a `Research Skill Loop Bootstrap` section that documents running `./scripts/install_research_skills.sh` and notes the requirement to run in a network-enabled environment and restart Codex.
- The installer delegates actual installation to `/opt/codex/skills/.system/skill-installer/scripts/install-skill-from-github.py` to preserve existing installer behavior.

### Testing
- Ran a shell-syntax check with `bash -n scripts/install_research_skills.sh`, which succeeded. 
- Ran the script help with `./scripts/install_research_skills.sh --help`, which produced the expected usage output. 
- Attempted to run `./scripts/install_research_skills.sh` end-to-end, but the run failed in this environment due to network restrictions (GitHub CONNECT tunnel returned HTTP 403), so full installation could not complete here. 
- No other automated tests were required for this change; documentation and basic runtime behavior were validated as described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cdde84110832a8459aabea1429343)