### PR TITLE
fix(deps): bump postcss to >=8.5.10 in viz (CVE-2026-41305 XSS)

### DIFF
--- a/viz/package-lock.json
+++ b/viz/package-lock.json
@@ -22,7 +22,7 @@
         "@types/react-dom": "^19.0.0",
         "eslint": "^9.39.2",
         "eslint-config-next": "^16.1.6",
-        "postcss": "^8.5.0",
+        "postcss": "^8.5.10",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.0"
       }
@@ -5761,9 +5761,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -5851,34 +5851,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-domexception": {
@@ -6236,10 +6208,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -6256,7 +6227,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/viz/package.json
+++ b/viz/package.json
@@ -25,8 +25,11 @@
     "@napi-rs/canvas": "^0.1.63",
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.1.6",
-    "postcss": "^8.5.0",
+    "postcss": "^8.5.10",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## What

Resolves **Dependabot alert [#47](https://github.com/swarm-ai-safety/swarm/security/dependabot/47)** — GHSA-qx2v-qp2m-jg93 / CVE-2026-41305: *PostCSS XSS via unescaped `</style>` in CSS stringify output* (medium, vulnerable `< 8.5.10`).

## Why two changes

`viz/package-lock.json` pinned **two** vulnerable postcss copies:

| Location | Before | After |
|---|---|---|
| `node_modules/postcss` (direct devDep) | `8.5.6` | `8.5.15` |
| `node_modules/next/node_modules/postcss` (nested) | `8.4.31` | *deduped away* |

- Bumped the direct devDependency range `^8.5.0` → `^8.5.10`.
- Added `"overrides": { "postcss": "^8.5.10" }` so the copy nested under `next` is forced up too (a lockfile-only `npm update` would have left `8.4.31` in place and kept the alert open).

npm now resolves both to a single hoisted **postcss 8.5.15**. Verified: no remaining postcss entry `< 8.5.10` in the lockfile.

## Scope

Lockfile-only dedupe + one range bump + override. No source changes.

> Note: `npm audit` still flags an **unrelated** moderate vuln in `ws` (GHSA-58qx-3vcg-4xpx) — out of scope for this PR; will be handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)