### PR TITLE
fix(release): install full test extras so PyPI publish isn't skipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,10 @@ jobs:
         with:
           python-version: "3.12"
 
-      - run: python -m pip install -e ".[dev,runtime]"
+      # Match ci.yml's full-test extras: the suite imports matplotlib (analysis),
+      # api, and gamescape deps, so a [dev,runtime]-only install fails at
+      # collection and silently skips build/publish (PyPI stuck at 1.5.0).
+      - run: python -m pip install -e ".[dev,runtime,api,analysis,gamescape]"
 
       - run: ruff check swarm/ tests/
 


### PR DESCRIPTION
## Problem

The `release.yml` `test` job installs only `.[dev,runtime]`, but the test suite imports `matplotlib` (the `analysis` extra), `api`, and `gamescape` deps. So on every tag push it fails at collection with 14 `ModuleNotFoundError` ImportErrors → `build`/`publish`/`github-release` are **skipped**.

**Consequence:** PyPI has been stuck at **1.5.0** since v1.6.0 — v1.6/1.7/1.8 (and just now v1.9.0) never published. The GitHub releases exist only because `populate-releases.yml` backfills them from the CHANGELOG.

## Fix

Align the release test job with `ci.yml`'s full-test job:
`.[dev,runtime]` → `.[dev,runtime,api,analysis,gamescape]`.

After this merges, re-tagging `v1.9.0` will run the pipeline through to the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)