### PR TITLE
Add resource negotiation game handler with multi-round bargaining

### DIFF
--- a/scenarios/resource_negotiation.yaml
+++ b/scenarios/resource_negotiation.yaml
@@ -1,0 +1,45 @@
+scenario_id: resource_negotiation
+description: >
+  Resource negotiation game where agents split heterogeneous resource
+  pools with private valuations.  Tests strategic bargaining, deadline
+  pressure, and win-win identification.
+motif: resource_negotiation
+
+agents:
+  - type: strategic_negotiator
+    count: 2
+
+  - type: fair_negotiator
+    count: 2
+
+  - type: greedy_negotiator
+    count: 2
+
+resource_negotiation:
+  enabled: true
+  min_resource_types: 3
+  max_resource_types: 4
+  min_quantity: 1
+  max_quantity: 5
+  min_valuation: 1.0
+  max_valuation: 10.0
+  guaranteed_rounds: 4
+  termination_probability: 0.3
+  no_deal_score: -0.5
+  max_rounds: 20
+
+simulation:
+  n_epochs: 5
+  steps_per_epoch: 10
+  seed: 42
+
+payoff:
+  s_plus: 2.0
+  s_minus: 1.0
+  h: 2.0
+  theta: 0.5
+
+governance:
+  transaction_tax_rate: 0.0
+  reputation_decay_rate: 1.0
+  circuit_breaker_enabled: false

--- a/swarm/agents/base.py
+++ b/swarm/agents/base.py
@@ -91,6 +91,9 @@ class ActionType(Enum):
     # Evolutionary game actions
     EVO_GAME_MOVE = "evo_game_move"
 
+    # Resource negotiation actions
+    RESOURCE_NEGOTIATE = "resource_negotiate"
+
     # Special actions
     NOOP = "noop"  # Do nothing this turn
 
@@ -242,6 +245,10 @@ class Observation:
     awm_last_result: Optional[Dict] = None  # Result of previous tool call
     awm_episode_active: bool = False  # Whether episode is in progress
     awm_steps_remaining: int = 0  # Steps left before max_steps
+
+    # Resource negotiation observations
+    resource_negotiation_games: List[Dict] = field(default_factory=list)  # Active games
+    resource_negotiation_results: List[Dict] = field(default_factory=list)  # Completed games
 
 
 @dataclass

--- a/swarm/agents/base.py
+++ b/swarm/agents/base.py
@@ -91,6 +91,9 @@ class ActionType(Enum):
     # Evolutionary game actions
     EVO_GAME_MOVE = "evo_game_move"
 
+    # Resource negotiation actions
+    RESOURCE_NEGOTIATE = "resource_negotiate"
+
     # Special actions
     NOOP = "noop"  # Do nothing this turn
 
@@ -246,6 +249,10 @@ class Observation:
     # Artifact layer observations (emergent tool chaining)
     available_artifacts: List[Dict] = field(default_factory=list)  # Consumable artifacts
     artifact_pressure: Dict[str, float] = field(default_factory=dict)  # Unmet demand by kind
+
+    # Resource negotiation observations
+    resource_negotiation_games: List[Dict] = field(default_factory=list)  # Active games
+    resource_negotiation_results: List[Dict] = field(default_factory=list)  # Completed games
 
 
 @dataclass

--- a/swarm/agents/negotiation_agent.py
+++ b/swarm/agents/negotiation_agent.py
@@ -1,0 +1,491 @@
+"""Negotiation agent strategies for resource negotiation games.
+
+Provides several agent types that play the resource negotiation game
+with different strategies:
+
+- ``FairNegotiator``: proposes even splits, accepts reasonable deals
+- ``GreedyNegotiator``: claims most value, concedes under deadline pressure
+- ``StrategicNegotiator``: reads opponent proposals to infer valuations,
+  proposes mutually-beneficial splits, tightens acceptance as deadline nears
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from swarm.agents.base import (
+    Action,
+    ActionType,
+    BaseAgent,
+    InteractionProposal,
+    Observation,
+    Role,
+)
+from swarm.models.agent import AgentType
+
+if TYPE_CHECKING:
+    from swarm.agents.memory_config import MemoryConfig
+
+
+class FairNegotiator(BaseAgent):
+    """Negotiation agent that proposes fair (even) splits.
+
+    Strategy: split resources roughly 50/50 by quantity, accept any
+    proposal that gives at least 30% of max possible score.
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        roles: Optional[List[Role]] = None,
+        config: Optional[Dict] = None,
+        name: Optional[str] = None,
+        memory_config: Optional["MemoryConfig"] = None,
+        rng=None,
+    ):
+        super().__init__(
+            agent_id=agent_id,
+            agent_type=AgentType.HONEST,
+            roles=roles,
+            config=config or {},
+            name=name,
+            memory_config=memory_config,
+            rng=rng,
+        )
+        self.accept_threshold = self.config.get("accept_threshold", 0.3)
+
+    def act(self, observation: Observation) -> Action:
+        game = self._get_active_game(observation)
+        if game is None:
+            return self.create_noop_action()
+
+        if not game.get("is_your_turn", False):
+            return self.create_noop_action()
+
+        pool = game["pool"]
+        valuations = game["your_valuations"]
+        last_proposal = game.get("last_proposal")
+
+        # Accept if the last proposal gives us enough value
+        if last_proposal and last_proposal.get("proposer_role") != game["role"]:
+            my_alloc = last_proposal["their_share"]  # we're the "their"
+            score = self._compute_score(my_alloc, valuations, pool)
+            if score >= self.accept_threshold:
+                return self._make_negotiate_action(
+                    game["game_id"], "accept", message="Fair enough, deal!"
+                )
+
+        # Propose an even split
+        my_share, their_share = self._even_split(pool)
+        return self._make_negotiate_action(
+            game["game_id"],
+            "propose",
+            proposal={"my_share": my_share, "their_share": their_share},
+            message="Let's split this fairly.",
+        )
+
+    def _even_split(self, pool: Dict[str, int]) -> tuple:
+        my_share = {}
+        their_share = {}
+        for name, qty in sorted(pool.items()):
+            half = qty // 2
+            my_share[name] = half
+            their_share[name] = qty - half
+        return my_share, their_share
+
+    def _compute_score(
+        self,
+        allocation: Dict[str, int],
+        valuations: Dict[str, float],
+        pool: Dict[str, int],
+    ) -> float:
+        raw = sum(valuations.get(r, 0) * allocation.get(r, 0) for r in pool)
+        max_s = sum(valuations.get(r, 0) * pool[r] for r in pool)
+        return raw / max_s if max_s > 0 else 0.0
+
+    def _get_active_game(self, observation: Observation) -> Optional[Dict]:
+        games = getattr(observation, "resource_negotiation_games", [])
+        for g in games:
+            if not g.get("game_over", True):
+                return g
+        return None
+
+    def _make_negotiate_action(
+        self,
+        game_id: str,
+        negotiate_action: str,
+        proposal: Optional[Dict] = None,
+        message: str = "",
+    ) -> Action:
+        meta: Dict[str, Any] = {
+            "game_id": game_id,
+            "negotiate_action": negotiate_action,
+            "message": message,
+        }
+        if proposal:
+            meta["proposal"] = proposal
+        return Action(
+            action_type=ActionType.RESOURCE_NEGOTIATE,
+            agent_id=self.agent_id,
+            metadata=meta,
+        )
+
+    def accept_interaction(
+        self, proposal: InteractionProposal, observation: Observation
+    ) -> bool:
+        return True
+
+    def propose_interaction(
+        self, observation: Observation, counterparty_id: str
+    ) -> Optional[InteractionProposal]:
+        return None
+
+
+class GreedyNegotiator(BaseAgent):
+    """Negotiation agent that maximizes own value aggressively.
+
+    Strategy: claim all high-value resources initially, slowly concede
+    as the deadline approaches to avoid the -0.5 no-deal penalty.
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        roles: Optional[List[Role]] = None,
+        config: Optional[Dict] = None,
+        name: Optional[str] = None,
+        memory_config: Optional["MemoryConfig"] = None,
+        rng=None,
+    ):
+        super().__init__(
+            agent_id=agent_id,
+            agent_type=AgentType.OPPORTUNISTIC,
+            roles=roles,
+            config=config or {},
+            name=name,
+            memory_config=memory_config,
+            rng=rng,
+        )
+
+    def act(self, observation: Observation) -> Action:
+        game = self._get_active_game(observation)
+        if game is None:
+            return self.create_noop_action()
+
+        if not game.get("is_your_turn", False):
+            return self.create_noop_action()
+
+        pool = game["pool"]
+        valuations = game["your_valuations"]
+        round_num = game.get("round_number", 1)
+        last_proposal = game.get("last_proposal")
+
+        # Under deadline pressure (round 5+), accept anything > 0
+        if round_num >= 5 and last_proposal:
+            proposer_role = last_proposal.get("proposer_role")
+            if proposer_role != game["role"]:
+                my_alloc = last_proposal["their_share"]
+                score = self._compute_score(my_alloc, valuations, pool)
+                if score > 0:
+                    return self._make_negotiate_action(
+                        game["game_id"], "accept",
+                        message="Fine, let's close this.",
+                    )
+
+        # In early rounds, accept only if ≥ 60% of max
+        if last_proposal and last_proposal.get("proposer_role") != game["role"]:
+            my_alloc = last_proposal["their_share"]
+            score = self._compute_score(my_alloc, valuations, pool)
+            threshold = max(0.2, 0.7 - 0.1 * round_num)
+            if score >= threshold:
+                return self._make_negotiate_action(
+                    game["game_id"], "accept",
+                    message="I can work with that.",
+                )
+
+        # Propose greedily: take all high-value resources
+        my_share, their_share = self._greedy_split(pool, valuations, round_num)
+        return self._make_negotiate_action(
+            game["game_id"],
+            "propose",
+            proposal={"my_share": my_share, "their_share": their_share},
+            message="Here's my offer.",
+        )
+
+    def _greedy_split(
+        self,
+        pool: Dict[str, int],
+        valuations: Dict[str, float],
+        round_num: int,
+    ) -> tuple:
+        """Split resources favoring high-value ones for self.
+
+        Concession factor increases with round number.
+        """
+        concession = min(0.5, 0.05 * round_num)
+        my_share = {}
+        their_share = {}
+
+        # Sort resources by our valuation (highest first)
+        sorted_resources = sorted(
+            pool.items(), key=lambda x: valuations.get(x[0], 0), reverse=True
+        )
+
+        for name, qty in sorted_resources:
+            # Take most of high-value resources, give away low-value ones
+            my_qty = max(0, int(qty * (1.0 - concession)))
+            my_share[name] = my_qty
+            their_share[name] = qty - my_qty
+
+        return my_share, their_share
+
+    def _compute_score(
+        self,
+        allocation: Dict[str, int],
+        valuations: Dict[str, float],
+        pool: Dict[str, int],
+    ) -> float:
+        raw = sum(valuations.get(r, 0) * allocation.get(r, 0) for r in pool)
+        max_s = sum(valuations.get(r, 0) * pool[r] for r in pool)
+        return raw / max_s if max_s > 0 else 0.0
+
+    def _get_active_game(self, observation: Observation) -> Optional[Dict]:
+        games = getattr(observation, "resource_negotiation_games", [])
+        for g in games:
+            if not g.get("game_over", True):
+                return g
+        return None
+
+    def _make_negotiate_action(
+        self,
+        game_id: str,
+        negotiate_action: str,
+        proposal: Optional[Dict] = None,
+        message: str = "",
+    ) -> Action:
+        meta: Dict[str, Any] = {
+            "game_id": game_id,
+            "negotiate_action": negotiate_action,
+            "message": message,
+        }
+        if proposal:
+            meta["proposal"] = proposal
+        return Action(
+            action_type=ActionType.RESOURCE_NEGOTIATE,
+            agent_id=self.agent_id,
+            metadata=meta,
+        )
+
+    def accept_interaction(
+        self, proposal: InteractionProposal, observation: Observation
+    ) -> bool:
+        return True
+
+    def propose_interaction(
+        self, observation: Observation, counterparty_id: str
+    ) -> Optional[InteractionProposal]:
+        return None
+
+
+class StrategicNegotiator(BaseAgent):
+    """Negotiation agent that infers opponent valuations from proposals.
+
+    Strategy:
+    - Round 1-2: anchor high, observe opponent's counter-proposals
+    - Round 3-4: propose win-win splits based on inferred valuations
+    - Round 5+: accept declining thresholds to avoid no-deal
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        roles: Optional[List[Role]] = None,
+        config: Optional[Dict] = None,
+        name: Optional[str] = None,
+        memory_config: Optional["MemoryConfig"] = None,
+        rng=None,
+    ):
+        super().__init__(
+            agent_id=agent_id,
+            agent_type=AgentType.HONEST,
+            roles=roles,
+            config=config or {},
+            name=name,
+            memory_config=memory_config,
+            rng=rng,
+        )
+
+    def act(self, observation: Observation) -> Action:
+        game = self._get_active_game(observation)
+        if game is None:
+            return self.create_noop_action()
+
+        if not game.get("is_your_turn", False):
+            return self.create_noop_action()
+
+        pool = game["pool"]
+        valuations = game["your_valuations"]
+        round_num = game.get("round_number", 1)
+        last_proposal = game.get("last_proposal")
+        history = game.get("history", [])
+
+        # Determine acceptance threshold based on round
+        if round_num >= 7:
+            threshold = 0.05
+        elif round_num >= 6:
+            threshold = 0.25
+        elif round_num >= 5:
+            threshold = 0.40
+        else:
+            threshold = 0.60
+
+        # Check if we should accept the current proposal
+        if last_proposal and last_proposal.get("proposer_role") != game["role"]:
+            my_alloc = last_proposal["their_share"]
+            score = self._compute_score(my_alloc, valuations, pool)
+            if score >= threshold:
+                return self._make_negotiate_action(
+                    game["game_id"], "accept",
+                    message="This works for both of us.",
+                )
+
+        # Infer what opponent values from their proposals
+        opponent_preferences = self._infer_opponent_preferences(
+            history, game["role"], pool
+        )
+
+        # Build a strategic proposal
+        my_share, their_share = self._strategic_split(
+            pool, valuations, opponent_preferences, round_num
+        )
+        return self._make_negotiate_action(
+            game["game_id"],
+            "propose",
+            proposal={"my_share": my_share, "their_share": their_share},
+            message="I think this works well for both of us.",
+        )
+
+    def _infer_opponent_preferences(
+        self,
+        history: List[Dict],
+        my_role: str,
+        pool: Dict[str, int],
+    ) -> Dict[str, float]:
+        """Infer relative opponent preferences from their proposals.
+
+        Returns a dict mapping resource_name → inferred preference weight
+        (higher means opponent values it more).
+        """
+        preferences: Dict[str, float] = dict.fromkeys(pool, 1.0)
+
+        for turn in history:
+            # Look at opponent's proposals
+            if turn["role"] == my_role:
+                continue
+            if turn["action"] != "propose" or turn.get("proposal") is None:
+                continue
+
+            prop = turn["proposal"]
+            # The opponent's "my_share" is what they want
+            their_desired = prop["my_share"]
+            for name, qty in their_desired.items():
+                total = pool.get(name, 1)
+                if total > 0:
+                    # Higher fraction claimed → higher preference
+                    preferences[name] += qty / total
+
+        return preferences
+
+    def _strategic_split(
+        self,
+        pool: Dict[str, int],
+        my_valuations: Dict[str, float],
+        opponent_preferences: Dict[str, float],
+        round_num: int,
+    ) -> tuple:
+        """Build a split that gives opponent what they seem to want
+        while keeping what we value most.
+        """
+        my_share = {}
+        their_share = {}
+
+        # Compute a "trade advantage" score for each resource:
+        # high advantage = we value it much more than opponent seems to
+        trade_scores = {}
+        for name, _qty in pool.items():
+            my_val = my_valuations.get(name, 0)
+            opp_pref = opponent_preferences.get(name, 1.0)
+            # Higher ratio = we want it more relative to them
+            trade_scores[name] = my_val / max(opp_pref, 0.01)
+
+        # Sort by trade advantage (we keep the highest advantage resources)
+        sorted_resources = sorted(
+            pool.items(), key=lambda x: trade_scores.get(x[0], 0), reverse=True
+        )
+
+        # Generosity increases with round number
+        generosity = min(0.5, 0.05 * round_num)
+
+        for name, qty in sorted_resources:
+            advantage = trade_scores.get(name, 1.0)
+            if advantage > 1.5:
+                # We want it more — take most
+                my_qty = max(0, int(qty * (0.8 - generosity)))
+            elif advantage < 0.7:
+                # They want it more — give most to them
+                my_qty = max(0, int(qty * (0.2 + generosity * 0.5)))
+            else:
+                # Similar preference — split evenly
+                my_qty = qty // 2
+
+            my_share[name] = min(my_qty, qty)
+            their_share[name] = qty - my_share[name]
+
+        return my_share, their_share
+
+    def _compute_score(
+        self,
+        allocation: Dict[str, int],
+        valuations: Dict[str, float],
+        pool: Dict[str, int],
+    ) -> float:
+        raw = sum(valuations.get(r, 0) * allocation.get(r, 0) for r in pool)
+        max_s = sum(valuations.get(r, 0) * pool[r] for r in pool)
+        return raw / max_s if max_s > 0 else 0.0
+
+    def _get_active_game(self, observation: Observation) -> Optional[Dict]:
+        games = getattr(observation, "resource_negotiation_games", [])
+        for g in games:
+            if not g.get("game_over", True):
+                return g
+        return None
+
+    def _make_negotiate_action(
+        self,
+        game_id: str,
+        negotiate_action: str,
+        proposal: Optional[Dict] = None,
+        message: str = "",
+    ) -> Action:
+        meta: Dict[str, Any] = {
+            "game_id": game_id,
+            "negotiate_action": negotiate_action,
+            "message": message,
+        }
+        if proposal:
+            meta["proposal"] = proposal
+        return Action(
+            action_type=ActionType.RESOURCE_NEGOTIATE,
+            agent_id=self.agent_id,
+            metadata=meta,
+        )
+
+    def accept_interaction(
+        self, proposal: InteractionProposal, observation: Observation
+    ) -> bool:
+        return True
+
+    def propose_interaction(
+        self, observation: Observation, counterparty_id: str
+    ) -> Optional[InteractionProposal]:
+        return None

