### PR TITLE
feat(detection): heterogeneity knobs to break the soft AUROC=1.0 ceiling

### DIFF
--- a/docs/notes/detection_informative_regime.md
+++ b/docs/notes/detection_informative_regime.md
@@ -1,0 +1,68 @@
+# An informative detection regime: breaking the soft AUROC = 1.00 ceiling
+
+**Date**: 2026-05-25
+**Follows**: `detection_soft_ceiling_caveat.md` (why the homogeneous defaults saturate).
+**Code**: `swarm/detection/degradation.py` — new `StreamConfig.benign_quality_std`, `floor_std`, and the `StreamConfig.heterogeneous()` preset.
+
+## The problem this fixes
+
+Under the homogeneous defaults, benign agents are pinned to a single quality (0.85) and degrading agents drift to a shared floor (0.66). Averaging ~50–100 interactions per agent then separates the two classes by ~8 standard deviations (d′ ≈ 7.8), so **soft AUROC saturates at 1.000** and the soft-vs-binary comparison measures nothing about detection skill — only the geometry of the generator. See the caveat note for the full diagnosis.
+
+## What changed
+
+Two opt-in knobs on `StreamConfig` (both default `0.0`, so existing behavior, tests, and RNG sequences are byte-identical):
+
+- **`benign_quality_std`** — samples each benign agent's quality from `N(benign_quality, benign_quality_std)`. This gives the benign toxicity distribution real width, so its lower tail can overlap mildly-degraded agents. *This is the single biggest driver of whether soft AUROC is informative.*
+- **`floor_std`** — samples each degrading agent's floor from `N(quality_floor, floor_std)`, clamped to `[0, initial_quality]`. Floors near `benign_quality` make the gap small and uncertain, producing genuinely hard-to-catch agents.
+
+The `StreamConfig.heterogeneous()` preset bundles a tuned operating point:
+
+```python
+StreamConfig.heterogeneous()  # benign_quality_std=0.10, quality_floor=0.74, floor_std=0.06
+```
+
+Pair it with a **short evaluation window** (last ~3 epochs) so within-agent noise actually matters rather than being averaged away.
+
+## Where soft AUROC lands now
+
+Per-agent toxicity AUROC, `heterogeneous()` preset, base rate 0.2, eval = last 3 epochs:
+
+| seed | soft AUROC | binary AUROC | gap |
+|---|---|---|---|
+| 0 | 0.872 | 0.584 | +0.288 |
+| 1 | 0.891 | 0.600 | +0.291 |
+| 2 | 0.919 | 0.637 | +0.282 |
+
+Soft sits in the **0.87–0.92** band — a real score, not a saturated 1.000 — and the soft advantage over binary (~+0.28 AUROC) is now a *measured* quantity rather than an artifact of perfect separation.
+
+### Why the numbers moved (mechanism, not magic)
+
+- **Benign spread:** per-agent benign soft-toxicity std rises from **0.009** (default, effectively a point mass) to **0.072** with `benign_quality_std=0.10` — an ~8× wider benign distribution whose tail now overlaps the degrading class.
+- **Floor spread:** with `floor_std=0.06` (onset/trajectory held fixed) degrading agents' late-epoch quality spans **0.48–0.82** instead of collapsing to a single floor — some agents barely degrade and are legitimately hard to flag.
+- **Short window:** scoring on 3 epochs (~24 interactions) instead of the full back-half keeps the per-agent standard error large enough that the class distributions overlap.
+
+## What this buys
+
+The soft-vs-binary delta is now interpretable as detection skill. The qualitative story from the saturated regime survives — soft beats binary, and binary is structurally penalized because the floor sits above `τ*=0.5` — but the magnitudes are no longer pinned at the generator's ceiling. Sweeps (e.g. the 2D `proxy_noise × quality_jitter` grid) run on `heterogeneous()` will produce gradients across cells instead of walls of 1.000.
+
+## Recommended use
+
+- For **headline / comparison results**, use `StreamConfig.heterogeneous()` with a short eval window and report soft AUROC in its true (sub-1.0) range alongside the binary gap.
+- Keep the homogeneous default for **unit tests and mechanism demos** where a clean, deterministic separation is the point.
+- When reporting, state the regime explicitly (heterogeneity stds, eval window) — the absolute AUROC is meaningless without it.
+
+## Reproduce
+
+```python
+from swarm.detection.degradation import StreamConfig, PopulationConfig, generate_population
+from swarm.detection.detectors import MatchedDetectors
+from swarm.detection.curves import compute_curve, per_agent_scores
+
+cfg = StreamConfig.heterogeneous()
+n = cfg.n_epochs; es, ee = n - 3, n
+streams = generate_population(PopulationConfig(n_agents=200, base_rate=0.2, stream=cfg), seed=0)
+det = MatchedDetectors()
+for name in ("soft_toxicity", "binary_toxicity"):
+    sc, lab = per_agent_scores(streams, getattr(det, name), es, ee)
+    print(name, round(compute_curve(sc, lab).auroc, 3))
+```

