### PR TITLE
log_run: parse adversarial_fraction from agent_snapshots (closes #347)

### DIFF
--- a/swarm/scripts/log_run.py
+++ b/swarm/scripts/log_run.py
@@ -27,6 +27,59 @@ from pathlib import Path
 # Metric extraction
 # ---------------------------------------------------------------------------
 
+# Agent types treated as adversarial when computing ``adversarial_fraction``.
+# Sourced from swarm.models.agent.AgentType — kept as a string set here so this
+# script can run on bare history.json files without importing the simulation
+# code (and without pulling in heavy deps like pydantic for a logging script).
+# Cross-checked against:
+#   - swarm/models/agent.py (AgentType enum)
+#   - swarm/redteam/metrics.py:321 (canonical predicate)
+#   - swarm/core/composition_analyzer.py:393 (canonical counting site)
+ADVERSARIAL_AGENT_TYPES = frozenset({"adversarial", "deceptive"})
+
+
+def _compute_adversarial_fraction(agent_snapshots: list) -> float:
+    """Compute the fraction of unique agents whose type is adversarial.
+
+    Args:
+        agent_snapshots: List of per-agent-per-epoch records as serialized by
+            ``swarm.analysis.export.history_to_agent_records`` (i.e. each
+            record has an ``agent_id`` and an ``agent_type`` field).
+
+    Returns:
+        Fraction in ``[0.0, 1.0]``. Returns ``0.0`` if ``agent_snapshots`` is
+        empty or contains no usable ``agent_id`` / ``agent_type`` fields, so
+        that older history.json files (which may pre-date the per-agent type
+        export) still produce a sensible default.
+
+    Notes:
+        Each agent appears once per epoch in the snapshots, so we deduplicate
+        by ``agent_id`` and take the first observed ``agent_type``. Agent type
+        in SWARM is immutable for the lifetime of a run.
+    """
+    if not agent_snapshots:
+        return 0.0
+
+    agent_type_by_id: dict[str, str] = {}
+    for record in agent_snapshots:
+        agent_id = record.get("agent_id")
+        if not agent_id or agent_id in agent_type_by_id:
+            continue
+        agent_type = record.get("agent_type")
+        if agent_type is None:
+            continue
+        agent_type_by_id[agent_id] = str(agent_type).lower()
+
+    n_total = len(agent_type_by_id)
+    if n_total == 0:
+        return 0.0
+
+    n_adversarial = sum(
+        1 for t in agent_type_by_id.values() if t in ADVERSARIAL_AGENT_TYPES
+    )
+    return round(n_adversarial / n_total, 4)
+
+
 def _parse_dir_name(run_dir: Path) -> dict:
     """Extract scenario_id, run_timestamp, and seed from directory name.
 
@@ -59,10 +112,11 @@ def _parse_dir_name(run_dir: Path) -> dict:
 
 def extract_from_history(history_path: Path) -> dict:
     """Extract metrics from a history.json file."""
-    with open(history_path) as f:
+    with open(history_path, encoding="utf-8") as f:
         h = json.load(f)
 
     epochs = h.get("epoch_snapshots", [])
+    agent_snapshots = h.get("agent_snapshots", [])
     n_epochs = len(epochs)
 
     total_interactions = sum(e["total_interactions"] for e in epochs)
@@ -102,9 +156,25 @@ def extract_from_history(history_path: Path) -> dict:
         "final_welfare": final_welfare,
         "total_welfare": total_welfare,
         "welfare_per_epoch": welfare_per_epoch,
-        "adversarial_fraction": 0.0,  # TODO: parse from agent snapshots
+        "adversarial_fraction": _compute_adversarial_fraction(agent_snapshots),
         "collapse_epoch": collapse_epoch,
     }
+
+
+def _adversarial_fraction_from_agents_csv(csv_dir: Path) -> float:
+    """Compute adversarial fraction from the ``*agents*.csv`` sidecar.
+
+    Mirrors :func:`_compute_adversarial_fraction` but operates on the CSV
+    export written by ``swarm.analysis.export.export_to_csv``. Returns
+    ``0.0`` when no agents CSV is present (e.g. legacy runs) so the caller
+    can transparently fall back.
+    """
+    agents_csvs = sorted(csv_dir.glob("*agents*.csv"))
+    if not agents_csvs:
+        return 0.0
+    with open(agents_csvs[0], encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    return _compute_adversarial_fraction(rows)
 
 
 def extract_from_csv(csv_dir: Path) -> dict:
@@ -116,7 +186,7 @@ def extract_from_csv(csv_dir: Path) -> dict:
         raise FileNotFoundError(f"No CSV files found in {csv_dir}")
 
     rows = []
-    with open(csv_files[0]) as f:
+    with open(csv_files[0], encoding="utf-8") as f:
         reader = csv.DictReader(f)
         for row in reader:
             rows.append(row)
@@ -165,7 +235,7 @@ def extract_from_csv(csv_dir: Path) -> dict:
         "final_welfare": final_welfare,
         "total_welfare": total_welfare,
         "welfare_per_epoch": welfare_per_epoch,
-        "adversarial_fraction": 0.0,
+        "adversarial_fraction": _adversarial_fraction_from_agents_csv(csv_dir),
         "collapse_epoch": collapse_epoch,
     }
 

--- a/tests/test_log_run_adversarial_fraction.py
+++ b/tests/test_log_run_adversarial_fraction.py
@@ -1,0 +1,201 @@
+"""Tests for ``adversarial_fraction`` extraction in ``swarm.scripts.log_run``.
+
+Covers:
+  - direct extraction from ``agent_snapshots`` in a history.json payload
+  - deduplication across epochs (each agent appears once per epoch)
+  - graceful fallback when ``agent_snapshots`` is missing / malformed
+  - CSV-based fallback via ``*agents*.csv`` sidecar
+  - end-to-end ``extract_from_history`` against a synthetic history.json
+
+These tests deliberately do **not** spin up a real simulation: the unit
+under test only parses serialized payloads.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import pytest
+
+from swarm.scripts.log_run import (
+    ADVERSARIAL_AGENT_TYPES,
+    _adversarial_fraction_from_agents_csv,
+    _compute_adversarial_fraction,
+    extract_from_history,
+)
+
+# ---------------------------------------------------------------------------
+# Pure helper: _compute_adversarial_fraction
+# ---------------------------------------------------------------------------
+
+def test_compute_adversarial_fraction_basic_mix():
+    """3 of 10 agents are adversarial/deceptive → 0.3."""
+    snaps = (
+        [{"agent_id": f"agent_{i}", "agent_type": "honest", "epoch": 0} for i in range(7)]
+        + [{"agent_id": "agent_7", "agent_type": "adversarial", "epoch": 0}]
+        + [{"agent_id": "agent_8", "agent_type": "deceptive", "epoch": 0}]
+        + [{"agent_id": "agent_9", "agent_type": "adversarial", "epoch": 0}]
+    )
+    assert _compute_adversarial_fraction(snaps) == pytest.approx(0.3)
+
+
+def test_compute_adversarial_fraction_deduplicates_across_epochs():
+    """Same 4 agents over 5 epochs (20 records) must still yield correct fraction."""
+    snaps = []
+    for epoch in range(5):
+        snaps.append({"agent_id": "a0", "agent_type": "honest", "epoch": epoch})
+        snaps.append({"agent_id": "a1", "agent_type": "honest", "epoch": epoch})
+        snaps.append({"agent_id": "a2", "agent_type": "adversarial", "epoch": epoch})
+        snaps.append({"agent_id": "a3", "agent_type": "deceptive", "epoch": epoch})
+
+    # 2/4 unique agents are adversarial → 0.5
+    assert _compute_adversarial_fraction(snaps) == pytest.approx(0.5)
+
+
+@pytest.mark.parametrize("variant", ["ADVERSARIAL", "Adversarial", "adversarial"])
+def test_compute_adversarial_fraction_case_insensitive(variant: str):
+    """Accept enum-value-cased and uppercase strings; the export currently
+    emits ``.value`` (lowercase), but tolerate older dumps."""
+    snaps = [
+        {"agent_id": "a", "agent_type": variant, "epoch": 0},
+        {"agent_id": "b", "agent_type": "honest", "epoch": 0},
+    ]
+    assert _compute_adversarial_fraction(snaps) == pytest.approx(0.5)
+
+
+def test_compute_adversarial_fraction_empty_list_returns_zero():
+    """Older history.json files may omit per-agent snapshots entirely."""
+    assert _compute_adversarial_fraction([]) == 0.0
+
+
+def test_compute_adversarial_fraction_missing_fields_returns_zero():
+    """Records without usable agent_id / agent_type are skipped, not crashed on."""
+    snaps = [
+        {"agent_id": None, "agent_type": "adversarial"},
+        {"agent_id": "", "agent_type": "adversarial"},
+        {"agent_id": "a", "agent_type": None},
+    ]
+    assert _compute_adversarial_fraction(snaps) == 0.0
+
+
+def test_compute_adversarial_fraction_all_adversarial():
+    snaps = [
+        {"agent_id": f"a{i}", "agent_type": "adversarial"} for i in range(4)
+    ]
+    assert _compute_adversarial_fraction(snaps) == 1.0
+
+
+def test_compute_adversarial_fraction_no_adversarial():
+    snaps = [{"agent_id": f"a{i}", "agent_type": "honest"} for i in range(4)]
+    assert _compute_adversarial_fraction(snaps) == 0.0
+
+
+def test_adversarial_agent_types_is_a_frozenset():
+    """Guard against accidental mutation of the canonical set."""
+    assert isinstance(ADVERSARIAL_AGENT_TYPES, frozenset)
+    assert "adversarial" in ADVERSARIAL_AGENT_TYPES
+    assert "deceptive" in ADVERSARIAL_AGENT_TYPES
+    assert "honest" not in ADVERSARIAL_AGENT_TYPES
+
+
+# ---------------------------------------------------------------------------
+# extract_from_history: end-to-end on synthetic JSON
+# ---------------------------------------------------------------------------
+
+def _write_history_json(path: Path, agent_snapshots: list) -> None:
+    """Build a minimal history.json payload that ``extract_from_history`` accepts."""
+    payload = {
+        "simulation_id": "test_sim",
+        "n_agents": len({s["agent_id"] for s in agent_snapshots}),
+        "steps_per_epoch": 1,
+        "seed": 42,
+        "epoch_snapshots": [
+            {
+                "total_interactions": 10,
+                "accepted_interactions": 8,
+                "toxicity_rate": 0.1,
+                "total_welfare": 1.0,
+            }
+        ],
+        "agent_snapshots": agent_snapshots,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_extract_from_history_includes_adversarial_fraction(tmp_path: Path):
+    """extract_from_history must surface adversarial_fraction from snapshots."""
+    snaps = [
+        {"agent_id": "a0", "agent_type": "honest", "epoch": 0},
+        {"agent_id": "a1", "agent_type": "honest", "epoch": 0},
+        {"agent_id": "a2", "agent_type": "adversarial", "epoch": 0},
+        {"agent_id": "a3", "agent_type": "deceptive", "epoch": 0},
+    ]
+    history_path = tmp_path / "history.json"
+    _write_history_json(history_path, snaps)
+
+    summary = extract_from_history(history_path)
+
+    assert summary["adversarial_fraction"] == pytest.approx(0.5)
+    # Other fields must continue to be populated as before.
+    assert summary["scenario_id"] == "test_sim"
+    assert summary["total_interactions"] == 10
+
+
+def test_extract_from_history_legacy_no_agent_snapshots(tmp_path: Path):
+    """history.json without ``agent_snapshots`` falls back to 0.0 (backwards compat)."""
+    history_path = tmp_path / "history.json"
+    history_path.write_text(
+        json.dumps(
+            {
+                "simulation_id": "legacy",
+                "n_agents": 3,
+                "steps_per_epoch": 1,
+                "seed": 1,
+                "epoch_snapshots": [
+                    {
+                        "total_interactions": 1,
+                        "accepted_interactions": 1,
+                        "toxicity_rate": 0.0,
+                        "total_welfare": 0.0,
+                    }
+                ],
+                # NOTE: no "agent_snapshots" key
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    summary = extract_from_history(history_path)
+    assert summary["adversarial_fraction"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# CSV fallback path
+# ---------------------------------------------------------------------------
+
+def test_adversarial_fraction_from_agents_csv(tmp_path: Path):
+    """Sidecar agents CSV: per-row agent_type column → correct fraction."""
+    csv_path = tmp_path / "run_agents.csv"
+    fieldnames = ["agent_id", "epoch", "agent_type"]
+    with open(csv_path, "w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        # 5 agents over 2 epochs (10 rows), 2 adversarial → 2/5 = 0.4
+        for epoch in range(2):
+            w.writerow({"agent_id": "a0", "epoch": epoch, "agent_type": "honest"})
+            w.writerow({"agent_id": "a1", "epoch": epoch, "agent_type": "honest"})
+            w.writerow({"agent_id": "a2", "epoch": epoch, "agent_type": "honest"})
+            w.writerow({"agent_id": "a3", "epoch": epoch, "agent_type": "adversarial"})
+            w.writerow({"agent_id": "a4", "epoch": epoch, "agent_type": "deceptive"})
+
+    assert _adversarial_fraction_from_agents_csv(tmp_path) == pytest.approx(0.4)
+
+
+def test_adversarial_fraction_from_agents_csv_no_sidecar(tmp_path: Path):
+    """Legacy CSV-only runs without an agents.csv sidecar: 0.0 fallback."""
+    (tmp_path / "run_epochs.csv").write_text(
+        "total_interactions,accepted_interactions\n1,1\n", encoding="utf-8"
+    )
+    assert _adversarial_fraction_from_agents_csv(tmp_path) == 0.0


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

Closes #347.

## What

Replaces the hardcoded ``adversarial_fraction: 0.0`` placeholder in
``swarm/scripts/log_run.py`` with a real computation from the
``agent_snapshots`` block of `history.json` (and from a ``*agents*.csv``
sidecar in the CSV fallback path).

## How

Adds a small pure helper ``_compute_adversarial_fraction(records)`` that:

1. Iterates per-agent-per-epoch records (the shape emitted by
   `swarm.analysis.export.history_to_agent_records`).
2. Dedupes by ``agent_id`` — agent type is immutable per run, so the first
   observed value wins.
3. Counts the fraction of unique agents whose lowercased ``agent_type`` is in
   ``ADVERSARIAL_AGENT_TYPES = {\"adversarial\", \"deceptive\"}``.
4. Falls back to ``0.0`` when the input is missing, empty, or has no usable
   ``agent_id`` / ``agent_type`` — preserving backwards compat with older
   `history.json` files that pre-date per-agent snapshot export.

`ADVERSARIAL_AGENT_TYPES` is sourced from `swarm.models.agent.AgentType` but
kept as a local frozenset so this logging script does **not** pull in the
pydantic / core sim stack just to count types. The set matches the canonical
predicates already used elsewhere:

- `swarm/redteam/metrics.py:321` — `is_adversarial = agent_types.get(...) in [\"adversarial\", \"deceptive\"]`
- `swarm/core/composition_analyzer.py:393` — `isinstance(a, (AdversarialAgent, DeceptiveAgent))`

### CSV fallback

`extract_from_csv` previously also hardcoded `0.0`. It now calls a sibling
helper `_adversarial_fraction_from_agents_csv(csv_dir)` that scans for a
`*agents*.csv` produced by `swarm.analysis.export.export_to_csv` and reuses
`_compute_adversarial_fraction`. Falls back to `0.0` when no sidecar is
present (legacy CSV-only dumps), so behaviour for those older runs is
unchanged.

### While here

Also pinned `encoding=\"utf-8\"` on the JSON / CSV reads in `log_run.py`
(same shape as upstream encoding sweeps; three sites; no behaviour change on
UTF-8 locales).

## Acceptance criteria from the issue

- [x] `adversarial_fraction` is correctly parsed from agent snapshots or
      scenario config — parsed from agent snapshots
- [x] Graceful fallback to `0.0` for logs that don't contain this field —
      missing / empty / malformed all return 0.0 (covered by 4 separate tests)
- [x] Existing tests pass — unrelated `test_run_export_json` matplotlib
      failure is pre-existing and orthogonal to this PR
- [x] Add a test case verifying the extraction logic — **14 new tests**

## Tests (14 new)

`tests/test_log_run_adversarial_fraction.py`:

- basic mix (3/10 adversarial → 0.3)
- dedup across epochs (4 agents × 5 epochs → still 2/4 unique)
- case-insensitivity (`ADVERSARIAL` / `Adversarial` / `adversarial`)
- empty list → `0.0`
- missing fields → `0.0` (no crash)
- all-adversarial → `1.0`
- no-adversarial → `0.0`
- `ADVERSARIAL_AGENT_TYPES` is a frozenset (mutation guard)
- end-to-end `extract_from_history` on a synthetic `history.json`
- legacy `history.json` without `agent_snapshots` → `0.0`
- CSV fallback with a real `*agents*.csv` sidecar
- CSV fallback when sidecar is missing → `0.0`

```
======================== 14 passed, 1 warning in 0.18s =========================
```

`ruff check` clean on both touched files.

## Diff stat

```
 swarm/scripts/log_run.py                   |  78 ++++++++++-
 tests/test_log_run_adversarial_fraction.py | 201 +++++++++++++++++++++++++++++
 2 files changed, 275 insertions(+), 4 deletions(-)
```

---

AI-assisted via Cursor (Claude Opus 4.7). Personal token-burn initiative by
@adv0r to use up an expiring Cursor subscription budget on small, useful
upstream contributions.

Made with [Cursor](https://cursor.com)
