### PR TITLE
test(api): fail loudly when a run expected to complete fails

### DIFF
--- a/tests/test_agent_api.py
+++ b/tests/test_agent_api.py
@@ -112,13 +112,34 @@ def _auth_header(api_key: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {api_key}"}
 
 
-def _wait_for_run(client, run_id: str, api_key: str, timeout: int = 60) -> dict:
-    """Wait for a run to complete and return its data."""
+def _wait_for_run(
+    client,
+    run_id: str,
+    api_key: str,
+    timeout: int = 60,
+    *,
+    require_completed: bool = False,
+) -> dict:
+    """Wait for a run to reach a terminal state and return its data.
+
+    By default both ``completed`` and ``failed`` are accepted as terminal
+    (some tests deliberately inspect failed runs). Pass
+    ``require_completed=True`` when the caller's contract is a *successful*
+    run: a ``failed`` run then fails the test loudly with the run's error,
+    rather than being returned silently and surfacing as a confusing
+    assertion further downstream (e.g. a compare endpoint returning 400
+    "not completed" instead of the expected 404).
+    """
     headers = _auth_header(api_key)
     for _ in range(timeout * 2):
         resp = client.get(f"/api/runs/{run_id}", headers=headers)
         data = resp.json()
         if data["status"] in ("completed", "failed"):
+            if require_completed and data["status"] == "failed":
+                pytest.fail(
+                    f"Run {run_id} failed during test setup "
+                    f"(expected completion): {data.get('error')!r}"
+                )
             return data
         time.sleep(0.5)
     pytest.fail("Run did not complete within timeout")
@@ -562,7 +583,7 @@ class TestCompareEndpoint:
             headers=_auth_header(api_key),
         )
         run_id = resp.json()["run_id"]
-        _wait_for_run(client, run_id, api_key)
+        _wait_for_run(client, run_id, api_key, require_completed=True)
         return run_id
 
     def test_compare_two_runs(self, client):


### PR DESCRIPTION
## Background

While unblocking #446, the `test (3.10, compatibility)` job flaked on:

```
FAILED tests/test_agent_api.py::TestCompareEndpoint::test_compare_nonexistent_run_404 - assert 400 == 404
```

## Root cause

The test builds a baseline run via `_create_completed_run`, which waits with `_wait_for_run`. That helper treats **both** `completed` and `failed` as terminal and returns either one silently. Under heavy parallel CI load the baseline sim run flaked to `failed`; the helper returned it anyway, and the compare endpoint then short-circuited with **400 "not completed (status: failed)"** on the *first* id — before ever reaching the `nonexistent-id` 404 path. Hence the misleading `assert 400 == 404`.

This is unrelated to #446 (a JS-only uuid bump) and to the perf fix in #448. It surfaced because the marker added in #448 invalidated the testmon cache, so #446's compat job ran the full suite under xdist load.

## Fix

Add a `require_completed` keyword to `_wait_for_run`. When set, a `failed` run fails the test **loudly with the run's error message** instead of being returned silently. `_create_completed_run` opts in, since its contract is a *successful* run.

- Default behavior is unchanged — tests that deliberately inspect failed runs (e.g. the error-truncation test) still pass.
- This doesn't paper over the underlying sim flake; it makes it **actionable**: the next time a baseline run fails under load, CI will report *why* (the run's error) rather than an unrelated status-code mismatch.

## Verification

`pytest tests/test_agent_api.py::TestCompareEndpoint` → **4 passed**. Reviewed all `_wait_for_run` call sites: only `_create_completed_run` opts into the strict mode; the two failed-run-inspecting tests keep the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)