### PR TITLE
Add Memori semantic memory middleware for LLM agents

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,9 @@ crewai = [
 awm = [
     "httpx>=0.27.0",
 ]
+memori = [
+    "memori>=3.0.0",
+]
 langgraph = [
     "langgraph>=0.2.0",
     "langchain-core>=0.3.0",

--- a/scenarios/llm_memori.yaml
+++ b/scenarios/llm_memori.yaml
@@ -1,0 +1,90 @@
+# LLM Agents with Memori Semantic Memory
+# Demonstrates persistent semantic memory across simulation steps/epochs.
+# Requires: pip install -e ".[llm,memori]" and ANTHROPIC_API_KEY set.
+#
+# NOTE: Semantic search (embedding similarity) is inherently non-deterministic
+# across runs. auto_wait ensures facts from call N are available for call N+1,
+# but embedding distances may vary slightly between runs.
+
+scenario_id: llm_memori_v1
+description: "LLM agents with Memori persistent memory vs scripted agents"
+motif: emergent_strategy
+
+agents:
+  # LLM agents with Memori enabled
+  - type: llm
+    count: 1
+    name: memori_open
+    llm:
+      provider: anthropic
+      model: claude-sonnet-4-20250514
+      persona: open
+      temperature: 0.7
+      max_tokens: 512
+      cost_tracking: true
+      memori:
+        enabled: true
+        db_path: ":memory:"
+        auto_wait: true
+        decay_on_epoch: true
+
+  - type: llm
+    count: 1
+    name: memori_strategic
+    llm:
+      provider: anthropic
+      model: claude-sonnet-4-20250514
+      persona: strategic
+      temperature: 0.5
+      max_tokens: 512
+      cost_tracking: true
+      memori:
+        enabled: true
+        db_path: ":memory:"
+        auto_wait: true
+        decay_on_epoch: true
+
+  # Scripted baseline agents for comparison
+  - type: honest
+    count: 3
+
+simulation:
+  n_epochs: 5
+  steps_per_epoch: 5
+  seed: 42
+
+payoff:
+  s_plus: 2.0
+  s_minus: 1.0
+  h: 2.0
+  theta: 0.5
+  rho_a: 0.1
+  rho_b: 0.1
+  w_rep: 1.0
+
+governance:
+  transaction_tax_rate: 0.05
+  transaction_tax_split: 0.5
+  reputation_decay_rate: 0.95
+  staking_enabled: false
+  circuit_breaker_enabled: true
+  freeze_threshold_toxicity: 0.7
+  freeze_duration_epochs: 2
+  audit_enabled: true
+  audit_probability: 0.1
+  audit_penalty_multiplier: 2.0
+
+rate_limits:
+  posts_per_epoch: 5
+  interactions_per_step: 3
+  votes_per_epoch: 20
+  tasks_per_epoch: 2
+
+outputs:
+  event_log: "logs/llm_memori.jsonl"
+  metrics_csv: "results/llm_memori_metrics.csv"
+
+success_criteria:
+  max_toxicity: 0.3
+  min_welfare: 15.0
+  max_llm_cost_usd: 5.0

--- a/swarm/agents/llm_config.py
+++ b/swarm/agents/llm_config.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 
 class LLMProvider(Enum):
@@ -67,6 +67,7 @@ class LLMConfig:
     prompt_audit_include_system_prompt: bool = False
     prompt_audit_hash_system_prompt: bool = True
     prompt_audit_max_chars: int = 20_000
+    memori_config: Optional[Dict[str, Any]] = None
 
     def __post_init__(self) -> None:
         """Validate configuration."""

--- a/swarm/agents/memori_middleware.py
+++ b/swarm/agents/memori_middleware.py
@@ -1,0 +1,170 @@
+"""Memori integration middleware for LLM agents.
+
+Wraps LLM client objects (Anthropic, OpenAI) with Memori's semantic memory
+layer, enabling persistent fact recall and extraction across simulation steps.
+
+Requires: pip install memori>=3.0.0
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MemoriConfig:
+    """Configuration for Memori semantic memory integration.
+
+    Attributes:
+        enabled: Master toggle for the middleware.
+        db_path: SQLite path for fact storage (":memory:" for ephemeral).
+        entity_id: Memori entity identifier; defaults to agent_id.
+        process_id: Memori process identifier; defaults to "swarm-{agent_id}".
+        auto_wait: Block until fact extraction completes (for reproducibility).
+        decay_on_epoch: Call new_session() at epoch boundaries for non-river
+            agents (persistence < 1.0), causing recency down-weighting.
+    """
+
+    enabled: bool = False
+    db_path: str = ":memory:"
+    entity_id: Optional[str] = None
+    process_id: Optional[str] = None
+    auto_wait: bool = True
+    decay_on_epoch: bool = True
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "MemoriConfig":
+        """Construct from a plain dictionary (e.g. YAML config)."""
+        return cls(
+            enabled=data.get("enabled", False),
+            db_path=data.get("db_path", ":memory:"),
+            entity_id=data.get("entity_id"),
+            process_id=data.get("process_id"),
+            auto_wait=data.get("auto_wait", True),
+            decay_on_epoch=data.get("decay_on_epoch", True),
+        )
+
+
+class MemoriMiddleware:
+    """Lazy-loading middleware that wraps LLM clients with Memori.
+
+    Usage::
+
+        mw = MemoriMiddleware(config, agent_id="agent_1")
+        client = mw.wrap_client(anthropic_client)
+        # client now auto-recalls and extracts facts on each LLM call
+    """
+
+    def __init__(self, config: MemoriConfig, agent_id: str) -> None:
+        self._config = config
+        self._agent_id = agent_id
+        self._memori: Any = None  # Lazy-loaded Memori instance
+
+    def _get_memori(self) -> Any:
+        """Lazy-import and initialize the Memori instance."""
+        if self._memori is not None:
+            return self._memori
+
+        try:
+            from memori import Memori
+        except ImportError as err:
+            raise ImportError(
+                "memori package not installed. "
+                "Install with: python -m pip install 'memori>=3.0.0'"
+            ) from err
+
+        entity_id = self._config.entity_id or self._agent_id
+        process_id = self._config.process_id or f"swarm-{self._agent_id}"
+
+        self._memori = Memori(
+            entity_id=entity_id,
+            process_id=process_id,
+            db_path=self._config.db_path,
+        )
+        # Build storage tables
+        self._memori.config.storage.build()
+        logger.info(
+            "Memori initialized for agent %s (entity=%s, db=%s)",
+            self._agent_id,
+            entity_id,
+            self._config.db_path,
+        )
+        return self._memori
+
+    def wrap_client(self, client: Any) -> Any:
+        """Register an LLM client with Memori for automatic memory injection.
+
+        Args:
+            client: An Anthropic, OpenAI, or compatible client object.
+
+        Returns:
+            The same client object (Memori patches it in-place).
+        """
+        memori = self._get_memori()
+        try:
+            memori.llm.register(client)
+        except Exception:
+            logger.warning(
+                "Memori could not register client for agent %s "
+                "(provider may be unsupported, e.g. Ollama). "
+                "Memory features disabled for this client.",
+                self._agent_id,
+            )
+        return client
+
+    def wait_for_augmentation(self) -> None:
+        """Block until any pending fact extraction completes."""
+        if self._memori is None:
+            return
+        try:
+            self._memori.augmentation.wait()
+        except Exception:
+            logger.debug(
+                "Memori augmentation wait failed for agent %s", self._agent_id
+            )
+
+    def on_epoch_boundary(self, epoch: int, epistemic_persistence: float) -> None:
+        """Handle epoch transitions for memory decay.
+
+        For agents with persistence < 1.0 (non-river), starts a new Memori
+        session so that older facts are naturally down-weighted by recency
+        in semantic search.
+
+        Args:
+            epoch: The new epoch number.
+            epistemic_persistence: The agent's epistemic persistence value
+                (0.0 = full rain, 1.0 = full river).
+        """
+        if not self._config.decay_on_epoch:
+            return
+
+        if epistemic_persistence >= 1.0:
+            # River agents: full persistence, no session rotation
+            return
+
+        if self._memori is None:
+            return
+
+        try:
+            self._memori.new_session()
+            logger.debug(
+                "Memori new_session() for agent %s at epoch %d "
+                "(persistence=%.2f)",
+                self._agent_id,
+                epoch,
+                epistemic_persistence,
+            )
+        except Exception:
+            logger.warning(
+                "Memori new_session() failed for agent %s at epoch %d",
+                self._agent_id,
+                epoch,
+            )
+
+    def close(self) -> None:
+        """Wait for pending work and clean up."""
+        if self._config.auto_wait:
+            self.wait_for_augmentation()
+        self._memori = None

--- a/swarm/scenarios/loader.py
+++ b/swarm/scenarios/loader.py
@@ -1025,6 +1025,7 @@ def parse_llm_config(data: Dict[str, Any]) -> Any:
             "prompt_audit_hash_system_prompt", True
         ),
         prompt_audit_max_chars=data.get("prompt_audit_max_chars", 20_000),
+        memori_config=data.get("memori"),
     )
 
 

--- a/tests/test_memori_middleware.py
+++ b/tests/test_memori_middleware.py
@@ -1,0 +1,168 @@
+"""Tests for Memori middleware integration."""
+
+from unittest.mock import MagicMock, patch
+
+from swarm.agents.memori_middleware import MemoriConfig, MemoriMiddleware
+
+
+class TestMemoriConfig:
+    """Tests for MemoriConfig dataclass."""
+
+    def test_defaults(self):
+        cfg = MemoriConfig()
+        assert cfg.enabled is False
+        assert cfg.db_path == ":memory:"
+        assert cfg.entity_id is None
+        assert cfg.process_id is None
+        assert cfg.auto_wait is True
+        assert cfg.decay_on_epoch is True
+
+    def test_from_dict_minimal(self):
+        cfg = MemoriConfig.from_dict({"enabled": True})
+        assert cfg.enabled is True
+        assert cfg.db_path == ":memory:"
+
+    def test_from_dict_full(self):
+        cfg = MemoriConfig.from_dict(
+            {
+                "enabled": True,
+                "db_path": "/tmp/test.db",
+                "entity_id": "ent_1",
+                "process_id": "proc_1",
+                "auto_wait": False,
+                "decay_on_epoch": False,
+            }
+        )
+        assert cfg.db_path == "/tmp/test.db"
+        assert cfg.entity_id == "ent_1"
+        assert cfg.process_id == "proc_1"
+        assert cfg.auto_wait is False
+        assert cfg.decay_on_epoch is False
+
+    def test_from_dict_empty(self):
+        cfg = MemoriConfig.from_dict({})
+        assert cfg.enabled is False
+
+
+class TestMemoriMiddleware:
+    """Tests for MemoriMiddleware with mocked Memori."""
+
+    def _make_middleware(self, **config_overrides):
+        cfg = MemoriConfig(enabled=True, **config_overrides)
+        return MemoriMiddleware(cfg, agent_id="test_agent")
+
+    @patch("swarm.agents.memori_middleware.MemoriMiddleware._get_memori")
+    def test_wrap_client_calls_register(self, mock_get_memori):
+        mock_memori = MagicMock()
+        mock_get_memori.return_value = mock_memori
+
+        mw = self._make_middleware()
+        fake_client = MagicMock()
+        result = mw.wrap_client(fake_client)
+
+        mock_memori.llm.register.assert_called_once_with(fake_client)
+        assert result is fake_client
+
+    @patch("swarm.agents.memori_middleware.MemoriMiddleware._get_memori")
+    def test_wrap_client_unsupported_provider_logs_warning(self, mock_get_memori):
+        mock_memori = MagicMock()
+        mock_memori.llm.register.side_effect = TypeError("unsupported")
+        mock_get_memori.return_value = mock_memori
+
+        mw = self._make_middleware()
+        fake_client = MagicMock()
+        # Should not raise
+        result = mw.wrap_client(fake_client)
+        assert result is fake_client
+
+    def test_on_epoch_boundary_river_no_session(self):
+        """River agents (persistence=1.0) should NOT call new_session()."""
+        mw = self._make_middleware()
+        mw._memori = MagicMock()
+
+        mw.on_epoch_boundary(epoch=2, epistemic_persistence=1.0)
+        mw._memori.new_session.assert_not_called()
+
+    def test_on_epoch_boundary_rain_calls_new_session(self):
+        """Rain agents (persistence=0.0) should call new_session()."""
+        mw = self._make_middleware()
+        mw._memori = MagicMock()
+
+        mw.on_epoch_boundary(epoch=2, epistemic_persistence=0.0)
+        mw._memori.new_session.assert_called_once()
+
+    def test_on_epoch_boundary_partial_calls_new_session(self):
+        """Partial persistence (0.5) should call new_session()."""
+        mw = self._make_middleware()
+        mw._memori = MagicMock()
+
+        mw.on_epoch_boundary(epoch=3, epistemic_persistence=0.5)
+        mw._memori.new_session.assert_called_once()
+
+    def test_on_epoch_boundary_decay_disabled(self):
+        """decay_on_epoch=False should skip session rotation."""
+        mw = self._make_middleware(decay_on_epoch=False)
+        mw._memori = MagicMock()
+
+        mw.on_epoch_boundary(epoch=1, epistemic_persistence=0.0)
+        mw._memori.new_session.assert_not_called()
+
+    def test_lazy_init_no_memori_before_use(self):
+        """Memori instance should be None until first use."""
+        mw = self._make_middleware()
+        assert mw._memori is None
+
+    def test_wait_for_augmentation_noop_when_uninitialized(self):
+        """wait_for_augmentation should be safe when _memori is None."""
+        mw = self._make_middleware()
+        mw.wait_for_augmentation()  # Should not raise
+
+    def test_close_clears_memori(self):
+        mw = self._make_middleware(auto_wait=False)
+        mw._memori = MagicMock()
+        mw.close()
+        assert mw._memori is None
+
+    def test_close_waits_when_auto_wait(self):
+        mw = self._make_middleware(auto_wait=True)
+        mock_memori = MagicMock()
+        mw._memori = mock_memori
+        mw.close()
+        mock_memori.augmentation.wait.assert_called_once()
+
+    @patch.dict("sys.modules", {"memori": MagicMock()})
+    def test_get_memori_lazy_init(self):
+        """_get_memori should create a Memori instance on first call."""
+        import sys
+
+        mock_module = sys.modules["memori"]
+        mock_memori_cls = MagicMock()
+        mock_module.Memori = mock_memori_cls
+
+        mw = self._make_middleware()
+        result = mw._get_memori()
+
+        mock_memori_cls.assert_called_once_with(
+            entity_id="test_agent",
+            process_id="swarm-test_agent",
+            db_path=":memory:",
+        )
+        assert result is mock_memori_cls.return_value
+
+    @patch.dict("sys.modules", {"memori": MagicMock()})
+    def test_get_memori_custom_ids(self):
+        """Custom entity_id and process_id should be used."""
+        import sys
+
+        mock_module = sys.modules["memori"]
+        mock_memori_cls = MagicMock()
+        mock_module.Memori = mock_memori_cls
+
+        mw = self._make_middleware(entity_id="custom_ent", process_id="custom_proc")
+        mw._get_memori()
+
+        mock_memori_cls.assert_called_once_with(
+            entity_id="custom_ent",
+            process_id="custom_proc",
+            db_path=":memory:",
+        )


### PR DESCRIPTION
## Summary

- Integrates [MemoriLabs/Memori](https://github.com/MemoriLabs/Memori) as an optional client-level middleware for `LLMAgent`, enabling persistent semantic fact recall and extraction across simulation steps/epochs
- Wraps Anthropic/OpenAI clients at lazy-load time via `MemoriMiddleware.wrap_client()` — zero changes to prompt building, action parsing, or the simulation loop
- Bridges SWARM's rain/river memory model: river agents (persistence=1.0) retain all facts; rain/partial agents rotate Memori sessions at epoch boundaries for recency-based decay
- Adds `memori` optional dependency group (`memori>=3.0.0`) in `pyproject.toml`
- Includes example scenario `scenarios/llm_memori.yaml` with 2 Memori-enabled LLM agents + 3 scripted honest agents

## Files changed

| File | Change |
|------|--------|
| `swarm/agents/memori_middleware.py` | **New** — `MemoriConfig` dataclass + `MemoriMiddleware` class |
| `tests/test_memori_middleware.py` | **New** — 16 unit tests with mocked Memori |
| `scenarios/llm_memori.yaml` | **New** — Example scenario |
| `swarm/agents/llm_config.py` | Added `memori_config` field to `LLMConfig` |
| `swarm/agents/llm_agent.py` | Added `_get_memori_middleware()`, client wrapping, `apply_memory_decay()` override |
| `swarm/scenarios/loader.py` | Pass `memori` YAML key to `LLMConfig` |
| `pyproject.toml` | Added `memori` optional dep group |

## Test plan

- [x] `python -m pytest tests/test_memori_middleware.py -v` — 16/16 pass
- [x] `python -m pytest tests/test_llm_agent.py -v` — 70/70 pass (no regressions)
- [x] `ruff check swarm/agents/memori_middleware.py` — clean
- [x] `python -m mypy swarm/agents/memori_middleware.py` — clean
- [ ] Manual: `python -m swarm run scenarios/llm_memori.yaml --seed 42 --epochs 2 --steps 5` (requires API keys + `pip install memori`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)