### PR TITLE
fix(api): deterministic 404 in compare endpoint (fixes flaky test_compare_nonexistent_run_404)

### DIFF
--- a/swarm/api/routers/runs.py
+++ b/swarm/api/routers/runs.py
@@ -719,11 +719,18 @@ async def compare_runs(
     runs = store.get_multiple(run_ids)
     runs_by_id = {r.run_id: r for r in runs}
 
-    # Check access: agent must own or runs must be public
+    # Existence is checked for *all* ids first: a run that doesn't exist is a 404
+    # regardless of any sibling's access/completion state. Folding this into the
+    # access/completion loop below made the result order-dependent — a sibling
+    # that was momentarily not-yet-COMPLETED would raise 400 before a nonexistent
+    # id could raise 404 (the source of a flaky 400-vs-404 test).
     for rid in run_ids:
-        run = runs_by_id.get(rid)
-        if run is None:
+        if rid not in runs_by_id:
             raise HTTPException(status_code=404, detail=f"Run '{rid}' not found")
+
+    # Then access (must own or be public) and completion.
+    for rid in run_ids:
+        run = runs_by_id[rid]
         if run.visibility == RunVisibility.PRIVATE and run.agent_id != agent_id:
             raise HTTPException(status_code=403, detail=f"Access denied to run '{rid}'")
         if run.status != RunStatus.COMPLETED:

--- a/tests/test_agent_api.py
+++ b/tests/test_agent_api.py
@@ -1,6 +1,7 @@
 """Tests for the SWARM Agent API (runs, posts, middleware, persistence)."""
 
 import time
+from datetime import datetime, timezone
 
 import pytest
 
@@ -629,6 +630,36 @@ class TestCompareEndpoint:
         resp = client.get(
             f"/api/runs/compare?ids={run_a},nonexistent-id",
             headers=headers,
+        )
+        assert resp.status_code == 404
+
+    def test_compare_nonexistent_takes_precedence_over_incomplete(self, client):
+        """A nonexistent id returns 404 even when a sibling run is not yet
+        completed. Regression: the existence (404) and completion (400) checks
+        were one ordered loop, so a not-yet-COMPLETED sibling checked first
+        raised 400 before the missing id could raise 404 — a flaky 400-vs-404
+        depending on whether the real run had finished. Seeded deterministically
+        (no run-execution timing)."""
+        import swarm.api.routers.runs as runs_mod
+        from swarm.api.models.run import RunResponse, RunStatus, RunVisibility
+
+        agent_id, api_key = _register_agent(client)
+        rid = "run-still-running-001"
+        runs_mod._store.save(
+            RunResponse(
+                run_id=rid,
+                scenario_id="baseline",
+                status=RunStatus.RUNNING,  # NOT completed
+                visibility=RunVisibility.PUBLIC,
+                agent_id=agent_id,
+                created_at=datetime.now(timezone.utc),
+                status_url=f"/api/runs/{rid}",
+            )
+        )
+        # Nonexistent id present alongside a not-completed run -> 404 wins, not 400.
+        resp = client.get(
+            f"/api/runs/compare?ids={rid},nonexistent-id",
+            headers=_auth_header(api_key),
         )
         assert resp.status_code == 404
 


### PR DESCRIPTION
Fixes the intermittent `test_agent_api.py::TestCompareEndpoint::test_compare_nonexistent_run_404` (`assert 400 == 404`) that has been tripping the parallel CI smoke set (it blocked #463 earlier; passes in isolation, flakes under load).

## Root cause
`/api/runs/compare` checked **existence (404) and completion (400) in a single ordered loop**. With `ids={run_a},nonexistent-id`, `run_a` is checked first — if it was *momentarily not yet `COMPLETED`* when the request landed, line 730 raised **400** ("not completed") before the nonexistent id could raise **404**. Whether that happened depended on run-execution timing under load → flaky.

## Fix
Split into two passes: **existence for all ids first** (404 for any missing), then access + completion (403/400). A missing run is now a 404 regardless of any sibling's state — more correct *and* order-independent. Behavior only changes when a nonexistent id coexists with a 403/400 id (now 404 wins, which is the right precedence).

## Test
Adds `test_compare_nonexistent_takes_precedence_over_incomplete`, which **seeds a RUNNING run directly** + a nonexistent id and asserts 404 — locking in the precedence with zero run-execution timing. All 5 compare tests + full `test_agent_api.py` (65) pass under `-n 4`; ruff + mypy clean.

Per the repo's test-fix discipline: made deterministic at the source (check ordering), not by loosening the assertion.