--- a/swarm/agents/negotiation_agent.py
+++ b/swarm/agents/negotiation_agent.py
@@ -104,7 +104,7 @@ class FairNegotiator(BaseAgent):
         return raw / max_s if max_s > 0 else 0.0
 
     def _get_active_game(self, observation: Observation) -> Optional[Dict]:
-        games = getattr(observation, "resource_negotiation_games", [])
+        games: List[Dict] = getattr(observation, "resource_negotiation_games", [])
         for g in games:
             if not g.get("game_over", True):
                 return g
@@ -250,7 +250,7 @@ class GreedyNegotiator(BaseAgent):
         return raw / max_s if max_s > 0 else 0.0
 
     def _get_active_game(self, observation: Observation) -> Optional[Dict]:
-        games = getattr(observation, "resource_negotiation_games", [])
+        games: List[Dict] = getattr(observation, "resource_negotiation_games", [])
         for g in games:
             if not g.get("game_over", True):
                 return g
@@ -454,7 +454,7 @@ class StrategicNegotiator(BaseAgent):
         return raw / max_s if max_s > 0 else 0.0
 
     def _get_active_game(self, observation: Observation) -> Optional[Dict]:
-        games = getattr(observation, "resource_negotiation_games", [])
+        games: List[Dict] = getattr(observation, "resource_negotiation_games", [])
         for g in games:
             if not g.get("game_over", True):
                 return g

--- a/swarm/core/handler_factory.py
+++ b/swarm/core/handler_factory.py
@@ -50,6 +50,7 @@ class HandlerSet:
         self.rivals_handler: Optional[Any] = None
         self.awm_handler: Optional[Any] = None
         self.evo_game_handler: Optional[Any] = None
+        self.resource_negotiation_handler: Optional[Any] = None
         self.tierra_handler: Optional[Any] = None
         self.boundary_handler: Optional[BoundaryHandler] = None
         self.feed_handler: Optional[FeedHandler] = None
@@ -174,6 +175,27 @@ def build_handlers(
             rng=rng,
         )
         hs.registry.register(hs.evo_game_handler)
+
+    # -- Resource negotiation (lazy import) --
+    if config.resource_negotiation_config is not None:
+        from swarm.core.resource_negotiation_handler import (
+            ResourceNegotiationConfig,
+            ResourceNegotiationHandler,
+        )
+
+        rn_cfg = config.resource_negotiation_config
+        if not isinstance(rn_cfg, ResourceNegotiationConfig):
+            rn_cfg = (
+                ResourceNegotiationConfig(**rn_cfg)
+                if isinstance(rn_cfg, dict)
+                else rn_cfg
+            )
+        hs.resource_negotiation_handler = ResourceNegotiationHandler(
+            config=rn_cfg,
+            event_bus=event_bus,
+            rng=rng,
+        )
+        hs.registry.register(hs.resource_negotiation_handler)
 
     # -- Tierra (lazy import) --
     if config.tierra_config is not None:

--- a/swarm/core/orchestrator.py
+++ b/swarm/core/orchestrator.py
@@ -161,6 +161,9 @@ class OrchestratorConfig(BaseModel):
     # Evolutionary game (gamescape) configuration
     evo_game_config: Optional[Any] = None
 
+    # Resource negotiation game configuration
+    resource_negotiation_config: Optional[Any] = None
+
     # Tierra (artificial life) configuration
     tierra_config: Optional[Any] = None
 
@@ -438,6 +441,7 @@ class Orchestrator:
         self._rivals_handler = self._handlers.rivals_handler
         self._awm_handler = self._handlers.awm_handler
         self._evo_game_handler = self._handlers.evo_game_handler
+        self._resource_negotiation_handler = self._handlers.resource_negotiation_handler
         self._tierra_handler = self._handlers.tierra_handler
         self._boundary_handler = self._handlers.boundary_handler
         self._feed_handler = self._handlers.feed_handler

