### PR TITLE
Release v1.9.0: finalize CHANGELOG, bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-05-28
+
 ### Fixed
 - **Worktree bridge CLI missing `rich` in CI** — `swarm/bridges/worktree/__main__.py` imports `rich` unconditionally, but it was declared only in the niche `cli` extra, so CI's `[dev,runtime,api,analysis,gamescape]` install lacked it and `test_worktree_attest_then_agentgit_verify_loop` failed with `ModuleNotFoundError: No module named 'rich'` (the test drives the bridge as a subprocess). Moved `rich>=13.0` into the `runtime` extra.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "swarm-safety"
-version = "1.8.0"
+version = "1.9.0"
 description = "SWARM: System-Wide Assessment of Risk in Multi-agent systems - A Distributional AGI Safety framework"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Cuts **swarm-safety 1.9.0** (1.8.0 → 1.9.0) and rolls `[Unreleased]` into `[1.9.0] - 2026-05-28`.

Once merged, pushing tag `v1.9.0` triggers `release.yml` → validate / test / build / **publish to PyPI** / GitHub release.

## Highlights (since 1.8.0)

### Added
- **SWARM↔Aeon agent-first ledger bridge** (`swarm/bridges/aeon/`) — scores Aeon's real autonomous multi-agent activity with SWARM soft-metrics (#467).
- **AgentGit cryptographic identity + delegation chains** — Ed25519 DID identity, signed human→org→agent delegation, wired into bundle build/verify.
- **AgentGit provenance MVP** — diff-vs-policy attestation with a task-scoped signed bundle.

### Fixed
- Worktree bridge CLI missing `rich` in CI (moved `rich>=13.0` into the `runtime` extra).

## Checklist
- [x] `pyproject.toml` version = `1.9.0` (matches the tag `release.yml` validates)
- [x] CHANGELOG `[1.9.0] - 2026-05-28` header added, fresh empty `[Unreleased]` retained
- [x] ruff clean on new code; aeon bridge tests green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)