--- a/swarm/detection/degradation.py
+++ b/swarm/detection/degradation.py
@@ -20,7 +20,7 @@ proxy-calibration metrics (Brier, ECE).
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Callable, Dict, List, Sequence
 
 import numpy as np
@@ -99,6 +99,42 @@ class StreamConfig:
     proxy_noise: float = 0.09
     # Per-epoch latent-quality jitter (std).
     quality_jitter: float = 0.02
+    # --- Population heterogeneity (default 0.0 -> homogeneous, original behavior) ---
+    # Per-agent spread of the *benign* quality level. With the default 0.0 every
+    # benign agent sits at exactly ``benign_quality``, which makes the two classes
+    # trivially separable (benign scores collapse to a point). A positive value
+    # samples each benign agent's quality from N(benign_quality, benign_quality_std),
+    # so the benign toxicity distribution has real width and its lower tail can
+    # overlap mildly-degraded agents — the single biggest driver of whether the
+    # soft AUROC is informative (<1.0) rather than saturated.
+    benign_quality_std: float = 0.0
+    # Per-agent spread of the degrading *floor*. With the default 0.0 every
+    # degrading agent decays toward the same ``quality_floor``. A positive value
+    # samples each degrading agent's floor from N(quality_floor, floor_std),
+    # clamped to ``[0, initial_quality]``; floors sampled near ``benign_quality``
+    # make the gap small/uncertain so those agents are genuinely hard to catch.
+    floor_std: float = 0.0
+
+    @classmethod
+    def heterogeneous(cls, **overrides: float) -> "StreamConfig":
+        """Preset where detection is a genuine statistical problem.
+
+        The homogeneous defaults make the two classes separable by ~8 standard
+        deviations, so soft AUROC saturates at 1.000 and the soft-vs-binary delta
+        is uninformative (see docs/notes/detection_soft_ceiling_caveat.md). This
+        preset adds benign heterogeneity and a raised, uncertain floor so soft
+        AUROC lands in ~0.80-0.90 — the regime where the gap to binary actually
+        measures something. Pair it with a short evaluation window (e.g. the last
+        ~3 epochs) for the cleanest signal. ``overrides`` are forwarded to the
+        constructor.
+        """
+        params: dict = {
+            "benign_quality_std": 0.10,
+            "quality_floor": 0.74,
+            "floor_std": 0.06,
+        }
+        params.update(overrides)
+        return cls(**params)
 
 
 @dataclass
