### PR TITLE
fix(deps): bump uuid 9→14 in claude_code service (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/swarm/bridges/claude_code/service/package.json
+++ b/swarm/bridges/claude_code/service/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "express": "^4.18.2",
     "ws": "^8.16.0",
-    "uuid": "^9.0.0"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",


### PR DESCRIPTION
## What

Resolves **Dependabot alert [#51](https://github.com/swarm-ai-safety/swarm/security/dependabot/51)** — GHSA-w5hq-g745-h8pq (medium): `uuid` `v3()/v5()/v6()` out-of-bounds write on an invalid `offset` (vulnerable `< 11.1.1`).

Bumps `uuid` `^9.0.0` → `^14.0.0` in `swarm/bridges/claude_code/service`.

## Why a standalone PR (not #444)

Dependabot's grouped PR #444 bundled this uuid bump with an unrelated **`next` 15.5.18 → 16.2.6 major upgrade** (and shipped a lockfile that still pinned vulnerable postcss). That major upgrade deserves a deliberate, separately-tested migration, so #444 was closed in favor of this focused fix.

## Compatibility

The service uses the named-export form `import { v4 as uuidv4 } from "uuid"` (`server.ts:25`, 3 call sites). That import is stable across uuid v9→v14 — the v14 breaking changes (ESM-only, dropped default export, no deep `uuid/v4` imports) don't touch this usage. `@types/uuid` is left as-is (validated green by #444's CI, which made the identical service change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)