### PR TITLE
fix(packaging): drop direct git dep so PyPI publish succeeds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,9 +121,12 @@ langgraph = [
     "langchain-ollama>=0.3.0",
     "langchain-openai>=0.3.0",
 ]
-evolve = [
-    "darwinian-evolver @ git+https://github.com/imbue-ai/darwinian_evolver.git",
-]
+# NOTE: darwinian-evolver is GitHub-only (not on PyPI). PyPI rejects direct
+# URL dependencies in published metadata (PEP 508 direct refs), so it cannot be
+# declared here. Install it alongside this extra when you need the evolve bridge:
+#   pip install "swarm-safety[evolve]" \
+#     "darwinian-evolver @ git+https://github.com/imbue-ai/darwinian_evolver.git"
+evolve = []
 gepa = [
     "gepa>=0.1.0",
 ]


### PR DESCRIPTION
## Problem

After the test-extras fix (#470), the v1.9.0 release got through `test` and `build`, but `publish` failed with a PyPI **400**:

> Can't have direct dependency: `darwinian-evolver @ git+https://github.com/imbue-ai/darwinian_evolver.git ; extra == "evolve"`

PyPI forbids PEP 508 direct-URL dependencies in uploaded metadata. This would block any version from publishing (it's why PyPI is still at 1.5.0 — combined with #470). OIDC trusted publishing itself works; this is purely a metadata issue.

## Fix

`darwinian-evolver` is GitHub-only (not on PyPI), so it can't be a declared dependency. The `evolve` extra becomes an empty no-op with a comment showing the manual git install. `all` does not reference `evolve`, so nothing else changes.

## Verified locally
- `python -m build` → wheel + sdist built
- `twine check dist/*` → **PASSED**
- built `METADATA` contains no `git+` line; `Provides-Extra: evolve` still present

After merge, re-tagging `v1.9.0` will run cleanly through to the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)