### PR TITLE
test(perf): run wall-clock budget tests serially without coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,13 @@ jobs:
         run: python scripts/test_changes.py -- pytest tests/ -v -n auto --dist=loadfile --timeout=300 --durations=20 --durations-min=1.0 -p no:pytest_cov
       - name: Run full tests with coverage
         if: matrix.mode == 'full'
-        run: pytest tests/ -v -n auto --dist=loadfile --timeout=300 --durations=20 --durations-min=1.0 --cov=swarm --cov-report=term-missing --cov-fail-under=70 -p no:testmon
+        run: pytest tests/ -v -n auto --dist=loadfile --timeout=300 --durations=20 --durations-min=1.0 --cov=swarm --cov-report=term-missing --cov-fail-under=70 -p no:testmon -m "not perf"
+      # Wall-clock budget tests run serially and without coverage: the coverage
+      # tracer and xdist parallelism inflate timing 5-20×, causing false failures
+      # unrelated to real regressions. See the `perf` marker in pyproject.toml.
+      - name: Run performance budgets (serial, no coverage)
+        if: matrix.mode == 'full'
+        run: pytest tests/test_performance.py -v --timeout=300 -p no:testmon -p no:pytest_cov -p no:xdist -m perf
       - name: Upload testmon data
         if: success() && matrix.mode == 'full'
         uses: actions/upload-artifact@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,7 @@ markers = [
     "slow: mark test as slow running (deselect with '-m \"not slow\"')",
     "memory: mark test as memory-focused (runs with memory limits)",
     "memory_intensive: mark test as long-running memory test (>1000 epochs)",
+    "perf: mark wall-clock performance budget test (run serially without coverage; tracer/xdist distort timing)",
 ]
 
 [tool.mypy]

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -243,8 +243,15 @@ PAYOFFS_BOTH_BUDGET_MS = 50.0   # optimised target ~2ms; CI runners are ~3-4× s
 SIGMOID_FAST_BUDGET_MS = 12.0   # optimised target ~0.5ms; 12ms allows CI jitter
 
 
+@pytest.mark.perf
 class TestPerformance:
-    """Wall-clock budgets for hot-path operations on 10k interactions."""
+    """Wall-clock budgets for hot-path operations on 10k interactions.
+
+    Marked ``perf`` so CI runs these serially and without coverage: the
+    coverage tracer and xdist parallelism distort wall-clock timing by
+    5-20×, which is unrelated to the regressions these budgets exist to
+    catch. See the dedicated ``perf`` step in ``.github/workflows/ci.yml``.
+    """
 
     def test_summary_within_budget(self, interactions_10k, reporter):
         elapsed_s = _timeit(lambda: reporter.summary(interactions_10k))


### PR DESCRIPTION
## Problem

The `test (3.12, full)` CI job has been flaking on wall-clock performance budget tests in `tests/test_performance.py` (surfaced on PR #446, the uuid CVE bump — but unrelated to it). Example failures:

| Test | Measured | Budget |
|---|---|---|
| `test_payoffs_both_within_budget` | 279.3 ms | 50 ms |
| `test_sigmoid_fast_within_budget` | 26.7 ms | 12 ms |
| `test_proxy_computer_batch_within_budget` | 980.7 ms | 500 ms |

## Root cause

These failures only occur in the **full** job, which runs:

```
pytest tests/ -n auto ... --cov=swarm --cov-fail-under=70
```

Two compounding effects distort wall-clock timing **only** here:

1. **`--cov=swarm`** installs a line tracer that inflates tight pure-Python loops 5–20×. The budgets were padded for "CI runners ~3-4× slower" (real code, no instrumentation), not for tracer overhead.
2. **`-n auto`** (xdist) runs the perf test concurrently with other CPU-bound tests, fighting for cores.

The 3.10/3.11 **compatibility** jobs run with `-p no:pytest_cov` and passed — confirming the diagnosis.

## Fix

Per the repo's test-fix discipline (make flaky tests deterministic rather than loosening budgets):

- Add a `perf` pytest marker and apply it to the `TestPerformance` (wall-clock) class.
- Deselect `perf` from the coverage run (`-m "not perf"`).
- Add a dedicated CI step that runs the budgets **serially** (`-p no:xdist`) and **without coverage** (`-p no:pytest_cov`), so they measure real code paths and only fail on genuine regressions.

The 18 correctness tests in the file remain in the coverage run; only the 4 timing tests move to the dedicated step.

## Verification

- `pytest tests/test_performance.py -p no:pytest_cov -p no:xdist -m perf` → **4 passed in 0.42s**
- `pytest tests/test_performance.py -m "not perf" --co` → 18 collected, 4 deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)