### PR TITLE
Add skill_activation_paradox scenario for testing skill-activation / purity-paradox

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ swarm/
 │   └── logging/         # Append-only JSONL logger
 ├── tests/               # 4556 tests across 133 files
 ├── examples/            # 39 runnable scripts + Streamlit demo
-├── scenarios/           # 78 YAML scenario definitions
+├── scenarios/           # 79 YAML scenario definitions
 ├── docs/                # Documentation, papers, blog posts
 └── pyproject.toml
 ```

--- a/scenarios/skill_activation_paradox.yaml
+++ b/scenarios/skill_activation_paradox.yaml
@@ -1,0 +1,66 @@
+# Skill Activation Paradox Scenario
+# Hypothesis:
+# - Safety skills are not enough by themselves; they need a strong trigger.
+# - A small adversarial minority should increase defensive skill usage,
+#   while larger adversarial shares should eventually collapse coordination.
+#
+# Mechanism isolated here:
+# - Skill-enabled honest agents (skill_honest) operate alongside baseline honest
+#   and adaptive adversaries under moderate governance pressure.
+#
+# Expected metric signature:
+# - Better welfare/toxicity outcomes than comparable non-skill baselines at low
+#   adversarial share, then a sharp degradation as adversaries approach parity.
+
+scenario_id: skill_activation_paradox
+description: "Tests whether adversarial presence triggers stronger safety-skill usage before phase-transition collapse"
+motif: adversarial_stress_test
+
+agents:
+  - type: skill_honest
+    count: 6
+  - type: honest
+    count: 2
+  - type: adaptive_adversary
+    count: 2
+
+governance:
+  transaction_tax_rate: 0.05
+  reputation_decay_rate: 0.95
+  bandwidth_cap: 10
+  staking_enabled: false
+  circuit_breaker_enabled: true
+  freeze_threshold_toxicity: 0.7
+  freeze_threshold_violations: 3
+  freeze_duration_epochs: 2
+  audit_enabled: true
+  audit_probability: 0.12
+
+simulation:
+  n_epochs: 12
+  steps_per_epoch: 8
+  seed: 42
+
+rate_limits:
+  posts_per_epoch: 10
+  interactions_per_step: 5
+  votes_per_epoch: 50
+  tasks_per_epoch: 3
+
+payoff:
+  s_plus: 2.0
+  s_minus: 1.0
+  h: 2.0
+  theta: 0.5
+  rho_a: 0.1
+  rho_b: 0.1
+  w_rep: 1.0
+
+success_criteria:
+  min_epochs: 12
+  min_agents: 10
+  toxicity_threshold: 0.4
+
+outputs:
+  event_log: "logs/skill_activation_paradox_events.jsonl"
+  metrics_csv: "logs/skill_activation_paradox_metrics.csv"


### PR DESCRIPTION
### Motivation
- Add a focused scenario to isolate the "skill activation / purity paradox" hypothesis so the suite can measure whether a small adversarial minority increases defensive skill usage before a phase-transition collapse. 

### Description
- Add `scenarios/skill_activation_paradox.yaml`, a compact scenario mixing `skill_honest`, `honest`, and `adaptive_adversary` agents with modest epochs/steps and explicit governance/rate/payoff settings to enable fast signal validation. 
- Update `README.md` scenario count from `78` to `79` to reflect the new scenario. 

### Testing
- Verified the new YAML parses successfully with a small Python check (`yaml.safe_load`) which returned the expected `scenario_id` (`ok`).
- Ran `pytest tests/test_scenarios.py -q` in this environment and it failed due to a missing dependency (`ModuleNotFoundError: No module named 'psutil'`), so full test-suite validation could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c4de7436c832aa860add4a73e7a34)