@@ -227,10 +263,28 @@ def generate_population(
     labels = [True] * n_deg + [False] * (pop.n_agents - n_deg)
     rng.shuffle(labels)
 
+    cfg = pop.stream
     streams: List[AgentStream] = []
     for idx, is_deg in enumerate(labels):
         onset = int(rng.choice(pop.onset_choices)) if is_deg else 0
         traj = str(rng.choice(pop.trajectory_choices)) if is_deg else "linear"
+        # Per-agent quality heterogeneity. Guarded on std > 0 so the default
+        # (homogeneous) population draws the exact same RNG sequence as before.
+        agent_cfg = cfg
+        if is_deg and cfg.floor_std > 0.0:
+            floor = float(
+                np.clip(
+                    rng.normal(cfg.quality_floor, cfg.floor_std),
+                    0.0,
+                    cfg.initial_quality,
+                )
+            )
+            agent_cfg = replace(cfg, quality_floor=floor)
+        elif not is_deg and cfg.benign_quality_std > 0.0:
+            bq = float(
+                np.clip(rng.normal(cfg.benign_quality, cfg.benign_quality_std), 0.0, 1.0)
+            )
+            agent_cfg = replace(cfg, benign_quality=bq)
         # Decorrelate per-agent RNG streams from the label assignment RNG.
         agent_seed = int(rng.integers(0, 2**31 - 1))
         streams.append(
@@ -239,7 +293,7 @@ def generate_population(
                 is_degrading=is_deg,
                 onset_epoch=onset,
                 trajectory=traj,
-                cfg=pop.stream,
+                cfg=agent_cfg,
                 rng=np.random.default_rng(agent_seed),
             )
         )

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -11,6 +11,7 @@ import pytest
 from swarm.detection.curves import (
     calibration,
     compute_curve,
+    per_agent_scores,
     threshold_at_fpr,
     time_to_detection,
 )
@@ -123,6 +124,74 @@ def test_benign_quality_stays_above_acceptance():
     for s in streams:
         mean_p = np.mean([i.p for i in s.all_interactions()])
         assert mean_p > cfg.acceptance_threshold
+
+
+# ----------------------------------------------------------------------
+# population heterogeneity (breaks the saturated AUROC=1.0 ceiling)
+# ----------------------------------------------------------------------
+def _benign_toxicity_std(cfg: StreamConfig, *, seed: int = 0, n_agents: int = 300) -> float:
+    """Std of per-agent soft toxicity over a benign-only population (back half)."""
+    det = MatchedDetectors()
+    n = cfg.n_epochs
+    streams = generate_population(
+        PopulationConfig(n_agents=n_agents, base_rate=0.0, stream=cfg), seed=seed
+    )
+    vals = [det.soft_toxicity(s.window(n // 2, n)) for s in streams]
+    return float(np.std(vals))
+
+
+def test_default_population_is_homogeneous():
+    # With the (default) zero heterogeneity, benign agents collapse to nearly a
+    # single point — this is exactly what saturates soft AUROC at 1.0.
+    assert _benign_toxicity_std(StreamConfig()) < 0.02
+
+
+def test_benign_heterogeneity_widens_score_spread():
+    # benign_quality_std injects real width into the benign score distribution.
+    homo = _benign_toxicity_std(StreamConfig())
+    hetero = _benign_toxicity_std(StreamConfig(benign_quality_std=0.10))
+    assert hetero > 0.03
+    assert hetero > 5 * homo
+
+
+def test_floor_std_varies_degrading_floors():
+    # Hold onset and trajectory fixed so the *only* source of variation in
+    # late-epoch quality is floor_std. Default (floor_std=0): all degrading
+    # agents converge to the same floor (range ~ jitter). With floor_std they
+    # spread out — some barely degrade, staying near benign.
+    def late_range(cfg):
+        pop = PopulationConfig(
+            n_agents=120, base_rate=1.0, stream=cfg,
+            onset_choices=(4,), trajectory_choices=("linear",),
+        )
+        streams = generate_population(pop, seed=0)
+        late = [np.mean([i.p for i in s.epochs[-1]]) for s in streams]
+        return max(late) - min(late)
+
+    homo = late_range(StreamConfig())
+    hetero = late_range(StreamConfig(floor_std=0.06))
+    assert homo < 0.15  # only jitter + finite-sample spread
+    assert hetero > 0.20
+    assert hetero > 2 * homo
+
+
+def test_heterogeneous_preset_is_not_saturated():
+    # The whole point: under the heterogeneous preset + a short eval window, soft
+    # AUROC is a genuine (sub-1.0) score and still clearly beats binary, rather
+    # than both being pinned by the generator. Measured ~0.87 soft / ~0.58 binary.
+    cfg = StreamConfig.heterogeneous()
+    det = MatchedDetectors()
+    n = cfg.n_epochs
+    es, ee = n - 3, n
+    streams = generate_population(
+        PopulationConfig(n_agents=200, base_rate=0.2, stream=cfg), seed=0
+    )
+    sc, lab = per_agent_scores(streams, det.soft_toxicity, es, ee)
+    soft = compute_curve(sc, lab).auroc
+    sc, lab = per_agent_scores(streams, det.binary_toxicity, es, ee)
+    binary = compute_curve(sc, lab).auroc
+    assert 0.75 < soft < 0.98  # informative, not saturated
+    assert binary < soft - 0.10  # soft advantage survives, quantifiably
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The matched soft-vs-binary detection experiment reports **soft AUROC = 1.000 (zero variance)**. Digging into the generator (`swarm/detection/degradation.py`) showed this is a *ceiling of the synthetic setup*, not a power estimate: benign agents are pinned to a single fixed quality (0.85), degrading agents drift to a shared floor (0.66), and averaging ~50–100 interactions/agent separates the classes by **~8 standard deviations** (d′ ≈ 7.8, no overlap). AUROC ≈ 1.0 is then near-mathematically guaranteed, and the soft-vs-binary delta measures generator geometry rather than detection skill.

(The companion caveat note `docs/notes/detection_soft_ceiling_caveat.md` — on the detection-enhancements branch/PR — documents the diagnosis. This PR is the fix.)

## What changed

Two **opt-in** `StreamConfig` knobs, both default `0.0` so existing behavior, tests, and RNG sequences are byte-identical:

- **`benign_quality_std`** — per-agent benign quality spread. The single biggest driver of de-saturation: benign per-agent toxicity std rises from **0.009** (effectively a point mass) to **0.072** at 0.10, so the benign tail overlaps mildly-degraded agents.
- **`floor_std`** — per-agent degrading-floor spread (uncertain gap). With onset/trajectory fixed, degrading agents' late-epoch quality spans ~0.48–0.82 instead of collapsing to one floor; some barely degrade and are legitimately hard to catch.

New **`StreamConfig.heterogeneous()`** preset bundles a tuned operating point (`benign_quality_std=0.10, quality_floor=0.74, floor_std=0.06`). Paired with a short eval window (last ~3 epochs):

| seed | soft AUROC | binary AUROC | gap |
|---|---|---|---|
| 0 | 0.872 | 0.584 | +0.288 |
| 1 | 0.891 | 0.600 | +0.291 |
| 2 | 0.919 | 0.637 | +0.282 |

Soft lands in the informative **0.87–0.92** band; the soft advantage (~+0.28 AUROC) is now *measured*, not pinned. The qualitative story survives (soft beats binary; binary is structurally penalized because the floor sits above τ*=0.5) — only the saturated magnitudes change.

## Tests
- `test_default_population_is_homogeneous` — defaults still collapse benign to ~a point (guards the saturation is opt-out).
- `test_benign_heterogeneity_widens_score_spread`
- `test_floor_std_varies_degrading_floors`
- `test_heterogeneous_preset_is_not_saturated` — soft AUROC ∈ (0.75, 0.98) and binary < soft − 0.10.

All 24 detection tests pass; ruff + mypy clean.

## Docs
- `docs/notes/detection_informative_regime.md` — the regime, the numbers, the mechanism, and recommended use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)