### PR TITLE
Fix governed swarm: cycle threshold, composite redirect, handoff counter

### DIFF
--- a/tests/test_governed_swarm.py
+++ b/tests/test_governed_swarm.py
@@ -393,9 +393,8 @@ class TestCompositePolicy:
         composite = CompositePolicy([Redirect1(), Redirect2()])
         result = composite.evaluate("a", "b", "task", {}, ProvenanceLogger())
         assert result.decision == GovernanceDecision.MODIFY
-        assert result.modified_context is not None
-        # Last redirect wins
-        assert result.modified_context["redirected_target"] == "agent_y"
+        # Last redirect wins — target is now on modified_target, not buried in modified_context
+        assert result.modified_target == "agent_y"
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary

- **Cycle detection threshold**: `CycleDetectionPolicy` ignored `max_cycles` because `detect_cycles()` hardcoded `count > 2`. Now `detect_cycles()` accepts a `threshold` parameter and the policy passes `self.max_cycles`, so `default_governance_stack(max_cycles=...)` is actually respected.
- **Composite policy redirect**: `CompositePolicy` stored `modified_target` inside `modified_context["redirected_target"]` but never set `GovernanceResult.modified_target`. Since `create_governed_handoff_tool` only checks `modified_target`, redirects from composed policies were silently dropped. Now the target is popped from context and set on the result properly.
- **Handoff counter**: The handoff update always wrote `"handoff_count": 1` instead of incrementing the existing value, so monitoring/governance reading this field always saw 1.

## Test plan

- [x] All 48 governed swarm tests pass
- [x] `test_modify_redirect_last_wins` updated to assert on `modified_target` instead of `modified_context`

🤖 Generated with [Claude Code](https://claude.com/claude-code)