### PR TITLE
fix: resolve mypy arg-type error for RewardMode in load_environment

### DIFF
--- a/swarm/bridges/prime_intellect/environment.py
+++ b/swarm/bridges/prime_intellect/environment.py
@@ -34,6 +34,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from swarm.bridges.prime_intellect.config import (
     PrimeIntellectConfig,
+    RewardMode,
 )
 from swarm.bridges.prime_intellect.events import (
     EpisodeSummary,
@@ -561,7 +562,7 @@ def load_environment(
     """
     config = PrimeIntellectConfig(
         scenario_path=scenario_path,
-        reward_mode=reward_mode,
+        reward_mode=RewardMode(reward_mode),
         population_size=population_size,
         max_turns=max_turns,
         **kwargs,


### PR DESCRIPTION
The load_environment function passed a plain str to PrimeIntellectConfig's reward_mode parameter which expects RewardMode. Wrap with RewardMode() to satisfy the type checker.

https://claude.ai/code/session_01Fe7GVxwutbV4KW6NWPZj19

## Summary

Brief description of the changes.

## Changes

- ...
- ...

## Test Plan

- [ ] Existing tests pass (`pytest tests/ -v`)
- [ ] Lint passes (`ruff check swarm/ tests/`)
- [ ] Type check passes (`mypy swarm/`)
- [ ] New tests added (if applicable)

## Results (SWARM)

If this change affects scenarios, metrics, agents, governance, or evaluation, include a reproducible run folder and the headline deltas.

**Reproduce**
- Scenario: `scenarios/<name>.yaml`
- Command: `python -m swarm run scenarios/<name>.yaml --seed <seed> --epochs <n> --steps <n> --export-json runs/<run_id>/history.json --export-csv runs/<run_id>/csv`
- Plots: `python examples/plot_run.py runs/<run_id>`

**Artifacts**
- `runs/<run_id>/history.json`
- `runs/<run_id>/csv/`
- `runs/<run_id>/plots/`

**Headline metrics**
- Total interactions:
- Accepted interactions:
- Avg toxicity:
- Final welfare:

**Invariants**
- [ ] `p ∈ [0, 1]` everywhere it is surfaced/logged
- [ ] Event logs remain replayable (append-only JSONL)

## Related Issues

Closes #
