### PR TITLE
Fix SkillRL refinement governance bypass

### DIFF
--- a/swarm/agents/skillrl_agent.py
+++ b/swarm/agents/skillrl_agent.py
@@ -446,18 +446,19 @@ class SkillRLAgent(BaseAgent):
 
         self._last_refinement_epoch = epoch
 
-        # Collect refinement proposals
-        refined_ids, proposals = self.skill_evolution.refine_skills_with_governance(
+        governance_lever = getattr(self, "governance_lever", None)
+
+        # Collect refinement proposals without auto-applying when governance exists.
+        _, proposals = self.skill_evolution.refine_skills_with_governance(
             self.skill_library,
             self.agent_id,
-            governance_lever=None,  # First pass: collect proposals
+            governance_lever=governance_lever,
         )
 
         if not proposals:
             return
 
         # Apply governance if enabled
-        governance_lever = getattr(self, 'governance_lever', None)
         if governance_lever is not None and env_state is not None:
             approved_proposals = []
 


### PR DESCRIPTION
## Summary

Brief description of the changes.

## Changes

- ...
- ...

## Test Plan

- [ ] Existing tests pass (`pytest tests/ -v`)
- [ ] Lint passes (`ruff check swarm/ tests/`)
- [ ] Type check passes (`mypy swarm/`)
- [ ] New tests added (if applicable)

## Results (SWARM)

If this change affects scenarios, metrics, agents, governance, or evaluation, include a reproducible run folder and the headline deltas.

**Reproduce**
- Scenario: `scenarios/<name>.yaml`
- Command: `python -m swarm run scenarios/<name>.yaml --seed <seed> --epochs <n> --steps <n> --export-json runs/<run_id>/history.json --export-csv runs/<run_id>/csv`
- Plots: `python examples/plot_run.py runs/<run_id>`

**Artifacts**
- `runs/<run_id>/history.json`
- `runs/<run_id>/csv/`
- `runs/<run_id>/plots/`

**Headline metrics**
- Total interactions:
- Accepted interactions:
- Avg toxicity:
- Final welfare:

**Invariants**
- [ ] `p ∈ [0, 1]` everywhere it is surfaced/logged
- [ ] Event logs remain replayable (append-only JSONL)

## Related Issues

Closes #
