### PR TITLE
fix: add p and v_hat bounds validation in interaction_proposed_event

### DIFF
--- a/swarm/models/events.py
+++ b/swarm/models/events.py
@@ -262,6 +262,10 @@ def interaction_proposed_event(
     step: Optional[int] = None,
 ) -> Event:
     """Create an interaction proposed event."""
+    if not (0.0 <= p <= 1.0):
+        raise ValueError(f"p must be in [0, 1], got {p}")
+    if not (-1.0 <= v_hat <= 1.0):
+        raise ValueError(f"v_hat must be in [-1, 1], got {v_hat}")
     return Event(
         event_type=EventType.INTERACTION_PROPOSED,
         interaction_id=interaction_id,


### PR DESCRIPTION
## Summary

- `interaction_proposed_event()` in `swarm/models/events.py` (lines 254-277) accepted `p` and `v_hat` without bounds validation, meaning replayed events from logs could silently contain `p` values outside `[0, 1]` — violating the project's core safety invariant
- Added explicit `ValueError` guards: `p` must be in `[0, 1]`, `v_hat` must be in `[-1, 1]`
- Added 7 tests in `TestInteractionProposedEventBounds` covering valid values, boundary values, and all four invalid-input error cases

Closes #263

## Test plan

- [x] `python -m pytest tests/test_event_log.py::TestInteractionProposedEventBounds -v` — 7/7 pass
- [x] `python -m pytest tests/ -v` — 4911 passed, 8 skipped
- [x] `ruff check swarm/models/events.py tests/test_event_log.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)