### PR TITLE
Allow AI crawlers to extract full content from documentation

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -16,6 +16,9 @@
   {% set author = page.meta.author if page and page.meta and page.meta.author else "SWARM Team" %}
   {% set keywords = page.meta.keywords if page and page.meta and page.meta.keywords else [] %}
 
+  <!-- AI crawl directives: allow full content extraction -->
+  <meta name="robots" content="max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
+
   <!-- Canonical URL -->
   <link rel="canonical" href="{{ url }}" />
 


### PR DESCRIPTION
## Summary

Add meta robots directives to allow AI crawlers and search engines to extract full content, images, and videos from documentation pages without snippet limitations.

## Changes

- Added `robots` meta tag with directives `max-snippet:-1, max-image-preview:large, max-video-preview:-1` to the documentation template
- This allows AI crawlers (like those used by LLMs and search engines) to access complete page content for indexing and training purposes

## Test Plan

N/A - This is a documentation metadata change with no code logic or tests affected.

## Related Issues

N/A

https://claude.ai/code/session_01JHAoEGgAnmn9eTbKj4Vkmt