### PR TITLE
Add SciAgentGym bridge primitives and loop-governance hooks

### DIFF
--- a/swarm/bridges/__init__.py
+++ b/swarm/bridges/__init__.py
@@ -13,6 +13,7 @@ Available bridge subpackages (lazy import to avoid pulling in optional deps):
     swarm.bridges.pettingzoo        — PettingZoo multi-agent RL environment bridge
     swarm.bridges.prime_intellect   — Prime Intellect RL training bridge
     swarm.bridges.ai_scientist     — AI-Scientist autonomous research pipeline bridge
+    swarm.bridges.sciagentgym      — SciAgentGym tool substrate integration bridge
 """
 
 __all__: list[str] = []

--- a/swarm/bridges/sciagentgym/__init__.py
+++ b/swarm/bridges/sciagentgym/__init__.py
@@ -1,0 +1,14 @@
+"""SciAgentGym integration bridge primitives for SWARM."""
+
+from .governance import ToolCallFingerprint, ToolLoopDetector
+from .manager import EmbeddingTopology, SciEnvManager
+from .provider import SciAgentGymToolProvider, ToolCallResult
+
+__all__ = [
+    "EmbeddingTopology",
+    "SciAgentGymToolProvider",
+    "SciEnvManager",
+    "ToolCallFingerprint",
+    "ToolCallResult",
+    "ToolLoopDetector",
+]

--- a/swarm/bridges/sciagentgym/governance.py
+++ b/swarm/bridges/sciagentgym/governance.py
@@ -1,0 +1,51 @@
+"""Governance utilities tuned for SciAgentGym-style tool loop failures."""
+
+from __future__ import annotations
+
+from collections import Counter, deque
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ToolCallFingerprint:
+    """Compact representation used for loop detection."""
+
+    tool_name: str
+    args_hash: str
+    error_class: str | None
+
+
+@dataclass
+class ToolLoopDetector:
+    """n-gram repetition detector for tool-call loops.
+
+    Tracks recent calls and estimates how much repetition exists over a moving
+    window. When repeat_ratio exceeds max_repeat_ratio, governance can trigger a
+    circuit breaker or force a re-planning phase.
+    """
+
+    ngram_size: int = 3
+    window_size: int = 24
+    max_repeat_ratio: float = 0.55
+    _calls: deque[ToolCallFingerprint] = field(default_factory=deque)
+
+    def record(self, fingerprint: ToolCallFingerprint) -> None:
+        """Add a call fingerprint to the rolling history window."""
+        self._calls.append(fingerprint)
+        while len(self._calls) > self.window_size:
+            self._calls.popleft()
+
+    def repeat_ratio(self) -> float:
+        """Return repeated n-gram ratio over the current window."""
+        calls = list(self._calls)
+        if len(calls) < self.ngram_size:
+            return 0.0
+
+        ngrams = [tuple(calls[i : i + self.ngram_size]) for i in range(len(calls) - self.ngram_size + 1)]
+        counts = Counter(ngrams)
+        repeated = sum(count - 1 for count in counts.values() if count > 1)
+        return repeated / len(ngrams)
+
+    def should_trip_circuit_breaker(self) -> bool:
+        """Whether repeat ratio crossed configured threshold."""
+        return self.repeat_ratio() >= self.max_repeat_ratio

--- a/swarm/bridges/sciagentgym/manager.py
+++ b/swarm/bridges/sciagentgym/manager.py
@@ -1,0 +1,86 @@
+"""SciAgentGym environment lifecycle management for SWARM bridges.
+
+This module keeps SWARM decoupled from SciAgentGym internals by requiring only
+factory callables that produce environment objects with a compatible interface.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class EmbeddingTopology(str, Enum):
+    """How SciAgentGym environments are allocated inside a SWARM simulation."""
+
+    SHARED_EPISODE = "shared_episode"
+    PER_AGENT = "per_agent"
+    PER_TASK = "per_task"
+
+
+@dataclass(frozen=True)
+class EnvAllocationKey:
+    """Lookup key describing which environment instance should be used."""
+
+    episode_id: str
+    agent_id: str | None = None
+    task_id: str | None = None
+
+
+@dataclass
+class SciEnvManager:
+    """Create, cache, and close SciAgentGym environments for SWARM episodes.
+
+    The manager accepts a factory function so SWARM can integrate with whichever
+    SciAgentGym constructor/version is installed.
+    """
+
+    env_factory: Callable[..., Any]
+    topology: EmbeddingTopology = EmbeddingTopology.SHARED_EPISODE
+    _envs: dict[EnvAllocationKey, Any] = field(default_factory=dict)
+
+    def get_or_create(
+        self,
+        *,
+        episode_id: str,
+        agent_id: str | None = None,
+        task_id: str | None = None,
+        **factory_kwargs: Any,
+    ) -> Any:
+        """Get an existing env for the topology or create one with env_factory."""
+        key = self._resolve_key(
+            episode_id=episode_id,
+            agent_id=agent_id,
+            task_id=task_id,
+        )
+        if key not in self._envs:
+            self._envs[key] = self.env_factory(
+                episode_id=episode_id,
+                agent_id=agent_id,
+                task_id=task_id,
+                **factory_kwargs,
+            )
+        return self._envs[key]
+
+    def close_all(self) -> None:
+        """Close all managed environments and clear cache."""
+        for env in self._envs.values():
+            close_fn = getattr(env, "close", None)
+            if callable(close_fn):
+                close_fn()
+        self._envs.clear()
+
+    def _resolve_key(
+        self,
+        *,
+        episode_id: str,
+        agent_id: str | None,
+        task_id: str | None,
+    ) -> EnvAllocationKey:
+        if self.topology == EmbeddingTopology.SHARED_EPISODE:
+            return EnvAllocationKey(episode_id=episode_id)
+        if self.topology == EmbeddingTopology.PER_AGENT:
+            return EnvAllocationKey(episode_id=episode_id, agent_id=agent_id)
+        return EnvAllocationKey(episode_id=episode_id, task_id=task_id)