--- a/swarm/core/resource_negotiation_handler.py
+++ b/swarm/core/resource_negotiation_handler.py
@@ -1,0 +1,742 @@
+"""Resource negotiation game handler.
+
+Two-player alternating-offers game where agents split a pool of
+heterogeneous resources with private valuations.  The handler manages
+multiple concurrent games, enforces turn order, implements the
+stochastic deadline, and computes normalized scores.
+
+Game flow per round:
+    Player A proposes/accepts/rejects → Player B proposes/accepts/rejects
+
+Scoring:
+    deal:    score = sum(val_i * qty_i) / max_possible, in [0, 1]
+    no deal: both players score -0.5
+
+Deadline:
+    Rounds 1-4 guaranteed.  From round 5 onward, 30% chance of
+    termination after each round (checked at round end).
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, FrozenSet, List, Optional, Tuple
+
+from swarm.core.handler import Handler, HandlerActionResult
+from swarm.core.proxy import ProxyObservables
+from swarm.logging.event_bus import EventBus
+from swarm.models.interaction import InteractionType
+
+logger = logging.getLogger(__name__)
+
+# ── Enums & data classes ──────────────────────────────────────────────
+
+
+class NegotiateAction(Enum):
+    """Actions a player can take on their turn."""
+
+    PROPOSE = "propose"
+    ACCEPT = "accept"
+    REJECT = "reject"
+
+
+@dataclass
+class ResourcePool:
+    """Named quantities of resources to divide."""
+
+    resources: Dict[str, int]  # resource_name → quantity
+
+    def total_items(self) -> int:
+        return sum(self.resources.values())
+
+    def names(self) -> List[str]:
+        return sorted(self.resources.keys())
+
+    def to_str(self) -> str:
+        parts = [f"{qty} {name}" for name, qty in sorted(self.resources.items())]
+        return ", ".join(parts)
+
+
+@dataclass
+class Proposal:
+    """A proposed split of the resource pool."""
+
+    my_share: Dict[str, int]
+    their_share: Dict[str, int]
+
+    def is_valid(self, pool: ResourcePool) -> bool:
+        """Check my_share + their_share == pool for every resource."""
+        for name, total in pool.resources.items():
+            mine = self.my_share.get(name, 0)
+            theirs = self.their_share.get(name, 0)
+            if mine < 0 or theirs < 0:
+                return False
+            if mine + theirs != total:
+                return False
+        # Ensure no extra resource names
+        valid_names = set(pool.resources.keys())
+        if set(self.my_share.keys()) - valid_names:
+            return False
+        if set(self.their_share.keys()) - valid_names:
+            return False
+        return True
+
+
+@dataclass
+class NegotiationTurn:
+    """Record of one player's action in a round."""
+
+    round_number: int
+    player_id: str
+    role: str  # "A" or "B"
+    action: NegotiateAction
+    proposal: Optional[Proposal] = None
+    message: str = ""
+
+
+@dataclass
+class GameResult:
+    """Outcome of a completed game."""
+
+    game_id: str
+    player_a_id: str
+    player_b_id: str
+    deal_reached: bool
+    rounds_played: int
+    score_a: float  # normalized 0–1 or -0.5
+    score_b: float
+    final_proposal: Optional[Proposal] = None
+    accepted_by: str = ""
+
+
+@dataclass
+class NegotiationGame:
+    """State of a single two-player resource negotiation game."""
+
+    game_id: str
+    player_a_id: str
+    player_b_id: str
+    pool: ResourcePool
+    valuations_a: Dict[str, float]
+    valuations_b: Dict[str, float]
+    round_number: int = 1
+    history: List[NegotiationTurn] = field(default_factory=list)
+    last_proposal: Optional[Proposal] = None
+    last_proposer: Optional[str] = None
+    deal_reached: bool = False
+    game_over: bool = False
+    result: Optional[GameResult] = None
+
+    # Turn tracking within a round
+    a_acted_this_round: bool = False
+    b_acted_this_round: bool = False
+
+    def whose_turn(self) -> Optional[str]:
+        """Return the player_id whose turn it is, or None if round is done."""
+        if self.game_over:
+            return None
+        if not self.a_acted_this_round:
+            return self.player_a_id
+        if not self.b_acted_this_round:
+            return self.player_b_id
+        return None  # round complete
+
+    def role_of(self, player_id: str) -> str:
+        if player_id == self.player_a_id:
+            return "A"
+        if player_id == self.player_b_id:
+            return "B"
+        raise ValueError(f"{player_id} is not in game {self.game_id}")
+
+    def max_score(self, player_id: str) -> float:
+        """Maximum possible score if the player gets everything."""
+        vals = (
+            self.valuations_a
+            if player_id == self.player_a_id
+            else self.valuations_b
+        )
+        return sum(
+            vals.get(name, 0.0) * qty
+            for name, qty in self.pool.resources.items()
+        )
+
+    def compute_score(
+        self, player_id: str, allocation: Dict[str, int]
+    ) -> float:
+        """Normalized score for a player given their allocation."""
+        vals = (
+            self.valuations_a
+            if player_id == self.player_a_id
+            else self.valuations_b
+        )
+        raw = sum(vals.get(name, 0.0) * qty for name, qty in allocation.items())
+        max_s = self.max_score(player_id)
+        if max_s <= 0:
+            return 0.0
+        return raw / max_s
+
+    def to_observation(self, player_id: str) -> Dict[str, Any]:
+        """Build an observation dict for the given player."""
+        role = self.role_of(player_id)
+        vals = (
+            self.valuations_a if role == "A" else self.valuations_b
+        )
+        val_str = ", ".join(
+            f"{name}={v}" for name, v in sorted(vals.items())
+        )
+        return {
+            "game_id": self.game_id,
+            "role": role,
+            "pool": dict(self.pool.resources),
+            "pool_str": self.pool.to_str(),
+            "your_valuations": dict(vals),
+            "val_str": val_str,
+            "round_number": self.round_number,
+            "is_your_turn": self.whose_turn() == player_id,
+            "last_proposal": (
+                {
+                    "proposer_role": self.role_of(self.last_proposer)
+                    if self.last_proposer
+                    else None,
+                    "my_share": dict(self.last_proposal.my_share),
+                    "their_share": dict(self.last_proposal.their_share),
+                }
+                if self.last_proposal
+                else None
+            ),
+            "history": [
+                {
+                    "round": t.round_number,
+                    "role": t.role,
+                    "action": t.action.value,
+                    "proposal": (
+                        {
+                            "my_share": dict(t.proposal.my_share),
+                            "their_share": dict(t.proposal.their_share),
+                        }
+                        if t.proposal
+                        else None
+                    ),
+                    "message": t.message,
+                }
+                for t in self.history
+            ],
+            "deal_reached": self.deal_reached,
+            "game_over": self.game_over,
+        }
+
+
+# ── Configuration ─────────────────────────────────────────────────────
+
+
+@dataclass
+class ResourceNegotiationConfig:
+    """Configuration for the resource negotiation handler."""
+
+    enabled: bool = True
+
+    # Number of resource types in each game
+    min_resource_types: int = 2
+    max_resource_types: int = 4
+
+    # Quantity range per resource
+    min_quantity: int = 1
+    max_quantity: int = 5
+
+    # Valuation range per resource per player
+    min_valuation: float = 1.0
+    max_valuation: float = 10.0
+
+    # Deadline parameters
+    guaranteed_rounds: int = 4
+    termination_probability: float = 0.3  # per round from round 5+
+
+    # No-deal penalty
+    no_deal_score: float = -0.5
+
+    # Max rounds (hard cap)
+    max_rounds: int = 20
+
+    # Resource names to use (if empty, generate generic names)
+    resource_names: List[str] = field(
+        default_factory=lambda: [
+            "apples", "bananas", "cherries", "dates", "elderberries",
+        ]
+    )
+
+    seed: Optional[int] = None
+
+
+# ── Handler ───────────────────────────────────────────────────────────
+
+
+class ResourceNegotiationHandler(Handler):
+    """Handler that manages multi-round resource negotiation games.
+
+    Each game pairs two agents who take turns proposing, accepting, or
+    rejecting splits of a shared resource pool.  The handler tracks game
+    state, enforces rules, and computes scores.
+    """
+
+    from swarm.agents.base import ActionType
+
+    _ACTION_TYPES: FrozenSet = frozenset({ActionType.RESOURCE_NEGOTIATE})
+
+    def __init__(
+        self,
+        *,
+        config: ResourceNegotiationConfig,
+        event_bus: EventBus,
+        rng: Optional[random.Random] = None,
+    ) -> None:
+        super().__init__(event_bus=event_bus)
+        self._config = config
+        self._rng = rng or random.Random(config.seed)
+
+        # Active games: game_id → NegotiationGame
+        self._games: Dict[str, NegotiationGame] = {}
+
+        # Player-to-game mapping: player_id → list of game_ids
+        self._player_games: Dict[str, List[str]] = {}
+
+        # Completed game results
+        self._results: List[GameResult] = []
+
+    @staticmethod
+    def handled_action_types() -> FrozenSet:
+        from swarm.agents.base import ActionType
+
+        return frozenset({ActionType.RESOURCE_NEGOTIATE})
+
+    # ── Game creation ─────────────────────────────────────────────
+
+    def create_game(
+        self,
+        player_a_id: str,
+        player_b_id: str,
+        pool: Optional[ResourcePool] = None,
+        valuations_a: Optional[Dict[str, float]] = None,
+        valuations_b: Optional[Dict[str, float]] = None,
+    ) -> NegotiationGame:
+        """Create a new negotiation game between two players.
+
+        If pool/valuations are not provided, they are randomly generated.
+        """
+        game_id = str(uuid.uuid4())[:8]
+        cfg = self._config
+
+        if pool is None:
+            n_types = self._rng.randint(
+                cfg.min_resource_types, cfg.max_resource_types
+            )
+            names = self._rng.sample(cfg.resource_names, min(n_types, len(cfg.resource_names)))
+            resources = {
+                name: self._rng.randint(cfg.min_quantity, cfg.max_quantity)
+                for name in names
+            }
+            pool = ResourcePool(resources=resources)
+
+        if valuations_a is None:
+            valuations_a = {
+                name: round(
+                    self._rng.uniform(cfg.min_valuation, cfg.max_valuation), 1
+                )
+                for name in pool.resources
+            }
+
+        if valuations_b is None:
+            valuations_b = {
+                name: round(
+                    self._rng.uniform(cfg.min_valuation, cfg.max_valuation), 1
+                )
+                for name in pool.resources
+            }
+
+        game = NegotiationGame(
+            game_id=game_id,
+            player_a_id=player_a_id,
+            player_b_id=player_b_id,
+            pool=pool,
+            valuations_a=valuations_a,
+            valuations_b=valuations_b,
+        )
+        self._games[game_id] = game
+        self._player_games.setdefault(player_a_id, []).append(game_id)
+        self._player_games.setdefault(player_b_id, []).append(game_id)
+
+        logger.info(
+            "Created negotiation game %s: %s vs %s, pool=%s",
+            game_id,
+            player_a_id,
+            player_b_id,
+            pool.to_str(),
+        )
+        return game
+
+    # ── Move processing ───────────────────────────────────────────
+
+    def process_move(
+        self,
+        game_id: str,
+        player_id: str,
+        action: NegotiateAction,
+        proposal: Optional[Proposal] = None,
+        message: str = "",
+    ) -> Tuple[bool, str]:
+        """Process a negotiation move. Returns (success, error_message)."""
+        game = self._games.get(game_id)
+        if game is None:
+            return False, f"Game {game_id} not found"
+
+        if game.game_over:
+            return False, "Game is already over"
+
+        if game.whose_turn() != player_id:
+            return False, f"Not {player_id}'s turn"
+
+        role = game.role_of(player_id)
+
+        # Validate action
+        if action == NegotiateAction.PROPOSE:
+            if proposal is None:
+                return False, "Proposal required for propose action"
+            if not proposal.is_valid(game.pool):
+                return False, "Invalid proposal: shares must sum to pool"
+
+        elif action == NegotiateAction.ACCEPT:
+            if game.last_proposal is None:
+                return False, "No proposal to accept"
+            if game.last_proposer == player_id:
+                return False, "Cannot accept your own proposal"
+
+        elif action == NegotiateAction.REJECT:
+            if game.last_proposal is None:
+                return False, "No proposal to reject"
+
+        # Record the turn
+        turn = NegotiationTurn(
+            round_number=game.round_number,
+            player_id=player_id,
+            role=role,
+            action=action,
+            proposal=proposal,
+            message=message,
+        )
+        game.history.append(turn)
+
+        # Mark player as having acted
+        if role == "A":
+            game.a_acted_this_round = True
+        else:
+            game.b_acted_this_round = True
+
+        # Process the action
+        if action == NegotiateAction.PROPOSE:
+            game.last_proposal = proposal
+            game.last_proposer = player_id
+
+        elif action == NegotiateAction.ACCEPT:
+            # Deal reached! Compute scores.
+            game.deal_reached = True
+            game.game_over = True
+            self._finalize_deal(game, player_id)
+
+        # After both players have acted, advance round
+        if not game.game_over and game.a_acted_this_round and game.b_acted_this_round:
+            self._advance_round(game)
+
+        return True, ""
+
+    def _finalize_deal(self, game: NegotiationGame, accepter_id: str) -> None:
+        """Finalize a deal after acceptance."""
+        proposer_id = game.last_proposer
+        assert proposer_id is not None
+        assert game.last_proposal is not None
+
+        prop = game.last_proposal
+
+        # The proposal's my_share/their_share is from the proposer's perspective
+        if proposer_id == game.player_a_id:
+            alloc_a = prop.my_share
+            alloc_b = prop.their_share
+        else:
+            alloc_a = prop.their_share
+            alloc_b = prop.my_share
+
+        score_a = game.compute_score(game.player_a_id, alloc_a)
+        score_b = game.compute_score(game.player_b_id, alloc_b)
+
+        result = GameResult(
+            game_id=game.game_id,
+            player_a_id=game.player_a_id,
+            player_b_id=game.player_b_id,
+            deal_reached=True,
+            rounds_played=game.round_number,
+            score_a=score_a,
+            score_b=score_b,
+            final_proposal=game.last_proposal,
+            accepted_by=accepter_id,
+        )
+        game.result = result
+        self._results.append(result)
+
+        logger.info(
+            "Game %s: deal reached in round %d. A=%.2f, B=%.2f",
+            game.game_id,
+            game.round_number,
+            score_a,
+            score_b,
+        )
+
+    def _advance_round(self, game: NegotiationGame) -> None:
+        """Advance to the next round, checking deadline."""
+        cfg = self._config
+
+        # Check stochastic termination from guaranteed_rounds+1 onward
+        if game.round_number >= cfg.guaranteed_rounds:
+            if self._rng.random() < cfg.termination_probability:
+                self._finalize_no_deal(game)
+                return
+
+        # Check hard cap
+        if game.round_number >= cfg.max_rounds:
+            self._finalize_no_deal(game)
+            return
+
+        # Advance
+        game.round_number += 1
+        game.a_acted_this_round = False
+        game.b_acted_this_round = False
+
+    def _finalize_no_deal(self, game: NegotiationGame) -> None:
+        """Finalize a game that ended without a deal."""
+        game.game_over = True
+        no_deal = self._config.no_deal_score
+
+        result = GameResult(
+            game_id=game.game_id,
+            player_a_id=game.player_a_id,
+            player_b_id=game.player_b_id,
+            deal_reached=False,
+            rounds_played=game.round_number,
+            score_a=no_deal,
+            score_b=no_deal,
+        )
+        game.result = result
+        self._results.append(result)
+
+        logger.info(
+            "Game %s: no deal after %d rounds. Both score %.2f",
+            game.game_id,
+            game.round_number,
+            no_deal,
+        )
+
+    # ── Handler interface ─────────────────────────────────────────
+
+    def handle_action(self, action: Any, state: Any) -> HandlerActionResult:
+        """Handle a RESOURCE_NEGOTIATE action.
+
+        Expected action metadata:
+            game_id: str — which game to act in
+            negotiate_action: str — "propose", "accept", or "reject"
+            proposal: Optional[Dict] — {"my_share": {...}, "their_share": {...}}
+            message: str — optional message to other player
+        """
+        agent_id = getattr(action, "agent_id", "")
+        metadata = getattr(action, "metadata", {}) or {}
+
+        game_id = metadata.get("game_id", "")
+        negotiate_action_str = metadata.get("negotiate_action", "")
+        message = metadata.get("message", "")
+
+        if not game_id:
+            return HandlerActionResult(
+                success=False,
+                metadata={"error": "no game_id in action metadata"},
+            )
+
+        try:
+            neg_action = NegotiateAction(negotiate_action_str)
+        except ValueError:
+            return HandlerActionResult(
+                success=False,
+                metadata={
+                    "error": f"invalid negotiate_action: {negotiate_action_str}"
+                },
+            )
+
+        # Parse proposal if present
+        proposal = None
+        prop_data = metadata.get("proposal")
+        if prop_data and isinstance(prop_data, dict):
+            proposal = Proposal(
+                my_share=prop_data.get("my_share", {}),
+                their_share=prop_data.get("their_share", {}),
+            )
+
+        success, error = self.process_move(
+            game_id=game_id,
+            player_id=agent_id,
+            action=neg_action,
+            proposal=proposal,
+            message=message,
+        )
+
+        if not success:
+            return HandlerActionResult(
+                success=False,
+                metadata={"error": error},
+            )
+
+        game = self._games[game_id]
+
+        # Generate observables based on game progress
+        observables = self._game_to_observables(game, agent_id)
+
+        # Determine counterparty
+        counterparty_id = (
+            game.player_b_id
+            if agent_id == game.player_a_id
+            else game.player_a_id
+        )
+
+        return HandlerActionResult(
+            success=True,
+            observables=observables,
+            initiator_id=agent_id,
+            counterparty_id=counterparty_id,
+            accepted=game.deal_reached,
+            interaction_type=InteractionType.COLLABORATION,
+            metadata={
+                "game": "resource_negotiation",
+                "game_id": game_id,
+                "action": neg_action.value,
+                "round": game.round_number,
+                "deal_reached": game.deal_reached,
+                "game_over": game.game_over,
+                "score_a": game.result.score_a if game.result else None,
+                "score_b": game.result.score_b if game.result else None,
+            },
+        )
+
+    def _game_to_observables(
+        self, game: NegotiationGame, agent_id: str
+    ) -> ProxyObservables:
+        """Generate proxy observables from game state."""
+        if game.result is not None:
+            score = (
+                game.result.score_a
+                if agent_id == game.player_a_id
+                else game.result.score_b
+            )
+            if game.deal_reached:
+                # Map score [0,1] → task_progress [-0.3, 0.8]
+                progress = -0.3 + 1.1 * max(0.0, score)
+                engagement = 0.5 * score
+            else:
+                # No deal → poor observables
+                progress = -0.5
+                engagement = -0.5
+        else:
+            # Game still in progress — neutral observables
+            progress = 0.0
+            engagement = 0.1
+
+        return ProxyObservables(
+            task_progress_delta=max(-1.0, min(1.0, progress)),
+            rework_count=0,
+            verifier_rejections=0,
+            tool_misuse_flags=0,
+            counterparty_engagement_delta=max(-1.0, min(1.0, engagement)),
+        )
+
+    # ── Observation building ──────────────────────────────────────
+
+    def build_observation_fields(
+        self, agent_id: str, state: Any
+    ) -> Dict[str, Any]:
+        """Return active games and completed results for this agent."""
+        game_ids = self._player_games.get(agent_id, [])
+
+        active_games = []
+        completed = []
+        for gid in game_ids:
+            game = self._games.get(gid)
+            if game is None:
+                continue
+            if game.game_over:
+                if game.result:
+                    completed.append({
+                        "game_id": game.game_id,
+                        "deal_reached": game.result.deal_reached,
+                        "your_score": (
+                            game.result.score_a
+                            if agent_id == game.player_a_id
+                            else game.result.score_b
+                        ),
+                        "rounds_played": game.result.rounds_played,
+                    })
+            else:
+                active_games.append(game.to_observation(agent_id))
+
+        return {
+            "resource_negotiation_games": active_games,
+            "resource_negotiation_results": completed,
+        }
+
+    # ── Epoch lifecycle ───────────────────────────────────────────
+
+    def on_epoch_start(self, state: Any) -> None:
+        """Auto-pair agents into games at epoch start if configured."""
+        # Games can be created externally or by the orchestrator.
+        # This hook is available for auto-pairing logic.
+        pass
+
+    def on_epoch_end(self, state: Any) -> None:
+        """Force-end any games that haven't concluded."""
+        for game in list(self._games.values()):
+            if not game.game_over:
+                self._finalize_no_deal(game)
+
+    def create_games_for_agents(
+        self, agent_ids: List[str]
+    ) -> List[NegotiationGame]:
+        """Create games by pairing agents round-robin.
+
+        Pairs agents [0,1], [2,3], etc. If odd number, last agent
+        gets no game this round.
+        """
+        self._rng.shuffle(agent_ids)
+        games = []
+        for i in range(0, len(agent_ids) - 1, 2):
+            game = self.create_game(agent_ids[i], agent_ids[i + 1])
+            games.append(game)
+        return games
+
+    # ── Accessors ─────────────────────────────────────────────────
+
+    @property
+    def games(self) -> Dict[str, NegotiationGame]:
+        return dict(self._games)
+
+    @property
+    def results(self) -> List[GameResult]:
+        return list(self._results)
+
+    def get_agent_games(self, agent_id: str) -> List[NegotiationGame]:
+        """Return all games (active + completed) for an agent."""
+        gids = self._player_games.get(agent_id, [])
+        return [self._games[gid] for gid in gids if gid in self._games]
+
+    def get_active_game(self, agent_id: str) -> Optional[NegotiationGame]:
+        """Return the first active game for an agent, or None."""
+        for gid in self._player_games.get(agent_id, []):
+            game = self._games.get(gid)
+            if game and not game.game_over:
+                return game
+        return None

