### PR TITLE
feat: add CautiousAgent, CollaborativeAgent, AdaptiveAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **Behavioral agent types** (`swarm/agents/behavioral.py`) — `CautiousAgent` (risk-averse, high acceptance threshold), `CollaborativeAgent` (coalition-building, EMA trust tracking), and `AdaptiveAgent` (rolling payoff window, threshold self-adaptation with exploration) with corresponding `AgentType` enum values and 20 unit tests (#66)
 - **RAG LEANN backend** (`swarm/bridges/rag/backend.py`) — `VectorBackend` protocol with ChromaDB and LEANN implementations; LEANN provides ~97% storage savings via graph-based selective recomputation with JSON sidecar metadata and post-retrieval filtering; selected via `RAGConfig.vector_backend`
 - **RAG bridge** (`swarm/bridges/rag/`) — semantic search over run history via ChromaDB vector store, with configurable embeddings (OpenAI/Ollama), LLM synthesis (Anthropic/OpenAI), CLI (`python -m swarm.bridges.rag`), and `rag` optional dependency group
 - **Adaptive governance controller** (`swarm/governance/adaptive.py`, `swarm/governance/adaptive_controller.py`) — three-phase loop with evidence accumulation, 3-pass contemplation (signal/trend/propose), and 3-gate crystallization (time/alignment/human review) for automatic threshold tuning of governance levers

--- a/swarm/agents/__init__.py
+++ b/swarm/agents/__init__.py
@@ -11,6 +11,11 @@ from swarm.agents.base import (
     BaseAgent,
     Observation,
 )
+from swarm.agents.behavioral import (
+    AdaptiveAgent,
+    CautiousAgent,
+    CollaborativeAgent,
+)
 from swarm.agents.deceptive import DeceptiveAgent
 from swarm.agents.honest import HonestAgent
 from swarm.agents.ldt_agent import LDTAgent
@@ -81,4 +86,8 @@ __all__ = [
     "AttackStrategy",
     # Threshold dancer adversary
     "ThresholdDancer",
+    # Behavioral archetypes (issue #66)
+    "CautiousAgent",
+    "CollaborativeAgent",
+    "AdaptiveAgent",
 ]

--- a/swarm/agents/behavioral.py
+++ b/swarm/agents/behavioral.py
@@ -1,0 +1,512 @@
+"""Behavioral agent types: Cautious, Collaborative, Adaptive.
+
+Three complementary behavioral archetypes for richer simulation scenarios:
+
+- CautiousAgent: Risk-averse; only accepts interactions with high expected quality.
+- CollaborativeAgent: Coalition-builder; preferentially partners with known good actors.
+- AdaptiveAgent: Learning agent; adjusts acceptance strategy from interaction history.
+"""
+
+from typing import Dict, List, Optional
+
+from swarm.agents.base import (
+    Action,
+    BaseAgent,
+    InteractionProposal,
+    Observation,
+    Role,
+)
+from swarm.models.agent import AgentType
+from swarm.models.interaction import InteractionType
+
+# ---------------------------------------------------------------------------
+# CautiousAgent
+# ---------------------------------------------------------------------------
+
+
+class CautiousAgent(BaseAgent):
+    """Agent that only accepts high-quality interactions.
+
+    Strategy:
+    - Applies a high acceptance threshold on expected interaction quality (p).
+    - Falls back to counterparty trust when no quality signal is present.
+    - Avoids proposing to agents with below-threshold trust scores.
+    - Models risk-averse behaviour in adversarial environments.
+
+    Config keys:
+        threshold (float, default 0.7): Minimum expected p to accept.
+        post_probability (float, default 0.2): Probability of posting each step.
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        threshold: float = 0.7,
+        roles: Optional[List[Role]] = None,
+        config: Optional[Dict] = None,
+        name: Optional[str] = None,
+        rng=None,
+    ):
+        super().__init__(
+            agent_id=agent_id,
+            agent_type=AgentType.CAUTIOUS,
+            roles=roles,
+            config=config or {},
+            name=name,
+            rng=rng,
+        )
+        self.threshold: float = self.config.get("threshold", threshold)
+        self.post_probability: float = self.config.get("post_probability", 0.2)
+
+    # ------------------------------------------------------------------
+    # Core decision methods
+    # ------------------------------------------------------------------
+
+    def act(self, observation: Observation) -> Action:
+        # 1. Handle pending proposals
+        if observation.pending_proposals:
+            proposal = observation.pending_proposals[0]
+            initiator_id = proposal.get("initiator_id", "")
+            expected_p = proposal.get("expected_p", None)
+            if self._is_acceptable(initiator_id, expected_p):
+                return self.create_accept_action(proposal["proposal_id"])
+            return self.create_reject_action(proposal["proposal_id"])
+
+        # 2. Handle bid decisions cautiously (accept only low bids from trusted bidders)
+        if observation.pending_bid_decisions:
+            return self._handle_bids(observation)
+
+        # 3. Work on active tasks
+        if observation.active_tasks:
+            task = observation.active_tasks[0]
+            if task.get("status") == "in_progress":
+                return self.create_submit_output_action(
+                    task["task_id"], f"Careful output for {task['task_id'][:8]}"
+                )
+
+        # 4. Claim easy tasks only
+        if observation.can_claim_task and observation.available_tasks:
+            safe_tasks = [
+                t
+                for t in observation.available_tasks
+                if t.get("difficulty", "hard") in ("trivial", "easy")
+            ]
+            if safe_tasks:
+                return self.create_claim_task_action(safe_tasks[0]["task_id"])
+
+        # 5. Propose to high-trust agents
+        if observation.can_interact and observation.visible_agents:
+            action = self._propose_to_trusted(observation)
+            if action:
+                return action
+
+        # 6. Post occasionally
+        if observation.can_post and self._rng.random() < self.post_probability:
+            return self.create_post_action("Sharing a carefully verified observation.")
+
+        # 7. Upvote quality content
+        if observation.can_vote and observation.visible_posts:
+            post = self._rng.choice(observation.visible_posts)
+            direction = 1 if post.get("net_votes", 0) >= 0 else -1
+            return self.create_vote_action(post.get("post_id", ""), direction)
+
+        return self.create_noop_action()
+
+    def accept_interaction(
+        self, proposal: InteractionProposal, observation: Observation
+    ) -> bool:
+        expected_p = proposal.metadata.get("expected_p") if proposal.metadata else None
+        return self._is_acceptable(proposal.initiator_id, expected_p)
+
+    def propose_interaction(
+        self, observation: Observation, counterparty_id: str
+    ) -> Optional[InteractionProposal]:
+        if not self._is_acceptable(counterparty_id):
+            return None
+        return InteractionProposal(
+            initiator_id=self.agent_id,
+            counterparty_id=counterparty_id,
+            interaction_type=InteractionType.COLLABORATION,
+            content="Proposing a careful, quality-focused collaboration.",
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _is_acceptable(
+        self, agent_id: str, expected_p: Optional[float] = None
+    ) -> bool:
+        """Return True only if the quality signal or trust meets our threshold."""
+        if expected_p is not None:
+            return bool(expected_p >= self.threshold)
+        # Fall back to trust-based gating
+        trust = self.compute_counterparty_trust(agent_id)
+        return bool(trust >= self.threshold)
+
+    def _propose_to_trusted(self, observation: Observation) -> Optional[Action]:
+        """Propose only to agents whose trust meets the threshold."""
+        candidates = [
+            (a.get("agent_id", ""), self.compute_counterparty_trust(a.get("agent_id", "")))
+            for a in observation.visible_agents
+            if a.get("agent_id", "") != self.agent_id
+        ]
+        qualified = [(aid, t) for aid, t in candidates if t >= self.threshold]
+        if not qualified:
+            return None
+        best_id = max(qualified, key=lambda x: x[1])[0]
+        return self.create_propose_action(
+            counterparty_id=best_id,
+            interaction_type=InteractionType.COLLABORATION,
+            content="I'd like to collaborate — your track record looks solid.",
+        )
+
+    def _handle_bids(self, observation: Observation) -> Action:
+        bids = observation.pending_bid_decisions
+        if not bids:
+            return self.create_noop_action()
+        # Accept the cheapest bid from a trusted bidder; otherwise skip.
+        trusted_bids = [
+            b
+            for b in bids
+            if self.compute_counterparty_trust(b.get("bidder_id", "")) >= self.threshold
+        ]
+        pool = trusted_bids if trusted_bids else bids  # fall back if no trusted bids
+        best = min(pool, key=lambda b: b.get("bid_amount", float("inf")))
+        return self.create_accept_bid_action(
+            bounty_id=best["bounty_id"], bid_id=best["bid_id"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# CollaborativeAgent
+# ---------------------------------------------------------------------------
+
+
+class CollaborativeAgent(BaseAgent):
+    """Agent that builds coalitions with known good actors.
+
+    Strategy:
+    - Maintains a running trust score per counterparty (via BaseAgent EMA).
+    - Preferentially proposes to and accepts from the highest-trust agents.
+    - Extends trust to neutral/unknown agents up to a configurable limit.
+    - Models cooperative coalition-formation dynamics.
+
+    Config keys:
+        min_trust (float, default 0.45): Minimum trust to accept from strangers.
+        coalition_size (int, default 5): Max preferred coalition partners.
+        post_probability (float, default 0.3): Probability of posting.
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        roles: Optional[List[Role]] = None,
+        config: Optional[Dict] = None,
+        name: Optional[str] = None,
+        rng=None,
+    ):
+        super().__init__(
+            agent_id=agent_id,
+            agent_type=AgentType.COLLABORATIVE,
+            roles=roles,
+            config=config or {},
+            name=name,
+            rng=rng,
+        )
+        self.min_trust: float = self.config.get("min_trust", 0.45)
+        self.coalition_size: int = self.config.get("coalition_size", 5)
+        self.post_probability: float = self.config.get("post_probability", 0.3)
+
+        # Preferred coalition set: {agent_id}
+        self._coalition: set = set()
+
+    # ------------------------------------------------------------------
+    # Core decision methods
+    # ------------------------------------------------------------------
+
+    def act(self, observation: Observation) -> Action:
+        # 1. Handle pending proposals — accept from coalition and trusted agents
+        if observation.pending_proposals:
+            proposal = observation.pending_proposals[0]
+            initiator_id = proposal.get("initiator_id", "")
+            if self._should_accept(initiator_id):
+                return self.create_accept_action(proposal["proposal_id"])
+            return self.create_reject_action(proposal["proposal_id"])
+
+        # 2. Work on active tasks
+        if observation.active_tasks:
+            task = observation.active_tasks[0]
+            if task.get("status") == "in_progress":
+                return self.create_submit_output_action(
+                    task["task_id"],
+                    f"Collaborative output for {task['task_id'][:8]}",
+                )
+
+        # 3. Claim tasks
+        if observation.can_claim_task and observation.available_tasks:
+            return self.create_claim_task_action(
+                observation.available_tasks[0]["task_id"]
+            )
+
+        # 4. Propose to coalition members or build new relationships
+        if observation.can_interact and observation.visible_agents:
+            action = self._propose_interaction(observation)
+            if action:
+                return action
+
+        # 5. Post to signal cooperation
+        if observation.can_post and self._rng.random() < self.post_probability:
+            return self.create_post_action(
+                "Open to collaboration — looking for reliable partners."
+            )
+
+        # 6. Vote on quality posts
+        if observation.can_vote and observation.visible_posts:
+            post = self._rng.choice(observation.visible_posts)
+            direction = 1 if post.get("net_votes", 0) >= 0 else -1
+            return self.create_vote_action(post.get("post_id", ""), direction)
+
+        return self.create_noop_action()
+
+    def accept_interaction(
+        self, proposal: InteractionProposal, observation: Observation
+    ) -> bool:
+        return self._should_accept(proposal.initiator_id)
+
+    def propose_interaction(
+        self, observation: Observation, counterparty_id: str
+    ) -> Optional[InteractionProposal]:
+        if not self._should_accept(counterparty_id):
+            return None
+        return InteractionProposal(
+            initiator_id=self.agent_id,
+            counterparty_id=counterparty_id,
+            interaction_type=InteractionType.COLLABORATION,
+            content="Join our coalition — better outcomes together.",
+        )
+
+    def update_from_outcome(self, interaction, payoff: float) -> None:
+        super().update_from_outcome(interaction, payoff)
+        # Promote high-quality partners into the coalition
+        counterparty = (
+            interaction.counterparty
+            if interaction.initiator == self.agent_id
+            else interaction.initiator
+        )
+        trust = self.compute_counterparty_trust(counterparty)
+        if trust >= 0.65 and len(self._coalition) < self.coalition_size:
+            self._coalition.add(counterparty)
+        elif trust < 0.4:
+            self._coalition.discard(counterparty)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _should_accept(self, agent_id: str) -> bool:
+        """Accept coalition members and sufficiently trusted strangers."""
+        if agent_id in self._coalition:
+            return True
+        trust = self.compute_counterparty_trust(agent_id)
+        return bool(trust >= self.min_trust)
+
+    def _propose_interaction(self, observation: Observation) -> Optional[Action]:
+        """Propose to the highest-trust visible agent, coalition members first."""
+        candidates: List[tuple] = []
+        for agent in observation.visible_agents:
+            aid = agent.get("agent_id", "")
+            if aid == self.agent_id:
+                continue
+            trust = self.compute_counterparty_trust(aid)
+            in_coalition = aid in self._coalition
+            candidates.append((aid, trust, in_coalition))
+
+        if not candidates:
+            return None
+
+        # Coalition members first, then highest trust
+        candidates.sort(key=lambda x: (x[2], x[1]), reverse=True)
+        best_id = candidates[0][0]
+
+        return self.create_propose_action(
+            counterparty_id=best_id,
+            interaction_type=InteractionType.COLLABORATION,
+            content="Coalition collaboration proposal.",
+        )
+
+
+# ---------------------------------------------------------------------------
+# AdaptiveAgent
+# ---------------------------------------------------------------------------
+
+
+class AdaptiveAgent(BaseAgent):
+    """Agent that learns from outcomes and adapts its acceptance strategy.
+
+    Strategy:
+    - Tracks a rolling window of recent interaction outcomes.
+    - Adjusts acceptance threshold up (more cautious) when recent payoffs are low
+      and down (more open) when payoffs are consistently high.
+    - Explores new counterparties occasionally to avoid local optima.
+    - Models reinforcement-learning / evolutionary dynamics.
+
+    Config keys:
+        initial_threshold (float, default 0.5): Starting acceptance threshold.
+        min_threshold (float, default 0.3): Floor for threshold adaptation.
+        max_threshold (float, default 0.8): Ceiling for threshold adaptation.
+        window_size (int, default 20): Rolling window for outcome tracking.
+        adapt_rate (float, default 0.05): Step size for threshold updates.
+        explore_probability (float, default 0.1): Prob of accepting a stranger.
+        post_probability (float, default 0.25): Probability of posting.
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        roles: Optional[List[Role]] = None,
+        config: Optional[Dict] = None,
+        name: Optional[str] = None,
+        rng=None,
+    ):
+        super().__init__(
+            agent_id=agent_id,
+            agent_type=AgentType.ADAPTIVE,
+            roles=roles,
+            config=config or {},
+            name=name,
+            rng=rng,
+        )
+        self.threshold: float = self.config.get("initial_threshold", 0.5)
+        self.min_threshold: float = self.config.get("min_threshold", 0.3)
+        self.max_threshold: float = self.config.get("max_threshold", 0.8)
+        self.window_size: int = self.config.get("window_size", 20)
+        self.adapt_rate: float = self.config.get("adapt_rate", 0.05)
+        self.explore_probability: float = self.config.get("explore_probability", 0.1)
+        self.post_probability: float = self.config.get("post_probability", 0.25)
+
+        # Rolling payoff window for adaptation
+        self._recent_payoffs: List[float] = []
+
+    # ------------------------------------------------------------------
+    # Core decision methods
+    # ------------------------------------------------------------------
+
+    def act(self, observation: Observation) -> Action:
+        # 1. Handle pending proposals with adaptive threshold
+        if observation.pending_proposals:
+            proposal = observation.pending_proposals[0]
+            initiator_id = proposal.get("initiator_id", "")
+            if self._is_acceptable(initiator_id):
+                return self.create_accept_action(proposal["proposal_id"])
+            return self.create_reject_action(proposal["proposal_id"])
+
+        # 2. Work on active tasks
+        if observation.active_tasks:
+            task = observation.active_tasks[0]
+            if task.get("status") == "in_progress":
+                return self.create_submit_output_action(
+                    task["task_id"],
+                    f"Adaptive output for {task['task_id'][:8]}",
+                )
+
+        # 3. Claim tasks
+        if observation.can_claim_task and observation.available_tasks:
+            return self.create_claim_task_action(
+                observation.available_tasks[0]["task_id"]
+            )
+
+        # 4. Propose interactions — explore or exploit
+        if observation.can_interact and observation.visible_agents:
+            action = self._propose_interaction(observation)
+            if action:
+                return action
+
+        # 5. Post occasionally
+        if observation.can_post and self._rng.random() < self.post_probability:
+            return self.create_post_action(
+                f"Adapting strategy. Current threshold: {self.threshold:.2f}"
+            )
+
+        # 6. Vote
+        if observation.can_vote and observation.visible_posts:
+            post = self._rng.choice(observation.visible_posts)
+            direction = 1 if post.get("net_votes", 0) >= 0 else -1
+            return self.create_vote_action(post.get("post_id", ""), direction)
+
+        return self.create_noop_action()
+
+    def accept_interaction(
+        self, proposal: InteractionProposal, observation: Observation
+    ) -> bool:
+        return self._is_acceptable(proposal.initiator_id)
+
+    def propose_interaction(
+        self, observation: Observation, counterparty_id: str
+    ) -> Optional[InteractionProposal]:
+        if not self._is_acceptable(counterparty_id):
+            return None
+        return InteractionProposal(
+            initiator_id=self.agent_id,
+            counterparty_id=counterparty_id,
+            interaction_type=InteractionType.COLLABORATION,
+            content=f"Proposal at adapted threshold {self.threshold:.2f}.",
+        )
+
+    def update_from_outcome(self, interaction, payoff: float) -> None:
+        super().update_from_outcome(interaction, payoff)
+        # Record payoff and adapt threshold
+        self._recent_payoffs.append(payoff)
+        if len(self._recent_payoffs) > self.window_size:
+            self._recent_payoffs.pop(0)
+        self._adapt_threshold()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _adapt_threshold(self) -> None:
+        """Adjust threshold based on recent payoff performance."""
+        if not self._recent_payoffs:
+            return
+        avg = sum(self._recent_payoffs) / len(self._recent_payoffs)
+        if avg > 0.5:
+            # Doing well — can afford to open up slightly
+            self.threshold = max(self.min_threshold, self.threshold - self.adapt_rate)
+        else:
+            # Poor outcomes — tighten standards
+            self.threshold = min(self.max_threshold, self.threshold + self.adapt_rate)
+
+    def _is_acceptable(self, agent_id: str) -> bool:
+        """Accept based on adaptive threshold, with occasional exploration."""
+        # Exploration: accept a stranger with small probability
+        if self._rng.random() < self.explore_probability:
+            return True
+        trust = self.compute_counterparty_trust(agent_id)
+        return bool(trust >= self.threshold)
+
+    def _propose_interaction(self, observation: Observation) -> Optional[Action]:
+        """Exploit best known partners or explore a random candidate."""
+        candidates = [
+            (a.get("agent_id", ""), self.compute_counterparty_trust(a.get("agent_id", "")))
+            for a in observation.visible_agents
+            if a.get("agent_id", "") != self.agent_id
+        ]
+        if not candidates:
+            return None
+
+        # Exploit: propose to highest-trust agent above threshold
+        above_threshold = [(aid, t) for aid, t in candidates if t >= self.threshold]
+        if above_threshold:
+            best_id = max(above_threshold, key=lambda x: x[1])[0]
+        elif self._rng.random() < self.explore_probability:
+            # Explore: pick a random unknown candidate
+            best_id = self._rng.choice(candidates)[0]
+        else:
+            return None
+
+        return self.create_propose_action(
+            counterparty_id=best_id,
+            interaction_type=InteractionType.COLLABORATION,
+            content=f"Adaptive collaboration proposal (threshold={self.threshold:.2f}).",
+        )

--- a/swarm/models/agent.py
+++ b/swarm/models/agent.py
@@ -17,6 +17,9 @@ class AgentType(Enum):
     CREWAI = "crewai"
     CODING = "coding"
     TIERRA = "tierra"
+    CAUTIOUS = "cautious"
+    COLLABORATIVE = "collaborative"
+    ADAPTIVE = "adaptive"
 
 
 class AgentStatus(Enum):


### PR DESCRIPTION
## Summary

Implements three new behavioral agent archetypes requested in #66.

- **`CautiousAgent`** (`AgentType.CAUTIOUS`) — risk-averse agent with a configurable high acceptance threshold (default 0.7). Rejects proposals unless `expected_p` (if present in the proposal dict) or counterparty trust meets the threshold. Only proposes to agents whose trust score qualifies.

- **`CollaborativeAgent`** (`AgentType.COLLABORATIVE`) — coalition-builder that maintains an explicit preferred-partner set. Promotes agents into the coalition when their EMA trust reaches ≥0.65, evicts them below 0.4. Proposals target coalition members first. Models cooperative coalition-formation dynamics.

- **`AdaptiveAgent`** (`AgentType.ADAPTIVE`) — learning agent that keeps a rolling payoff window and adjusts its acceptance threshold up (cautious) when recent average payoff ≤0.5 and down (open) when it is >0.5. Includes configurable exploration probability to avoid local optima. Models reinforcement-learning / evolutionary dynamics.

### Files changed

| File | Change |
|---|---|
| `swarm/agents/behavioral.py` | New file — all three agents |
| `swarm/agents/__init__.py` | Export `CautiousAgent`, `CollaborativeAgent`, `AdaptiveAgent` |
| `swarm/models/agent.py` | Add `CAUTIOUS`, `COLLABORATIVE`, `ADAPTIVE` to `AgentType` |
| `tests/test_agents.py` | 20 new tests (7 CautiousAgent, 6 CollaborativeAgent, 7 AdaptiveAgent) |
| `CHANGELOG.md` | Unreleased entry |

## Test plan

- [x] `python -m pytest tests/test_agents.py -v` — 42 tests pass (22 existing + 20 new)
- [x] `python -m pytest tests/ -v` — 4882 passed, 0 failed
- [x] `ruff check swarm/ tests/` — clean
- [x] `python -m mypy swarm/` — clean (pre-commit hook passed)

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)