--- a/swarm/bridges/sciagentgym/provider.py
+++ b/swarm/bridges/sciagentgym/provider.py
@@ -1,0 +1,82 @@
+"""SciAgentGym tool provider adapter for SWARM action interfaces."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from .manager import SciEnvManager
+
+
+class SciToolEnvironment(Protocol):
+    """Minimal protocol expected from a SciAgentGym-like environment."""
+
+    def list_tools(self) -> list[dict[str, Any]]: ...
+
+    def call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]: ...
+
+
+@dataclass
+class ToolCallResult:
+    """Normalized tool-call payload for SWARM decision loops."""
+
+    ok: bool
+    result: Any = None
+    error: str | None = None
+    artifacts: list[str] = field(default_factory=list)
+    call_signature_hash: str = ""
+
+
+@dataclass
+class SciAgentGymToolProvider:
+    """Expose SciAgentGym tools through a SWARM-friendly API."""
+
+    env_manager: SciEnvManager
+
+    def list_tools(
+        self,
+        *,
+        episode_id: str,
+        agent_id: str | None = None,
+        task_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        env: SciToolEnvironment = self.env_manager.get_or_create(
+            episode_id=episode_id,
+            agent_id=agent_id,
+            task_id=task_id,
+        )
+        return env.list_tools()
+
+    def call_tool(
+        self,
+        *,
+        episode_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+        agent_id: str | None = None,
+        task_id: str | None = None,
+    ) -> ToolCallResult:
+        env: SciToolEnvironment = self.env_manager.get_or_create(
+            episode_id=episode_id,
+            agent_id=agent_id,
+            task_id=task_id,
+        )
+        signature = self._signature_hash(tool_name=tool_name, arguments=arguments)
+        try:
+            raw = env.call_tool(tool_name, arguments)
+        except Exception as exc:  # noqa: BLE001
+            return ToolCallResult(ok=False, error=str(exc), call_signature_hash=signature)
+
+        return ToolCallResult(
+            ok=bool(raw.get("ok", True)),
+            result=raw.get("result"),
+            error=raw.get("error"),
+            artifacts=list(raw.get("artifacts", [])),
+            call_signature_hash=signature,
+        )
+
+    @staticmethod
+    def _signature_hash(tool_name: str, arguments: dict[str, Any]) -> str:
+        payload = f"{tool_name}:{sorted(arguments.items())}"
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]

--- a/tests/bridges/test_sciagentgym_bridge.py
+++ b/tests/bridges/test_sciagentgym_bridge.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from swarm.bridges.sciagentgym import (
+    EmbeddingTopology,
+    SciAgentGymToolProvider,
+    SciEnvManager,
+    ToolCallFingerprint,
+    ToolLoopDetector,
+)
+
+
+@dataclass
+class FakeEnv:
+    name: str
+    closed: bool = False
+
+    def list_tools(self) -> list[dict]:
+        return [{"name": f"tool_{self.name}", "args_schema": {"x": "int"}}]
+
+    def call_tool(self, name: str, arguments: dict) -> dict:
+        if name == "explode":
+            raise RuntimeError("boom")
+        return {
+            "ok": True,
+            "result": {"tool": name, "args": arguments},
+            "artifacts": [f"/{self.name}/result.json"],
+        }
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_env_manager_reuses_env_for_shared_topology():
+    created: list[str] = []
+
+    def factory(**kwargs):
+        created.append(kwargs["episode_id"])
+        return FakeEnv(name=kwargs["episode_id"])
+
+    manager = SciEnvManager(env_factory=factory, topology=EmbeddingTopology.SHARED_EPISODE)
+
+    env1 = manager.get_or_create(episode_id="ep1", agent_id="a1")
+    env2 = manager.get_or_create(episode_id="ep1", agent_id="a2")
+
+    assert env1 is env2
+    assert created == ["ep1"]
+
+
+def test_env_manager_uses_agent_partition_for_per_agent_topology():
+    manager = SciEnvManager(
+        env_factory=lambda **kwargs: FakeEnv(name=f"{kwargs['episode_id']}:{kwargs['agent_id']}"),
+        topology=EmbeddingTopology.PER_AGENT,
+    )
+
+    env1 = manager.get_or_create(episode_id="ep1", agent_id="a1")
+    env2 = manager.get_or_create(episode_id="ep1", agent_id="a2")
+
+    assert env1 is not env2
+
+
+def test_tool_provider_normalizes_call_results_and_errors():
+    manager = SciEnvManager(env_factory=lambda **_: FakeEnv(name="lab"))
+    provider = SciAgentGymToolProvider(env_manager=manager)
+
+    tools = provider.list_tools(episode_id="ep")
+    assert tools[0]["name"] == "tool_lab"
+
+    ok = provider.call_tool(
+        episode_id="ep",
+        tool_name="measure",
+        arguments={"sample": 2},
+    )
+    assert ok.ok is True
+    assert ok.result == {"tool": "measure", "args": {"sample": 2}}
+    assert ok.artifacts == ["/lab/result.json"]
+    assert len(ok.call_signature_hash) == 16
+
+    failed = provider.call_tool(
+        episode_id="ep",
+        tool_name="explode",
+        arguments={},
+    )
+    assert failed.ok is False
+    assert failed.error == "boom"
+
+
+def test_tool_loop_detector_trips_circuit_breaker_on_repetition():
+    detector = ToolLoopDetector(ngram_size=2, window_size=8, max_repeat_ratio=0.3)
+    fp_a = ToolCallFingerprint("query_db", "a", None)
+    fp_b = ToolCallFingerprint("query_db", "b", "ValidationError")
+
+    for fp in [fp_a, fp_b, fp_a, fp_b, fp_a, fp_b]:
+        detector.record(fp)
+
+    assert detector.repeat_ratio() > 0.3
+    assert detector.should_trip_circuit_breaker() is True
+
+
+def test_env_manager_close_all_calls_close_hook():
+    envs: list[FakeEnv] = []
+
+    def factory(**kwargs):
+        env = FakeEnv(name=kwargs["episode_id"])
+        envs.append(env)
+        return env
+
+    manager = SciEnvManager(env_factory=factory, topology=EmbeddingTopology.PER_TASK)
+    manager.get_or_create(episode_id="ep1", task_id="t1")
+    manager.get_or_create(episode_id="ep1", task_id="t2")
+
+    manager.close_all()
+
+    assert all(e.closed for e in envs)


### PR DESCRIPTION
### Motivation
- Provide a clean integration surface to embed SciAgentGym as SWARM's domain tool substrate without porting many tools. 
- Allow configurable embedding topologies (shared episode / per-agent / per-task) so scenarios can choose isolation semantics. 
- Surface governance hooks to detect and mitigate SciAgentGym-style tool-call looping failure modes (circuit breaker / replan triggers). 

### Description
- Add a new bridge package `swarm.bridges.sciagentgym` that exports `SciEnvManager`, `SciAgentGymToolProvider`, `ToolCallFingerprint`, `ToolLoopDetector`, and related types. 
- Implement `SciEnvManager` (in `manager.py`) to create, cache, and tear down environment instances with selectable `EmbeddingTopology` (`SHARED_EPISODE`, `PER_AGENT`, `PER_TASK`). 
- Implement `SciAgentGymToolProvider` (in `provider.py`) which adapts `list_tools` / `call_tool` into a normalized `ToolCallResult` (includes `ok/result/error/artifacts` and a deterministic call-signature hash). 
- Add governance utilities (in `governance.py`) implementing an n-gram `ToolLoopDetector` using `ToolCallFingerprint` to compute a repeat ratio and a `should_trip_circuit_breaker` predicate; update `swarm.bridges` docs to list the new bridge and add focused unit tests. 

### Testing
- Ran targeted unit tests with `PYTHONPATH=. pytest -q --noconftest tests/bridges/test_sciagentgym_bridge.py`, which passed (`5 passed`) against the new bridge. 
- Ran `ruff check swarm/bridges/sciagentgym tests/bridges/test_sciagentgym_bridge.py`, which passed with no lint issues. 
- Attempting to run the repo-wide test collection initially failed due to a missing optional test dependency (`psutil`) imported by the repo `conftest.py`, and `pip install psutil` failed in this environment due to network/proxy restrictions, so the full test matrix was not executed here. 
- All added unit tests exercise env allocation/topologies, tool-call normalization and error handling, loop detection behavior, and env teardown.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993371f4244832a9c957b1931e54da1)