### PR TITLE
Fix gastown bridge: branch fallback in mixed envs, ci-fail grep

### DIFF
--- a/swarm/bridges/gastown/bridge.py
+++ b/swarm/bridges/gastown/bridge.py
@@ -81,13 +81,12 @@ class GasTownBridge:
         base = self._config.base_branch
         worktrees = self._git_observer.get_agent_worktrees()
 
-        # Build a lookup from agent name → best matching branch
+        # Build a lookup from agent name → best matching branch for agents
+        # that don't have a local worktree.
         branch_map: Dict[str, str] = {}
-        if not worktrees:
-            for info in self._git_observer.get_feature_branches(base):
-                agent = info["agent"]
-                # Keep the first (or only) branch per agent; callers that
-                # need all branches should use poll_branches().
+        for info in self._git_observer.get_feature_branches(base):
+            agent = info["agent"]
+            if agent not in worktrees:
                 branch_map.setdefault(agent, info["branch"])
 
         for event in new_events:

--- a/swarm/bridges/gastown/git_observer.py
+++ b/swarm/bridges/gastown/git_observer.py
@@ -85,7 +85,7 @@ class GitObserver:
 
         # CI failures (convention: commits with "[ci-fail]" in message)
         result = _run_git(
-            ["log", "--oneline", "--grep=[ci-fail]", "main..HEAD"],
+            ["log", "--oneline", "--fixed-strings", "--grep=[ci-fail]", "main..HEAD"],
             cwd=worktree,
         )
         if result and result.returncode == 0:
@@ -234,7 +234,7 @@ class GitObserver:
 
         # CI failures (commits with "[ci-fail]" in message)
         result = _run_git(
-            ["log", "--oneline", "--grep=[ci-fail]", f"{base}..{branch}"],
+            ["log", "--oneline", "--fixed-strings", "--grep=[ci-fail]", f"{base}..{branch}"],
             cwd=cwd,
         )
         if result and result.returncode == 0:


### PR DESCRIPTION
## Summary

- **Branch fallback in mixed environments**: `branch_map` was only built when `get_agent_worktrees()` returned empty. In mixed setups (some agents with local worktrees, others with only remote feature branches), agents without a worktree got empty git stats, suppressing commit/file signals and distorting `p`/`v_hat`. Now `branch_map` is populated for any agent that doesn't have a worktree, regardless of whether other agents do.
- **CI failure grep pattern**: `git log --grep=[ci-fail]` was parsed as a regex character class (invalid `i-f` range), causing the command to exit non-zero and `ci_failures` to always remain 0. Added `--fixed-strings` so the brackets are matched literally.

## Test plan

- [x] All 14 gastown bridge tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)