### PR TITLE
test(api): isolate default API DB to temp for the session (close get_store real-DB hazard)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,36 @@ def pytest_configure(config):
         raise SystemExit(1)
 
 
+@pytest.fixture(autouse=True, scope="session")
+def _isolate_default_api_db(tmp_path_factory):
+    """Redirect the agent-API persistence default DB path to a temp location for
+    the whole test session.
+
+    The API stores resolve their path as ``db_path or _DEFAULT_DB_PATH``. Per-test
+    fixtures pass an explicit temp ``db_path``, but a background run thread can
+    outlive its test, and any lazy ``get_store()`` call once the per-test store has
+    been reset to ``None`` constructs a store with *no* path — which would otherwise
+    fall back to the real ``runs/agent_api.db``, leaking test writes to the real
+    database and contaminating later tests. Pointing the default at a throwaway temp
+    file makes that fallback harmless. Guarded so environments that can't import the
+    persistence module (e.g. missing optional deps) still run.
+    """
+    try:
+        import swarm.api.persistence as persistence
+    except Exception:
+        yield
+        return
+
+    original = persistence._DEFAULT_DB_PATH
+    persistence._DEFAULT_DB_PATH = (
+        tmp_path_factory.mktemp("api_default_db") / "agent_api.db"
+    )
+    try:
+        yield
+    finally:
+        persistence._DEFAULT_DB_PATH = original
+
+
 # ---------------------------------------------------------------------------
 # Memory Profiling and Limiting
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #465. Closes the latent test-isolation hazard found while fixing the compare-endpoint flake.

## The hazard
API stores resolve their path as `db_path or _DEFAULT_DB_PATH`. Per-test fixtures pass an explicit temp `db_path`, **but**:
- runs execute in background threads that resolve the store lazily via `get_store()`, and
- a thread can outlive its test; once the per-test fixture resets `_store = None`, a late `get_store()` constructs a store with *no* path → falls back to the real `runs/agent_api.db`, leaking test writes to the real DB and contaminating later tests (a plausible source of intermittent cross-test failures).

## Fix
A session-scoped autouse fixture in `conftest.py` points `persistence._DEFAULT_DB_PATH` at a throwaway temp file for the whole test session, so the fallback can never touch the real database.

Chosen over joining background threads in teardown, which I prototyped but rejected — it stalled teardown up to ~60s waiting on lingering run threads. The path redirect is O(0) latency and strictly safer.

- Prod `get_store()` lazy-singleton behavior is **unchanged**; its dedicated lazy-init tests still pass.
- `test_agent_api.py` (65 tests) passes under `-n 4`, consistently ~3s (no teardown stalls); ruff + mypy clean.
- Guarded so environments that can't import the persistence module still run.