--- a/swarm/scenarios/loader.py
+++ b/swarm/scenarios/loader.py
@@ -59,6 +59,11 @@ from swarm.agents.wiki_editor import (
     PointFarmerAgent,
     VandalAgent,
 )
+from swarm.agents.negotiation_agent import (
+    FairNegotiator,
+    GreedyNegotiator,
+    StrategicNegotiator,
+)
 from swarm.agents.work_regime_agent import WorkRegimeAgent
 from swarm.contracts.contract import (
     FairDivisionContract,
@@ -155,6 +160,10 @@ AGENT_TYPES: Dict[str, Type[BaseAgent]] = {
     "tierra": TierraAgent,
     # Work regime (policy-drifting workers under labor stress)
     "work_regime": WorkRegimeAgent,
+    # Resource negotiation agents
+    "fair_negotiator": FairNegotiator,
+    "greedy_negotiator": GreedyNegotiator,
+    "strategic_negotiator": StrategicNegotiator,
 }
 
 class _LazyLoader:
@@ -1098,6 +1107,26 @@ def parse_evo_game_config(data: Dict[str, Any]) -> Optional[Any]:
     return EvoGameConfig(**data)
 
 
+def parse_resource_negotiation_config(data: Dict[str, Any]) -> Optional[Any]:
+    """Parse resource_negotiation section from YAML.
+
+    Args:
+        data: The resource_negotiation section from YAML
+
+    Returns:
+        ResourceNegotiationConfig if enabled, None otherwise
+    """
+    if not data:
+        return None
+
+    if data.get("enabled") is False:
+        return None
+
+    from swarm.core.resource_negotiation_handler import ResourceNegotiationConfig
+
+    return ResourceNegotiationConfig(**data)
+
+
 def _expand_agent_specs(agent_specs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Expand agent specs honoring ``count``, yielding one dict per agent."""
     expanded: List[Dict[str, Any]] = []
@@ -1146,6 +1175,9 @@ def load_scenario(path: Path) -> ScenarioConfig:
     )
     contracts_config = parse_contracts_config(data.get("contracts", {}))
     evo_game_config = parse_evo_game_config(data.get("evo_game", {}))
+    resource_negotiation_config = parse_resource_negotiation_config(
+        data.get("resource_negotiation", {})
+    )
     tierra_config = parse_tierra_config(data.get("tierra", {}))
 
     # Parse simulation settings
@@ -1180,6 +1212,7 @@ def load_scenario(path: Path) -> ScenarioConfig:
         perturbation_config=perturbation_config,
         contracts_config=contracts_config,
         evo_game_config=evo_game_config,
+        resource_negotiation_config=resource_negotiation_config,
         tierra_config=tierra_config,
         dynamic_toxicity=data.get("dynamic_toxicity"),
         graph_memory_path=outputs_data.get("graph_memory_path"),
@@ -1605,6 +1638,13 @@ def build_orchestrator(scenario: ScenarioConfig) -> Orchestrator:
                 orchestrator._tierra_handler.register_genome(
                     agent.agent_id, agent.genome.to_dict()
                 )
+
+    # Create initial resource negotiation games if handler is present
+    if orchestrator._resource_negotiation_handler is not None:
+        agent_ids = [a.agent_id for a in agents]
+        orchestrator._resource_negotiation_handler.create_games_for_agents(
+            agent_ids
+        )
 
     # Register evolutionary game strategies if handler is present
     if orchestrator._evo_game_handler is not None:

--- a/swarm/scenarios/loader.py
+++ b/swarm/scenarios/loader.py
@@ -32,6 +32,11 @@ from swarm.agents.moltbook_agent import (
     HumanPretenderAgent,
     SpamBotAgent,
 )
+from swarm.agents.negotiation_agent import (
+    FairNegotiator,
+    GreedyNegotiator,
+    StrategicNegotiator,
+)
 from swarm.agents.obfuscating import ObfuscatingAgent
 from swarm.agents.opportunistic import OpportunisticAgent
 from swarm.agents.rain_river import RainAgent, RiverAgent
@@ -58,11 +63,6 @@ from swarm.agents.wiki_editor import (
     DiligentEditorAgent,
     PointFarmerAgent,
     VandalAgent,
-)
-from swarm.agents.negotiation_agent import (
-    FairNegotiator,
-    GreedyNegotiator,
-    StrategicNegotiator,
 )
 from swarm.agents.work_regime_agent import WorkRegimeAgent
 from swarm.contracts.contract import (

--- a/tests/test_resource_negotiation_handler.py
+++ b/tests/test_resource_negotiation_handler.py
@@ -1,0 +1,692 @@
+"""Tests for the resource negotiation game handler."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+import pytest
+
+from swarm.core.resource_negotiation_handler import (
+    NegotiateAction,
+    NegotiationGame,
+    Proposal,
+    ResourceNegotiationConfig,
+    ResourceNegotiationHandler,
+    ResourcePool,
+)
+from swarm.logging.event_bus import EventBus
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def event_bus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+def config() -> ResourceNegotiationConfig:
+    return ResourceNegotiationConfig(
+        min_resource_types=2,
+        max_resource_types=3,
+        min_quantity=2,
+        max_quantity=4,
+        guaranteed_rounds=4,
+        termination_probability=0.3,
+        seed=42,
+    )
+
+
+@pytest.fixture
+def handler(config: ResourceNegotiationConfig, event_bus: EventBus) -> ResourceNegotiationHandler:
+    return ResourceNegotiationHandler(config=config, event_bus=event_bus)
+
+
+@pytest.fixture
+def fixed_pool() -> ResourcePool:
+    return ResourcePool(resources={"apples": 3, "bananas": 2})
+
+
+@pytest.fixture
+def fixed_game(handler: ResourceNegotiationHandler, fixed_pool: ResourcePool) -> NegotiationGame:
+    return handler.create_game(
+        player_a_id="alice",
+        player_b_id="bob",
+        pool=fixed_pool,
+        valuations_a={"apples": 5.0, "bananas": 2.0},
+        valuations_b={"apples": 1.0, "bananas": 8.0},
+    )
+
+
+@dataclass
+class _FakeAction:
+    """Minimal action-like object for testing handle_action."""
+
+    agent_id: str = ""
+    action_type: str = "resource_negotiate"
+    metadata: Dict[str, Any] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.metadata is None:
+            self.metadata = {}
+
+
+# ---------------------------------------------------------------------------
+# ResourcePool
+# ---------------------------------------------------------------------------
+
+
+class TestResourcePool:
+    def test_to_str(self, fixed_pool: ResourcePool) -> None:
+        s = fixed_pool.to_str()
+        assert "apples" in s
+        assert "bananas" in s
+
+    def test_total_items(self, fixed_pool: ResourcePool) -> None:
+        assert fixed_pool.total_items() == 5
+
+    def test_names_sorted(self, fixed_pool: ResourcePool) -> None:
+        assert fixed_pool.names() == ["apples", "bananas"]
+
+
+# ---------------------------------------------------------------------------
+# Proposal validation
+# ---------------------------------------------------------------------------
+
+
+class TestProposal:
+    def test_valid_proposal(self, fixed_pool: ResourcePool) -> None:
+        p = Proposal(
+            my_share={"apples": 2, "bananas": 1},
+            their_share={"apples": 1, "bananas": 1},
+        )
+        assert p.is_valid(fixed_pool)
+
+    def test_invalid_sum(self, fixed_pool: ResourcePool) -> None:
+        p = Proposal(
+            my_share={"apples": 3, "bananas": 2},
+            their_share={"apples": 1, "bananas": 1},
+        )
+        assert not p.is_valid(fixed_pool)
+
+    def test_negative_quantity(self, fixed_pool: ResourcePool) -> None:
+        p = Proposal(
+            my_share={"apples": 4, "bananas": -1},
+            their_share={"apples": -1, "bananas": 3},
+        )
+        assert not p.is_valid(fixed_pool)
+
+    def test_extra_resource(self, fixed_pool: ResourcePool) -> None:
+        p = Proposal(
+            my_share={"apples": 2, "bananas": 1, "extra": 1},
+            their_share={"apples": 1, "bananas": 1},
+        )
+        assert not p.is_valid(fixed_pool)
+
+    def test_all_to_one_player(self, fixed_pool: ResourcePool) -> None:
+        p = Proposal(
+            my_share={"apples": 3, "bananas": 2},
+            their_share={"apples": 0, "bananas": 0},
+        )
+        assert p.is_valid(fixed_pool)
+
+
+# ---------------------------------------------------------------------------
+# Game creation
+# ---------------------------------------------------------------------------
+
+
+class TestGameCreation:
+    def test_create_game_with_explicit_params(
+        self, handler: ResourceNegotiationHandler, fixed_pool: ResourcePool
+    ) -> None:
+        game = handler.create_game(
+            player_a_id="alice",
+            player_b_id="bob",
+            pool=fixed_pool,
+            valuations_a={"apples": 5.0, "bananas": 2.0},
+            valuations_b={"apples": 1.0, "bananas": 8.0},
+        )
+        assert game.player_a_id == "alice"
+        assert game.player_b_id == "bob"
+        assert game.pool == fixed_pool
+        assert game.round_number == 1
+        assert not game.game_over
+
+    def test_create_game_with_random_params(
+        self, handler: ResourceNegotiationHandler
+    ) -> None:
+        game = handler.create_game("alice", "bob")
+        assert len(game.pool.resources) >= 2
+        assert len(game.valuations_a) == len(game.pool.resources)
+        assert len(game.valuations_b) == len(game.pool.resources)
+
+    def test_game_registered(
+        self, handler: ResourceNegotiationHandler
+    ) -> None:
+        game = handler.create_game("alice", "bob")
+        assert game.game_id in handler.games
+        assert game.game_id in handler._player_games.get("alice", [])
+        assert game.game_id in handler._player_games.get("bob", [])
+
+
+# ---------------------------------------------------------------------------
+# Turn order
+# ---------------------------------------------------------------------------
+
+
+class TestTurnOrder:
+    def test_a_goes_first(self, fixed_game: NegotiationGame) -> None:
+        assert fixed_game.whose_turn() == "alice"
+
+    def test_b_goes_after_a(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        # Alice proposes
+        proposal = Proposal(
+            my_share={"apples": 2, "bananas": 1},
+            their_share={"apples": 1, "bananas": 1},
+        )
+        ok, _ = handler.process_move(
+            fixed_game.game_id, "alice", NegotiateAction.PROPOSE, proposal
+        )
+        assert ok
+        assert fixed_game.whose_turn() == "bob"
+
+    def test_wrong_turn_rejected(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        ok, err = handler.process_move(
+            fixed_game.game_id, "bob", NegotiateAction.PROPOSE,
+            Proposal({"apples": 1, "bananas": 1}, {"apples": 2, "bananas": 1}),
+        )
+        assert not ok
+        assert "Not bob's turn" in err
+
+
+# ---------------------------------------------------------------------------
+# Move processing
+# ---------------------------------------------------------------------------
+
+
+class TestMoveProcessing:
+    def test_propose(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        prop = Proposal(
+            my_share={"apples": 3, "bananas": 0},
+            their_share={"apples": 0, "bananas": 2},
+        )
+        ok, _ = handler.process_move(
+            fixed_game.game_id, "alice", NegotiateAction.PROPOSE, prop
+        )
+        assert ok
+        assert fixed_game.last_proposal == prop
+        assert fixed_game.last_proposer == "alice"
+
+    def test_accept_completes_game(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        # Alice proposes
+        prop = Proposal(
+            my_share={"apples": 3, "bananas": 0},
+            their_share={"apples": 0, "bananas": 2},
+        )
+        handler.process_move(
+            fixed_game.game_id, "alice", NegotiateAction.PROPOSE, prop
+        )
+        # Bob accepts
+        ok, _ = handler.process_move(
+            fixed_game.game_id, "bob", NegotiateAction.ACCEPT
+        )
+        assert ok
+        assert fixed_game.deal_reached
+        assert fixed_game.game_over
+        assert fixed_game.result is not None
+
+    def test_reject_continues_game(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        prop = Proposal(
+            my_share={"apples": 3, "bananas": 2},
+            their_share={"apples": 0, "bananas": 0},
+        )
+        handler.process_move(
+            fixed_game.game_id, "alice", NegotiateAction.PROPOSE, prop
+        )
+        ok, _ = handler.process_move(
+            fixed_game.game_id, "bob", NegotiateAction.REJECT
+        )
+        assert ok
+        assert not fixed_game.deal_reached
+        # Round should advance after both players acted
+        assert fixed_game.round_number == 2
+
+    def test_cannot_accept_own_proposal(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        prop = Proposal(
+            my_share={"apples": 2, "bananas": 1},
+            their_share={"apples": 1, "bananas": 1},
+        )
+        handler.process_move(
+            fixed_game.game_id, "alice", NegotiateAction.PROPOSE, prop
+        )
+        # Bob proposes (not accepts)
+        prop2 = Proposal(
+            my_share={"apples": 1, "bananas": 2},
+            their_share={"apples": 2, "bananas": 0},
+        )
+        handler.process_move(
+            fixed_game.game_id, "bob", NegotiateAction.PROPOSE, prop2
+        )
+        # Now it's round 2, Alice tries to accept her own... but last proposer is bob
+        # Actually bob is last proposer, so Alice can accept
+        ok, _ = handler.process_move(
+            fixed_game.game_id, "alice", NegotiateAction.ACCEPT
+        )
+        assert ok  # This should work since bob was the last proposer
+
+    def test_cannot_accept_no_proposal(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        ok, err = handler.process_move(
+            fixed_game.game_id, "alice", NegotiateAction.ACCEPT
+        )
+        assert not ok
+        assert "No proposal" in err
+
+    def test_invalid_proposal_rejected(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        # Shares don't sum to pool
+        prop = Proposal(
+            my_share={"apples": 3, "bananas": 2},
+            their_share={"apples": 3, "bananas": 2},
+        )
+        ok, err = handler.process_move(
+            fixed_game.game_id, "alice", NegotiateAction.PROPOSE, prop
+        )
+        assert not ok
+        assert "Invalid proposal" in err
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+class TestScoring:
+    def test_score_all_resources(self, fixed_game: NegotiationGame) -> None:
+        # Alice gets everything: (5*3 + 2*2) / (5*3 + 2*2) = 1.0
+        alloc = {"apples": 3, "bananas": 2}
+        assert fixed_game.compute_score("alice", alloc) == 1.0
+
+    def test_score_nothing(self, fixed_game: NegotiationGame) -> None:
+        alloc = {"apples": 0, "bananas": 0}
+        assert fixed_game.compute_score("alice", alloc) == 0.0
+
+    def test_score_partial(self, fixed_game: NegotiationGame) -> None:
+        # Alice gets 2 apples: 5*2 / (5*3 + 2*2) = 10/19
+        alloc = {"apples": 2, "bananas": 0}
+        expected = 10.0 / 19.0
+        assert abs(fixed_game.compute_score("alice", alloc) - expected) < 1e-9
+
+    def test_deal_scores_correct(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        # Alice proposes: she gets apples, Bob gets bananas
+        # This is optimal for both since Alice values apples (5)
+        # and Bob values bananas (8)
+        prop = Proposal(
+            my_share={"apples": 3, "bananas": 0},
+            their_share={"apples": 0, "bananas": 2},
+        )
+        handler.process_move(
+            fixed_game.game_id, "alice", NegotiateAction.PROPOSE, prop
+        )
+        handler.process_move(
+            fixed_game.game_id, "bob", NegotiateAction.ACCEPT
+        )
+
+        result = fixed_game.result
+        assert result is not None
+        assert result.deal_reached
+
+        # Alice: 5*3 / (5*3+2*2) = 15/19
+        expected_a = 15.0 / 19.0
+        assert abs(result.score_a - expected_a) < 1e-9
+
+        # Bob: 8*2 / (1*3+8*2) = 16/19
+        expected_b = 16.0 / 19.0
+        assert abs(result.score_b - expected_b) < 1e-9
+
+    def test_no_deal_scores(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        handler._finalize_no_deal(fixed_game)
+        assert fixed_game.result is not None
+        assert fixed_game.result.score_a == -0.5
+        assert fixed_game.result.score_b == -0.5
+
+
+# ---------------------------------------------------------------------------
+# Round advancement & deadline
+# ---------------------------------------------------------------------------
+
+
+class TestDeadline:
+    def test_round_advances_after_both_act(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        prop = Proposal(
+            my_share={"apples": 3, "bananas": 0},
+            their_share={"apples": 0, "bananas": 2},
+        )
+        handler.process_move(
+            fixed_game.game_id, "alice", NegotiateAction.PROPOSE, prop
+        )
+        handler.process_move(
+            fixed_game.game_id, "bob", NegotiateAction.REJECT
+        )
+        assert fixed_game.round_number == 2
+
+    def test_guaranteed_rounds_no_termination(self, event_bus: EventBus) -> None:
+        """Rounds 1-4 should never terminate the game."""
+        config = ResourceNegotiationConfig(
+            guaranteed_rounds=4,
+            termination_probability=1.0,  # Would always terminate if checked
+            seed=42,
+        )
+        handler = ResourceNegotiationHandler(
+            config=config, event_bus=event_bus
+        )
+        pool = ResourcePool(resources={"a": 2})
+        game = handler.create_game(
+            "alice", "bob",
+            pool=pool,
+            valuations_a={"a": 1.0},
+            valuations_b={"a": 1.0},
+        )
+
+        # Play through 3 rounds of proposals + rejects
+        for _ in range(3):
+            prop = Proposal(my_share={"a": 2}, their_share={"a": 0})
+            handler.process_move(game.game_id, "alice", NegotiateAction.PROPOSE, prop)
+            handler.process_move(game.game_id, "bob", NegotiateAction.REJECT)
+
+        # After 3 rounds of reject, we should be on round 4
+        assert game.round_number == 4
+        assert not game.game_over
+
+    def test_max_rounds_forces_end(self, event_bus: EventBus) -> None:
+        config = ResourceNegotiationConfig(
+            guaranteed_rounds=100,  # never stochastic
+            termination_probability=0.0,
+            max_rounds=3,
+            seed=42,
+        )
+        handler = ResourceNegotiationHandler(
+            config=config, event_bus=event_bus
+        )
+        pool = ResourcePool(resources={"a": 2})
+        game = handler.create_game(
+            "alice", "bob",
+            pool=pool,
+            valuations_a={"a": 1.0},
+            valuations_b={"a": 1.0},
+        )
+
+        # Play through max_rounds
+        for _ in range(3):
+            prop = Proposal(my_share={"a": 2}, their_share={"a": 0})
+            handler.process_move(game.game_id, "alice", NegotiateAction.PROPOSE, prop)
+            handler.process_move(game.game_id, "bob", NegotiateAction.REJECT)
+
+        assert game.game_over
+        assert not game.deal_reached
+
+    def test_epoch_end_forces_completion(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        assert not fixed_game.game_over
+        handler.on_epoch_end(state=None)
+        assert fixed_game.game_over
+        assert fixed_game.result is not None
+        assert not fixed_game.result.deal_reached
+
+
+# ---------------------------------------------------------------------------
+# Observation building
+# ---------------------------------------------------------------------------
+
+
+class TestObservations:
+    def test_active_game_in_observations(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        obs = handler.build_observation_fields("alice", state=None)
+        assert len(obs["resource_negotiation_games"]) == 1
+        assert obs["resource_negotiation_games"][0]["game_id"] == fixed_game.game_id
+        assert obs["resource_negotiation_games"][0]["role"] == "A"
+
+    def test_completed_game_in_results(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        handler._finalize_no_deal(fixed_game)
+        obs = handler.build_observation_fields("alice", state=None)
+        assert len(obs["resource_negotiation_games"]) == 0
+        assert len(obs["resource_negotiation_results"]) == 1
+
+    def test_game_observation_has_valuations(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        obs = handler.build_observation_fields("alice", state=None)
+        game_obs = obs["resource_negotiation_games"][0]
+        assert game_obs["your_valuations"]["apples"] == 5.0
+        assert game_obs["your_valuations"]["bananas"] == 2.0
+
+    def test_opponent_valuations_hidden(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        obs = handler.build_observation_fields("alice", state=None)
+        game_obs = obs["resource_negotiation_games"][0]
+        # Only "your_valuations" should be present, not the opponent's
+        assert "your_valuations" in game_obs
+        # Bob's valuations should not appear
+        assert game_obs["your_valuations"]["bananas"] != 8.0  # This is alice's val
+
+
+# ---------------------------------------------------------------------------
+# Handle action (integration with handler protocol)
+# ---------------------------------------------------------------------------
+
+
+class TestHandleAction:
+    def test_successful_propose(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        action = _FakeAction(
+            agent_id="alice",
+            metadata={
+                "game_id": fixed_game.game_id,
+                "negotiate_action": "propose",
+                "proposal": {
+                    "my_share": {"apples": 2, "bananas": 1},
+                    "their_share": {"apples": 1, "bananas": 1},
+                },
+                "message": "Let's share!",
+            },
+        )
+        result = handler.handle_action(action, state=None)
+        assert result.success
+        assert result.metadata["action"] == "propose"
+        assert not result.metadata["deal_reached"]
+
+    def test_successful_accept(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        # Alice proposes
+        handler.process_move(
+            fixed_game.game_id,
+            "alice",
+            NegotiateAction.PROPOSE,
+            Proposal(
+                my_share={"apples": 2, "bananas": 1},
+                their_share={"apples": 1, "bananas": 1},
+            ),
+        )
+        # Bob accepts via handler
+        action = _FakeAction(
+            agent_id="bob",
+            metadata={
+                "game_id": fixed_game.game_id,
+                "negotiate_action": "accept",
+            },
+        )
+        result = handler.handle_action(action, state=None)
+        assert result.success
+        assert result.metadata["deal_reached"]
+        assert result.metadata["score_a"] is not None
+
+    def test_missing_game_id(
+        self, handler: ResourceNegotiationHandler
+    ) -> None:
+        action = _FakeAction(agent_id="alice", metadata={})
+        result = handler.handle_action(action, state=None)
+        assert not result.success
+
+    def test_invalid_action_type(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        action = _FakeAction(
+            agent_id="alice",
+            metadata={
+                "game_id": fixed_game.game_id,
+                "negotiate_action": "invalid_action",
+            },
+        )
+        result = handler.handle_action(action, state=None)
+        assert not result.success
+
+
+# ---------------------------------------------------------------------------
+# Game pairing
+# ---------------------------------------------------------------------------
+
+
+class TestGamePairing:
+    def test_pair_even_agents(
+        self, handler: ResourceNegotiationHandler
+    ) -> None:
+        games = handler.create_games_for_agents(
+            ["a1", "a2", "a3", "a4"]
+        )
+        assert len(games) == 2
+
+    def test_pair_odd_agents(
+        self, handler: ResourceNegotiationHandler
+    ) -> None:
+        games = handler.create_games_for_agents(
+            ["a1", "a2", "a3"]
+        )
+        assert len(games) == 1
+
+
+# ---------------------------------------------------------------------------
+# Handler action types
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerActionTypes:
+    def test_handled_action_types(self) -> None:
+        from swarm.agents.base import ActionType
+
+        types = ResourceNegotiationHandler.handled_action_types()
+        assert ActionType.RESOURCE_NEGOTIATE in types
+
+
+# ---------------------------------------------------------------------------
+# Multi-round negotiation integration
+# ---------------------------------------------------------------------------
+
+
+class TestMultiRoundNegotiation:
+    def test_full_negotiation_sequence(
+        self,
+        handler: ResourceNegotiationHandler,
+        fixed_game: NegotiationGame,
+    ) -> None:
+        """Play through a full multi-round negotiation ending in a deal."""
+        # Round 1: Alice proposes greedy, Bob rejects
+        prop1 = Proposal(
+            my_share={"apples": 3, "bananas": 2},
+            their_share={"apples": 0, "bananas": 0},
+        )
+        handler.process_move(fixed_game.game_id, "alice", NegotiateAction.PROPOSE, prop1)
+        handler.process_move(fixed_game.game_id, "bob", NegotiateAction.REJECT)
+        assert fixed_game.round_number == 2
+
+        # Round 2: Alice proposes, Bob counter-proposes
+        prop2 = Proposal(
+            my_share={"apples": 3, "bananas": 1},
+            their_share={"apples": 0, "bananas": 1},
+        )
+        handler.process_move(fixed_game.game_id, "alice", NegotiateAction.PROPOSE, prop2)
+        prop3 = Proposal(
+            my_share={"apples": 0, "bananas": 2},
+            their_share={"apples": 3, "bananas": 0},
+        )
+        handler.process_move(fixed_game.game_id, "bob", NegotiateAction.PROPOSE, prop3)
+        assert fixed_game.round_number == 3
+        assert fixed_game.last_proposer == "bob"
+
+        # Round 3: Alice accepts Bob's proposal (good deal for both)
+        handler.process_move(fixed_game.game_id, "alice", NegotiateAction.ACCEPT)
+
+        assert fixed_game.deal_reached
+        assert fixed_game.game_over
+        assert fixed_game.result.score_a > 0
+        assert fixed_game.result.score_b > 0
+        assert len(handler.results) == 1

--- a/tests/test_strategy_prompt.py
+++ b/tests/test_strategy_prompt.py
@@ -1,0 +1,505 @@
+"""Test the user's strategy prompt against baseline negotiation agents.
+
+Translates the natural-language strategy prompt into a deterministic
+agent, then runs 10 games against each baseline (Fair, Greedy,
+Strategic) — 5 as Player A, 5 as Player B — and reports per-game
+scores plus aggregates.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any, Dict, List, Optional
+
+from swarm.core.resource_negotiation_handler import (
+    NegotiateAction,
+    NegotiationGame,
+    Proposal,
+    ResourceNegotiationConfig,
+    ResourceNegotiationHandler,
+    ResourcePool,
+)
+from swarm.agents.base import (
+    Action,
+    ActionType,
+    Observation,
+)
+from swarm.agents.negotiation_agent import (
+    FairNegotiator,
+    GreedyNegotiator,
+    StrategicNegotiator,
+)
+from swarm.logging.event_bus import EventBus
+
+
+# ── The strategy prompt, implemented as code ──────────────────────────
+
+
+class PromptStrategyAgent:
+    """Faithful code translation of the user's strategy prompt.
+
+    Not a BaseAgent subclass — just a callable that takes game
+    observation dicts and returns (action, proposal, message).
+    """
+
+    def __init__(self, player_id: str):
+        self.player_id = player_id
+
+    def decide(
+        self, game: NegotiationGame
+    ) -> tuple[NegotiateAction, Optional[Proposal], str]:
+        """Return (action, proposal_or_None, message)."""
+        role = game.role_of(self.player_id)
+        my_vals = (
+            game.valuations_a if role == "A" else game.valuations_b
+        )
+        pool = game.pool.resources
+        round_num = game.round_number
+        last_proposal = game.last_proposal
+        last_proposer = game.last_proposer
+
+        # Can we accept? Only if there's a proposal from the other player.
+        can_accept = (
+            last_proposal is not None
+            and last_proposer is not None
+            and last_proposer != self.player_id
+        )
+
+        # Score the current proposal from our perspective
+        their_offer_score = 0.0
+        if can_accept:
+            # Their proposal: last_proposal.my_share goes to proposer,
+            # their_share goes to us
+            our_alloc = last_proposal.their_share
+            their_offer_score = game.compute_score(self.player_id, our_alloc)
+
+        # ── PHASE 3: CLOSE (Round 5+) ─────────────────────────────
+        # Check acceptance thresholds first (highest priority: avoid no-deal)
+        if round_num >= 7 and can_accept and their_offer_score > 0:
+            return NegotiateAction.ACCEPT, None, "Deal — any positive value beats no deal."
+
+        if round_num >= 6 and can_accept and their_offer_score >= 0.25:
+            return NegotiateAction.ACCEPT, None, "Let's close this out."
+
+        if round_num >= 5 and can_accept and their_offer_score >= 0.40:
+            return NegotiateAction.ACCEPT, None, "This is reasonable, deal."
+
+        # ── PHASE 2: OPTIMIZE (Rounds 3-4) ────────────────────────
+        if round_num >= 3 and can_accept and their_offer_score >= 0.60:
+            return NegotiateAction.ACCEPT, None, "Good deal for both sides."
+
+        # ── PHASE 1: PROBE (Rounds 1-2) ──────────────────────────
+        if round_num == 1 and role == "A":
+            # Anchor: propose ALL resources for ourselves
+            my_share = dict(pool)
+            their_share = {name: 0 for name in pool}
+            return (
+                NegotiateAction.PROPOSE,
+                Proposal(my_share=my_share, their_share=their_share),
+                "Here's my opening offer.",
+            )
+
+        if round_num == 1 and role == "B":
+            # If opponent proposed something, reject (greedy anchor) or accept if amazing
+            if can_accept and their_offer_score >= 0.60:
+                return NegotiateAction.ACCEPT, None, "That's generous, I'll take it."
+
+            # Propose our ideal: we get what we value most
+            my_share, their_share = self._ideal_split(pool, my_vals)
+            return (
+                NegotiateAction.PROPOSE,
+                Proposal(my_share=my_share, their_share=their_share),
+                "I think this split makes more sense.",
+            )
+
+        if round_num == 2:
+            # Study opponent proposals and counter with value-aware split
+            if can_accept and their_offer_score >= 0.60:
+                return NegotiateAction.ACCEPT, None, "That works well."
+
+            opp_prefs = self._infer_opponent_prefs(game)
+            my_share, their_share = self._win_win_split(pool, my_vals, opp_prefs, round_num)
+            return (
+                NegotiateAction.PROPOSE,
+                Proposal(my_share=my_share, their_share=their_share),
+                "I've thought about what works for both of us.",
+            )
+
+        # ── PHASE 2: Rounds 3-4 ──────────────────────────────────
+        if round_num <= 4:
+            opp_prefs = self._infer_opponent_prefs(game)
+            my_share, their_share = self._win_win_split(pool, my_vals, opp_prefs, round_num)
+            return (
+                NegotiateAction.PROPOSE,
+                Proposal(my_share=my_share, their_share=their_share),
+                "I think this works well for both of us.",
+            )
+
+        # ── PHASE 3: Rounds 5+ proposals ─────────────────────────
+        # Offer ~55/45 split (by our valuations) to make it easy to accept
+        opp_prefs = self._infer_opponent_prefs(game)
+        my_share, their_share = self._concession_split(pool, my_vals, opp_prefs, round_num)
+        return (
+            NegotiateAction.PROPOSE,
+            Proposal(my_share=my_share, their_share=their_share),
+            "Let's reach a deal — this is fair for both.",
+        )
+
+    def _ideal_split(
+        self, pool: Dict[str, int], my_vals: Dict[str, float]
+    ) -> tuple[Dict[str, int], Dict[str, int]]:
+        """Give ourselves all resources we value most, rest to them."""
+        my_share = {}
+        their_share = {}
+        # Sort by our valuation (highest first)
+        for name, qty in sorted(
+            pool.items(), key=lambda x: my_vals.get(x[0], 0), reverse=True
+        ):
+            my_share[name] = qty
+            their_share[name] = 0
+        return my_share, their_share
+
+    def _infer_opponent_prefs(
+        self, game: NegotiationGame
+    ) -> Dict[str, float]:
+        """Infer opponent preferences from their proposal history."""
+        my_role = game.role_of(self.player_id)
+        prefs: Dict[str, float] = {name: 1.0 for name in game.pool.resources}
+
+        for turn in game.history:
+            if turn.role == my_role:
+                continue
+            if turn.action != NegotiateAction.PROPOSE or turn.proposal is None:
+                continue
+            # What they claimed for themselves
+            for name, qty in turn.proposal.my_share.items():
+                total = game.pool.resources.get(name, 1)
+                if total > 0:
+                    prefs[name] += qty / total
+
+        return prefs
+
+    def _win_win_split(
+        self,
+        pool: Dict[str, int],
+        my_vals: Dict[str, float],
+        opp_prefs: Dict[str, float],
+        round_num: int,
+    ) -> tuple[Dict[str, int], Dict[str, int]]:
+        """Give them what they seem to value (that we value least),
+        keep what we value most."""
+        my_share = {}
+        their_share = {}
+
+        # Trade advantage: high = we want it more than they seem to
+        trade = {}
+        for name in pool:
+            my_val = my_vals.get(name, 0)
+            opp_pref = opp_prefs.get(name, 1.0)
+            trade[name] = my_val / max(opp_pref, 0.01)
+
+        # Sort by trade advantage (highest first = we keep)
+        sorted_res = sorted(pool.items(), key=lambda x: trade[x[0]], reverse=True)
+
+        # Generosity: increases with round number to converge
+        generosity = min(0.45, 0.05 * round_num)
+
+        for name, qty in sorted_res:
+            adv = trade[name]
+            if adv > 1.5:
+                # We value it more — keep most
+                my_qty = max(0, int(qty * (0.85 - generosity)))
+            elif adv < 0.7:
+                # They value it more — give most to them
+                my_qty = max(0, int(qty * (0.15 + generosity * 0.5)))
+            else:
+                # Similar — split roughly even, slight tilt to us
+                my_qty = max(0, int(qty * (0.55 - generosity * 0.3)))
+
+            my_share[name] = min(my_qty, qty)
+            their_share[name] = qty - my_share[name]
+
+        return my_share, their_share
+
+    def _concession_split(
+        self,
+        pool: Dict[str, int],
+        my_vals: Dict[str, float],
+        opp_prefs: Dict[str, float],
+        round_num: int,
+    ) -> tuple[Dict[str, int], Dict[str, int]]:
+        """Late-game: offer ~55/45 or even 50/50 to close the deal."""
+        my_share = {}
+        their_share = {}
+
+        trade = {}
+        for name in pool:
+            my_val = my_vals.get(name, 0)
+            opp_pref = opp_prefs.get(name, 1.0)
+            trade[name] = my_val / max(opp_pref, 0.01)
+
+        sorted_res = sorted(pool.items(), key=lambda x: trade[x[0]], reverse=True)
+
+        # Increasingly generous: round 5 → 55%, round 7+ → ~50%
+        my_target = max(0.45, 0.60 - 0.03 * round_num)
+
+        for name, qty in sorted_res:
+            adv = trade[name]
+            if adv > 1.2:
+                my_qty = max(0, int(qty * my_target))
+            elif adv < 0.8:
+                my_qty = max(0, int(qty * (1.0 - my_target)))
+            else:
+                my_qty = qty // 2
+
+            my_share[name] = min(my_qty, qty)
+            their_share[name] = qty - my_share[name]
+
+        return my_share, their_share
+
+
+# ── Test harness: run the prompt agent against baselines ──────────────
+
+
+def run_single_game(
+    handler: ResourceNegotiationHandler,
+    game: NegotiationGame,
+    prompt_agent: PromptStrategyAgent,
+    baseline_agent: Any,  # BaseAgent with .act()
+) -> Dict[str, Any]:
+    """Play one full game, alternating turns until done."""
+    prompt_id = prompt_agent.player_id
+    baseline_id = baseline_agent.agent_id
+    max_rounds = 30  # safety cap
+
+    for _ in range(max_rounds * 2):
+        if game.game_over:
+            break
+
+        current_turn = game.whose_turn()
+        if current_turn is None:
+            break
+
+        if current_turn == prompt_id:
+            # Prompt strategy agent's turn
+            action, proposal, message = prompt_agent.decide(game)
+            ok, err = handler.process_move(
+                game.game_id, prompt_id, action, proposal, message
+            )
+            if not ok:
+                # Fallback: just propose an even split
+                my_share = {}
+                their_share = {}
+                for name, qty in game.pool.resources.items():
+                    my_share[name] = qty // 2
+                    their_share[name] = qty - qty // 2
+                handler.process_move(
+                    game.game_id,
+                    prompt_id,
+                    NegotiateAction.PROPOSE,
+                    Proposal(my_share=my_share, their_share=their_share),
+                    "Let's just split evenly.",
+                )
+        else:
+            # Baseline agent's turn — build observation and let it act
+            obs = Observation()
+            obs.resource_negotiation_games = [game.to_observation(baseline_id)]
+            agent_action = baseline_agent.act(obs)
+
+            meta = agent_action.metadata or {}
+            neg_action_str = meta.get("negotiate_action", "propose")
+            try:
+                neg_action = NegotiateAction(neg_action_str)
+            except ValueError:
+                neg_action = NegotiateAction.PROPOSE
+
+            proposal = None
+            prop_data = meta.get("proposal")
+            if prop_data and isinstance(prop_data, dict):
+                proposal = Proposal(
+                    my_share=prop_data.get("my_share", {}),
+                    their_share=prop_data.get("their_share", {}),
+                )
+
+            ok, err = handler.process_move(
+                game.game_id,
+                baseline_id,
+                neg_action,
+                proposal,
+                meta.get("message", ""),
+            )
+            if not ok:
+                # Fallback: propose even split
+                my_share = {}
+                their_share = {}
+                for name, qty in game.pool.resources.items():
+                    my_share[name] = qty // 2
+                    their_share[name] = qty - qty // 2
+                handler.process_move(
+                    game.game_id,
+                    baseline_id,
+                    NegotiateAction.PROPOSE,
+                    Proposal(my_share=my_share, their_share=their_share),
+                    "Fallback even split.",
+                )
+
+    # Force end if still going
+    if not game.game_over:
+        handler._finalize_no_deal(game)
+
+    result = game.result
+    prompt_role = game.role_of(prompt_id)
+    prompt_score = result.score_a if prompt_role == "A" else result.score_b
+    baseline_score = result.score_b if prompt_role == "A" else result.score_a
+
+    return {
+        "game_id": game.game_id,
+        "prompt_role": prompt_role,
+        "deal_reached": result.deal_reached,
+        "rounds_played": result.rounds_played,
+        "prompt_score": prompt_score,
+        "baseline_score": baseline_score,
+        "pool": dict(game.pool.resources),
+        "prompt_vals": dict(game.valuations_a if prompt_role == "A" else game.valuations_b),
+        "baseline_vals": dict(game.valuations_b if prompt_role == "A" else game.valuations_a),
+    }
+
+
+def run_tournament(
+    baseline_class,
+    baseline_name: str,
+    n_games: int = 10,
+    seed: int = 42,
+) -> List[Dict[str, Any]]:
+    """Run n_games between prompt agent and a baseline.
+
+    Half as Player A, half as Player B.
+    """
+    results = []
+    rng = random.Random(seed)
+
+    for i in range(n_games):
+        # Alternate roles
+        prompt_is_a = i % 2 == 0
+
+        prompt_id = "prompt" if prompt_is_a else "baseline"
+        baseline_id = "baseline" if prompt_is_a else "prompt"
+
+        # Oops, let's fix the IDs to be consistent
+        prompt_id = "prompt_agent"
+        baseline_id = "baseline_agent"
+
+        event_bus = EventBus()
+        config = ResourceNegotiationConfig(
+            min_resource_types=2,
+            max_resource_types=4,
+            min_quantity=1,
+            max_quantity=5,
+            min_valuation=1.0,
+            max_valuation=10.0,
+            guaranteed_rounds=4,
+            termination_probability=0.3,
+            max_rounds=20,
+            seed=seed + i * 100,
+        )
+        handler = ResourceNegotiationHandler(
+            config=config, event_bus=event_bus
+        )
+
+        if prompt_is_a:
+            player_a_id = prompt_id
+            player_b_id = baseline_id
+        else:
+            player_a_id = baseline_id
+            player_b_id = prompt_id
+
+        game = handler.create_game(
+            player_a_id=player_a_id,
+            player_b_id=player_b_id,
+        )
+
+        prompt_agent = PromptStrategyAgent(prompt_id)
+        baseline_agent = baseline_class(
+            agent_id=baseline_id,
+            rng=random.Random(seed + i * 200),
+        )
+
+        result = run_single_game(handler, game, prompt_agent, baseline_agent)
+        result["baseline_type"] = baseline_name
+        result["game_num"] = i + 1
+        results.append(result)
+
+    return results
+
+
+def print_results(results: List[Dict[str, Any]], baseline_name: str) -> Dict[str, float]:
+    """Print a formatted table and return summary stats."""
+    print(f"\n{'='*72}")
+    print(f"  PROMPT STRATEGY vs {baseline_name.upper()}")
+    print(f"{'='*72}")
+    print(f"{'Game':>4} {'Role':>4} {'Deal':>5} {'Rnd':>3}  {'Prompt':>8} {'Baseline':>8}  Pool")
+    print(f"{'-'*72}")
+
+    prompt_scores = []
+    baseline_scores = []
+    deals = 0
+
+    for r in results:
+        deal_str = "YES" if r["deal_reached"] else "NO"
+        if r["deal_reached"]:
+            deals += 1
+        prompt_scores.append(r["prompt_score"])
+        baseline_scores.append(r["baseline_score"])
+
+        pool_str = ", ".join(f"{v}{k[0].upper()}" for k, v in sorted(r["pool"].items()))
+        print(
+            f"  {r['game_num']:>2}    {r['prompt_role']:>1}   {deal_str:>4}  {r['rounds_played']:>2}"
+            f"    {r['prompt_score']:>+.3f}   {r['baseline_score']:>+.3f}   {pool_str}"
+        )
+
+    avg_prompt = sum(prompt_scores) / len(prompt_scores)
+    avg_baseline = sum(baseline_scores) / len(baseline_scores)
+    print(f"{'-'*72}")
+    print(f"  AVERAGE              {avg_prompt:>+.3f}   {avg_baseline:>+.3f}")
+    print(f"  DEALS: {deals}/{len(results)}")
+    print(f"  WIN/LOSS: prompt wins {sum(1 for p, b in zip(prompt_scores, baseline_scores) if p > b)}"
+          f" / baseline wins {sum(1 for p, b in zip(prompt_scores, baseline_scores) if b > p)}"
+          f" / ties {sum(1 for p, b in zip(prompt_scores, baseline_scores) if p == b)}")
+    print()
+
+    return {
+        "avg_prompt": avg_prompt,
+        "avg_baseline": avg_baseline,
+        "deal_rate": deals / len(results),
+    }
+
+
+# ── Main execution ────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    baselines = [
+        (FairNegotiator, "FairNegotiator"),
+        (GreedyNegotiator, "GreedyNegotiator"),
+        (StrategicNegotiator, "StrategicNegotiator"),
+    ]
+
+    all_summaries = {}
+    all_prompt_scores = []
+
+    for cls, name in baselines:
+        results = run_tournament(cls, name, n_games=10, seed=42)
+        summary = print_results(results, name)
+        all_summaries[name] = summary
+        all_prompt_scores.extend([r["prompt_score"] for r in results])
+
+    # Overall summary
+    print(f"\n{'='*72}")
+    print("  OVERALL SUMMARY")
+    print(f"{'='*72}")
+    for name, s in all_summaries.items():
+        print(f"  vs {name:>20}: prompt {s['avg_prompt']:>+.3f}  baseline {s['avg_baseline']:>+.3f}  deals {s['deal_rate']:.0%}")
+
+    overall_avg = sum(all_prompt_scores) / len(all_prompt_scores)
+    print(f"\n  PROMPT STRATEGY OVERALL AVG: {overall_avg:>+.3f}")
+    print(f"  (across {len(all_prompt_scores)} games)")
+    print()

--- a/tests/test_strategy_prompt.py
+++ b/tests/test_strategy_prompt.py
@@ -26,7 +26,6 @@ from swarm.core.resource_negotiation_handler import (
 )
 from swarm.logging.event_bus import EventBus
 
-
 # ── The strategy prompt, implemented as code ──────────────────────────
 
 

--- a/tests/test_strategy_prompt.py
+++ b/tests/test_strategy_prompt.py
@@ -11,23 +11,18 @@ from __future__ import annotations
 import random
 from typing import Any, Dict, List, Optional
 
+from swarm.agents.base import Observation
+from swarm.agents.negotiation_agent import (
+    FairNegotiator,
+    GreedyNegotiator,
+    StrategicNegotiator,
+)
 from swarm.core.resource_negotiation_handler import (
     NegotiateAction,
     NegotiationGame,
     Proposal,
     ResourceNegotiationConfig,
     ResourceNegotiationHandler,
-    ResourcePool,
-)
-from swarm.agents.base import (
-    Action,
-    ActionType,
-    Observation,
-)
-from swarm.agents.negotiation_agent import (
-    FairNegotiator,
-    GreedyNegotiator,
-    StrategicNegotiator,
 )
 from swarm.logging.event_bus import EventBus
 
@@ -92,7 +87,7 @@ class PromptStrategyAgent:
         if round_num == 1 and role == "A":
             # Anchor: propose ALL resources for ourselves
             my_share = dict(pool)
-            their_share = {name: 0 for name in pool}
+            their_share = dict.fromkeys(pool, 0)
             return (
                 NegotiateAction.PROPOSE,
                 Proposal(my_share=my_share, their_share=their_share),
@@ -164,7 +159,7 @@ class PromptStrategyAgent:
     ) -> Dict[str, float]:
         """Infer opponent preferences from their proposal history."""
         my_role = game.role_of(self.player_id)
-        prefs: Dict[str, float] = {name: 1.0 for name in game.pool.resources}
+        prefs: Dict[str, float] = dict.fromkeys(game.pool.resources, 1.0)
 
         for turn in game.history:
             if turn.role == my_role:
@@ -376,7 +371,6 @@ def run_tournament(
     Half as Player A, half as Player B.
     """
     results = []
-    rng = random.Random(seed)
 
     for i in range(n_games):
         # Alternate roles
@@ -462,9 +456,9 @@ def print_results(results: List[Dict[str, Any]], baseline_name: str) -> Dict[str
     print(f"{'-'*72}")
     print(f"  AVERAGE              {avg_prompt:>+.3f}   {avg_baseline:>+.3f}")
     print(f"  DEALS: {deals}/{len(results)}")
-    print(f"  WIN/LOSS: prompt wins {sum(1 for p, b in zip(prompt_scores, baseline_scores) if p > b)}"
-          f" / baseline wins {sum(1 for p, b in zip(prompt_scores, baseline_scores) if b > p)}"
-          f" / ties {sum(1 for p, b in zip(prompt_scores, baseline_scores) if p == b)}")
+    print(f"  WIN/LOSS: prompt wins {sum(1 for p, b in zip(prompt_scores, baseline_scores, strict=False) if p > b)}"
+          f" / baseline wins {sum(1 for p, b in zip(prompt_scores, baseline_scores, strict=False) if b > p)}"
+          f" / ties {sum(1 for p, b in zip(prompt_scores, baseline_scores, strict=False) if p == b)}")
     print()
 
     return {

--- a/tests/test_strategy_v2.py
+++ b/tests/test_strategy_v2.py
@@ -1,0 +1,378 @@
+"""Optimized strategy prompt v2 — test against baselines.
+
+Key improvements over v1:
+1. Greedy unit-by-unit allocation instead of percentage-based (fixes int truncation)
+2. Better opponent modeling (fraction-kept, not additive)
+3. Round 1: value-sorted split instead of "take everything" (reveals preferences productively)
+4. EV-aware acceptance (accounts for termination probability)
+5. Tighter early thresholds, smoother concession curve
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any, Dict, List, Optional
+
+from swarm.core.resource_negotiation_handler import (
+    NegotiateAction,
+    NegotiationGame,
+    Proposal,
+    ResourceNegotiationConfig,
+    ResourceNegotiationHandler,
+    ResourcePool,
+)
+from swarm.agents.base import (
+    Action,
+    ActionType,
+    Observation,
+)
+from swarm.agents.negotiation_agent import (
+    FairNegotiator,
+    GreedyNegotiator,
+    StrategicNegotiator,
+)
+from swarm.logging.event_bus import EventBus
+
+
+class OptimizedPromptAgent:
+    """V2: unit-level greedy allocation with EV-aware acceptance."""
+
+    def __init__(self, player_id: str):
+        self.player_id = player_id
+
+    def decide(
+        self, game: NegotiationGame
+    ) -> tuple[NegotiateAction, Optional[Proposal], str]:
+        role = game.role_of(self.player_id)
+        my_vals = game.valuations_a if role == "A" else game.valuations_b
+        pool = game.pool.resources
+        rnd = game.round_number
+        last_proposal = game.last_proposal
+        last_proposer = game.last_proposer
+
+        can_accept = (
+            last_proposal is not None
+            and last_proposer is not None
+            and last_proposer != self.player_id
+        )
+
+        offer_score = 0.0
+        if can_accept:
+            offer_score = game.compute_score(self.player_id, last_proposal.their_share)
+
+        # ── ACCEPTANCE LOGIC (checked first at every round) ───────
+        accept_threshold = self._accept_threshold(rnd)
+        if can_accept and offer_score >= accept_threshold:
+            return NegotiateAction.ACCEPT, None, "Deal."
+
+        # Emergency: round 6+, accept anything non-negative
+        if rnd >= 6 and can_accept and offer_score > 0:
+            return NegotiateAction.ACCEPT, None, "Deal."
+
+        # ── PROPOSAL LOGIC ────────────────────────────────────────
+        opp_prefs = self._infer_opponent_prefs(game)
+        target = self._proposal_target(rnd)
+        my_share, their_share = self._greedy_alloc(pool, my_vals, opp_prefs, target)
+
+        return (
+            NegotiateAction.PROPOSE,
+            Proposal(my_share=my_share, their_share=their_share),
+            "I think this is fair for both of us.",
+        )
+
+    def _accept_threshold(self, rnd: int) -> float:
+        """EV-aware acceptance threshold.
+
+        In round R >= 5, there's 0.3 chance game ends = -0.5.
+        So expected value of rejecting degrades fast.
+        Aggressive late-round acceptance prevents no-deal disasters.
+        """
+        if rnd <= 2:
+            return 0.70  # Hold firm early — time to optimize
+        elif rnd == 3:
+            return 0.58
+        elif rnd == 4:
+            return 0.50
+        elif rnd == 5:
+            return 0.30  # Deadline pressure begins
+        elif rnd == 6:
+            return 0.12
+        else:
+            return 0.01  # Accept almost anything
+
+    def _proposal_target(self, rnd: int) -> float:
+        """Target fraction of max score to keep for ourselves.
+
+        Starts aggressive, concedes to entice acceptance.
+        Late rounds: generous enough that opponent accepts quickly.
+        """
+        if rnd == 1:
+            return 0.85  # Aggressive opener
+        elif rnd == 2:
+            return 0.75
+        elif rnd == 3:
+            return 0.65
+        elif rnd == 4:
+            return 0.60
+        elif rnd == 5:
+            return 0.55
+        elif rnd == 6:
+            return 0.52
+        else:
+            return 0.50  # Even split — just close the deal
+
+    def _infer_opponent_prefs(self, game: NegotiationGame) -> Dict[str, float]:
+        """Infer opponent preferences from fraction of each resource they claim."""
+        my_role = game.role_of(self.player_id)
+        pool = game.pool.resources
+
+        # Track total fraction claimed per resource across all opponent proposals
+        claim_sum: Dict[str, float] = {name: 0.0 for name in pool}
+        n_proposals = 0
+
+        for turn in game.history:
+            if turn.role == my_role:
+                continue
+            if turn.action != NegotiateAction.PROPOSE or turn.proposal is None:
+                continue
+            n_proposals += 1
+            for name, qty in turn.proposal.my_share.items():
+                total = pool.get(name, 1)
+                if total > 0:
+                    claim_sum[name] += qty / total
+
+        if n_proposals == 0:
+            # No data — assume uniform preferences
+            return {name: 1.0 for name in pool}
+
+        # Average fraction claimed = estimated relative preference
+        # Scale to [0.1, 2.0] range
+        prefs = {}
+        for name in pool:
+            avg_claim = claim_sum[name] / n_proposals
+            # Higher claim fraction → higher estimated value
+            prefs[name] = 0.1 + avg_claim * 1.9
+        return prefs
+
+    def _greedy_alloc(
+        self,
+        pool: Dict[str, int],
+        my_vals: Dict[str, float],
+        opp_prefs: Dict[str, float],
+        target: float,
+    ) -> tuple[Dict[str, int], Dict[str, int]]:
+        """Greedy unit-by-unit allocation.
+
+        Start with everything. Give away units one at a time,
+        cheapest first (lowest my_val / opp_pref ratio), until
+        we hit our target score.
+        """
+        my_share = dict(pool)
+        their_share = {name: 0 for name in pool}
+
+        my_max = sum(my_vals.get(n, 0) * pool[n] for n in pool)
+        if my_max <= 0:
+            return my_share, their_share
+
+        # Build list of individual units we could give away
+        # Each entry: (normalized_cost, opp_benefit, resource_name)
+        giveaways = []
+        for name, qty in pool.items():
+            cost_per_unit = my_vals.get(name, 0) / my_max
+            opp_benefit = opp_prefs.get(name, 1.0)
+            for _ in range(qty):
+                giveaways.append((cost_per_unit, opp_benefit, name))
+
+        # Sort by cost/benefit ratio: give away things that are cheap for us
+        # but valuable to them first
+        giveaways.sort(key=lambda x: x[0] / max(x[1], 0.001))
+
+        current_score = 1.0
+
+        for cost, _benefit, name in giveaways:
+            # Stop if giving this unit would drop us below target
+            if current_score - cost < target:
+                continue  # skip this one, try next (might be cheaper)
+            if my_share[name] <= 0:
+                continue
+            my_share[name] -= 1
+            their_share[name] += 1
+            current_score -= cost
+
+        return my_share, their_share
+
+
+# ── Reuse harness from test_strategy_prompt ───────────────────────────
+
+def run_single_game(handler, game, prompt_agent, baseline_agent):
+    prompt_id = prompt_agent.player_id
+    baseline_id = baseline_agent.agent_id
+
+    for _ in range(60):
+        if game.game_over:
+            break
+        current_turn = game.whose_turn()
+        if current_turn is None:
+            break
+
+        if current_turn == prompt_id:
+            action, proposal, message = prompt_agent.decide(game)
+            ok, err = handler.process_move(
+                game.game_id, prompt_id, action, proposal, message
+            )
+            if not ok:
+                my_share = {n: q // 2 for n, q in game.pool.resources.items()}
+                their_share = {n: q - q // 2 for n, q in game.pool.resources.items()}
+                handler.process_move(
+                    game.game_id, prompt_id, NegotiateAction.PROPOSE,
+                    Proposal(my_share=my_share, their_share=their_share), "Fallback.",
+                )
+        else:
+            obs = Observation()
+            obs.resource_negotiation_games = [game.to_observation(baseline_id)]
+            agent_action = baseline_agent.act(obs)
+            meta = agent_action.metadata or {}
+            neg_action_str = meta.get("negotiate_action", "propose")
+            try:
+                neg_action = NegotiateAction(neg_action_str)
+            except ValueError:
+                neg_action = NegotiateAction.PROPOSE
+            proposal = None
+            prop_data = meta.get("proposal")
+            if prop_data and isinstance(prop_data, dict):
+                proposal = Proposal(
+                    my_share=prop_data.get("my_share", {}),
+                    their_share=prop_data.get("their_share", {}),
+                )
+            ok, err = handler.process_move(
+                game.game_id, baseline_id, neg_action, proposal,
+                meta.get("message", ""),
+            )
+            if not ok:
+                my_share = {n: q // 2 for n, q in game.pool.resources.items()}
+                their_share = {n: q - q // 2 for n, q in game.pool.resources.items()}
+                handler.process_move(
+                    game.game_id, baseline_id, NegotiateAction.PROPOSE,
+                    Proposal(my_share=my_share, their_share=their_share), "Fallback.",
+                )
+
+    if not game.game_over:
+        handler._finalize_no_deal(game)
+
+    result = game.result
+    prompt_role = game.role_of(prompt_id)
+    prompt_score = result.score_a if prompt_role == "A" else result.score_b
+    baseline_score = result.score_b if prompt_role == "A" else result.score_a
+    return {
+        "game_id": game.game_id,
+        "prompt_role": prompt_role,
+        "deal_reached": result.deal_reached,
+        "rounds_played": result.rounds_played,
+        "prompt_score": prompt_score,
+        "baseline_score": baseline_score,
+        "pool": dict(game.pool.resources),
+    }
+
+
+def run_tournament(agent_class, baseline_class, baseline_name, n_games=10, seed=42):
+    results = []
+    for i in range(n_games):
+        prompt_is_a = i % 2 == 0
+        prompt_id = "prompt_agent"
+        baseline_id = "baseline_agent"
+        event_bus = EventBus()
+        config = ResourceNegotiationConfig(
+            min_resource_types=2, max_resource_types=4,
+            min_quantity=1, max_quantity=5,
+            min_valuation=1.0, max_valuation=10.0,
+            guaranteed_rounds=4, termination_probability=0.3,
+            max_rounds=20, seed=seed + i * 100,
+        )
+        handler = ResourceNegotiationHandler(config=config, event_bus=event_bus)
+        if prompt_is_a:
+            player_a_id, player_b_id = prompt_id, baseline_id
+        else:
+            player_a_id, player_b_id = baseline_id, prompt_id
+        game = handler.create_game(player_a_id=player_a_id, player_b_id=player_b_id)
+        prompt_agent = agent_class(prompt_id)
+        baseline_agent = baseline_class(
+            agent_id=baseline_id, rng=random.Random(seed + i * 200),
+        )
+        result = run_single_game(handler, game, prompt_agent, baseline_agent)
+        result["baseline_type"] = baseline_name
+        result["game_num"] = i + 1
+        results.append(result)
+    return results
+
+
+def print_results(results, baseline_name):
+    print(f"\n{'='*72}")
+    print(f"  OPTIMIZED v2 vs {baseline_name.upper()}")
+    print(f"{'='*72}")
+    print(f"{'Game':>4} {'Role':>4} {'Deal':>5} {'Rnd':>3}  {'Prompt':>8} {'Baseline':>8}  Pool")
+    print(f"{'-'*72}")
+    prompt_scores, baseline_scores, deals = [], [], 0
+    for r in results:
+        deal_str = "YES" if r["deal_reached"] else "NO"
+        if r["deal_reached"]: deals += 1
+        prompt_scores.append(r["prompt_score"])
+        baseline_scores.append(r["baseline_score"])
+        pool_str = ", ".join(f"{v}{k[0].upper()}" for k, v in sorted(r["pool"].items()))
+        print(
+            f"  {r['game_num']:>2}    {r['prompt_role']:>1}   {deal_str:>4}  {r['rounds_played']:>2}"
+            f"    {r['prompt_score']:>+.3f}   {r['baseline_score']:>+.3f}   {pool_str}"
+        )
+    avg_p = sum(prompt_scores) / len(prompt_scores)
+    avg_b = sum(baseline_scores) / len(baseline_scores)
+    print(f"{'-'*72}")
+    print(f"  AVERAGE              {avg_p:>+.3f}   {avg_b:>+.3f}")
+    print(f"  DEALS: {deals}/{len(results)}")
+    wins = sum(1 for p, b in zip(prompt_scores, baseline_scores) if p > b)
+    losses = sum(1 for p, b in zip(prompt_scores, baseline_scores) if b > p)
+    ties = sum(1 for p, b in zip(prompt_scores, baseline_scores) if p == b)
+    print(f"  WIN/LOSS: {wins}W / {losses}L / {ties}T")
+    print()
+    return {"avg_prompt": avg_p, "avg_baseline": avg_b, "deal_rate": deals / len(results)}
+
+
+if __name__ == "__main__":
+    from tests.test_strategy_prompt import PromptStrategyAgent
+
+    baselines = [
+        (FairNegotiator, "FairNegotiator"),
+        (GreedyNegotiator, "GreedyNegotiator"),
+        (StrategicNegotiator, "StrategicNegotiator"),
+    ]
+
+    # Run V1 for comparison
+    print("\n" + "=" * 72)
+    print("  V1 (ORIGINAL) RESULTS")
+    print("=" * 72)
+    v1_scores = []
+    for cls, name in baselines:
+        results = run_tournament(PromptStrategyAgent, cls, name, n_games=10, seed=42)
+        s = print_results(results, name)
+        v1_scores.extend([r["prompt_score"] for r in results])
+
+    # Run V2
+    print("\n" + "=" * 72)
+    print("  V2 (OPTIMIZED) RESULTS")
+    print("=" * 72)
+    v2_scores = []
+    v2_summaries = {}
+    for cls, name in baselines:
+        results = run_tournament(OptimizedPromptAgent, cls, name, n_games=10, seed=42)
+        s = print_results(results, name)
+        v2_summaries[name] = s
+        v2_scores.extend([r["prompt_score"] for r in results])
+
+    # Comparison
+    v1_avg = sum(v1_scores) / len(v1_scores)
+    v2_avg = sum(v2_scores) / len(v2_scores)
+    print(f"\n{'='*72}")
+    print("  HEAD-TO-HEAD COMPARISON")
+    print(f"{'='*72}")
+    print(f"  V1 overall avg: {v1_avg:>+.3f}")
+    print(f"  V2 overall avg: {v2_avg:>+.3f}")
+    print(f"  Improvement:    {v2_avg - v1_avg:>+.3f} ({(v2_avg - v1_avg) / max(abs(v1_avg), 0.001) * 100:>+.1f}%)")
+    print()

--- a/tests/test_strategy_v2.py
+++ b/tests/test_strategy_v2.py
@@ -11,25 +11,20 @@ Key improvements over v1:
 from __future__ import annotations
 
 import random
-from typing import Any, Dict, List, Optional
+from typing import Dict, Optional
 
+from swarm.agents.base import Observation
+from swarm.agents.negotiation_agent import (
+    FairNegotiator,
+    GreedyNegotiator,
+    StrategicNegotiator,
+)
 from swarm.core.resource_negotiation_handler import (
     NegotiateAction,
     NegotiationGame,
     Proposal,
     ResourceNegotiationConfig,
     ResourceNegotiationHandler,
-    ResourcePool,
-)
-from swarm.agents.base import (
-    Action,
-    ActionType,
-    Observation,
-)
-from swarm.agents.negotiation_agent import (
-    FairNegotiator,
-    GreedyNegotiator,
-    StrategicNegotiator,
 )
 from swarm.logging.event_bus import EventBus
 
@@ -127,7 +122,7 @@ class OptimizedPromptAgent:
         pool = game.pool.resources
 
         # Track total fraction claimed per resource across all opponent proposals
-        claim_sum: Dict[str, float] = {name: 0.0 for name in pool}
+        claim_sum: Dict[str, float] = dict.fromkeys(pool, 0.0)
         n_proposals = 0
 
         for turn in game.history:
@@ -143,7 +138,7 @@ class OptimizedPromptAgent:
 
         if n_proposals == 0:
             # No data — assume uniform preferences
-            return {name: 1.0 for name in pool}
+            return dict.fromkeys(pool, 1.0)
 
         # Average fraction claimed = estimated relative preference
         # Scale to [0.1, 2.0] range
@@ -168,7 +163,7 @@ class OptimizedPromptAgent:
         we hit our target score.
         """
         my_share = dict(pool)
-        their_share = {name: 0 for name in pool}
+        their_share = dict.fromkeys(pool, 0)
 
         my_max = sum(my_vals.get(n, 0) * pool[n] for n in pool)
         if my_max <= 0:
@@ -314,7 +309,8 @@ def print_results(results, baseline_name):
     prompt_scores, baseline_scores, deals = [], [], 0
     for r in results:
         deal_str = "YES" if r["deal_reached"] else "NO"
-        if r["deal_reached"]: deals += 1
+        if r["deal_reached"]:
+            deals += 1
         prompt_scores.append(r["prompt_score"])
         baseline_scores.append(r["baseline_score"])
         pool_str = ", ".join(f"{v}{k[0].upper()}" for k, v in sorted(r["pool"].items()))
@@ -327,9 +323,9 @@ def print_results(results, baseline_name):
     print(f"{'-'*72}")
     print(f"  AVERAGE              {avg_p:>+.3f}   {avg_b:>+.3f}")
     print(f"  DEALS: {deals}/{len(results)}")
-    wins = sum(1 for p, b in zip(prompt_scores, baseline_scores) if p > b)
-    losses = sum(1 for p, b in zip(prompt_scores, baseline_scores) if b > p)
-    ties = sum(1 for p, b in zip(prompt_scores, baseline_scores) if p == b)
+    wins = sum(1 for p, b in zip(prompt_scores, baseline_scores, strict=False) if p > b)
+    losses = sum(1 for p, b in zip(prompt_scores, baseline_scores, strict=False) if b > p)
+    ties = sum(1 for p, b in zip(prompt_scores, baseline_scores, strict=False) if p == b)
     print(f"  WIN/LOSS: {wins}W / {losses}L / {ties}T")
     print()
     return {"avg_prompt": avg_p, "avg_baseline": avg_b, "deal_rate": deals / len(results)}


### PR DESCRIPTION
Implements a two-player alternating-offers resource negotiation game where
agents split heterogeneous resource pools with private valuations. Features
stochastic deadline (30% termination from round 5+), normalized scoring,
and three agent strategies (fair, greedy, strategic).

New files:
- swarm/core/resource_negotiation_handler.py — game engine + handler
- swarm/agents/negotiation_agent.py — Fair/Greedy/Strategic negotiator agents
- scenarios/resource_negotiation.yaml — example scenario
- tests/test_resource_negotiation_handler.py — 41 tests (all passing)

Wired into: ActionType, Observation, HandlerSet, handler_factory,
OrchestratorConfig, scenario loader.

https://claude.ai/code/session_01HCi3C52e4shM3QWBhxLt24