### PR TITLE
Scrub platform run ID from eval lessons note

### DIFF
--- a/research/notes/swarm_economy_rl_eval_lessons.md
+++ b/research/notes/swarm_economy_rl_eval_lessons.md
@@ -122,7 +122,7 @@ Easy difficulty (more honest bots, fewer adversarial bots, lower taxes) establis
 - Difficulty: easy
 - Platform: Prime Intellect (H100 cluster, 4 inference servers)
 
-### Steps 0-1 (pre-weight-update, run `tlzhomfn0wv409o0by31nkg5`)
+### Steps 0-1 (pre-weight-update)
 
 | Metric | Step 0 | Step 1 |
 |---|---|---|


### PR DESCRIPTION
## Summary
- Removes Prime Intellect run ID (`tlzhomfn0wv409o0by31nkg5`) that was inadvertently included in `research/notes/swarm_economy_rl_eval_lessons.md`

## Test plan
- [x] Verified no other platform-specific IDs remain in the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)