### PR TITLE
feat(agentgit): enriched, tamper-evident provenance block (8ll9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- **AgentGit enriched provenance** (`swarm/agentgit/bundle.py`, issue `8ll9`) — bundles now record a `provenance` block describing *what happened* producing the diff: `commands` run (binary, return code, OS `isolation` backend, duration; build via `CommandRecord.from_command_result`), `environment` (model/runtime/version), `dependency_changes` (manifest/lockfile edits detected automatically from the diff), `sources` consulted, reviewer `reviews`, and human `overrides`. The block is folded into the signed receipt payload, so it is **tamper-evident** — editing a recorded command or hiding a dependency change fails `verify_bundle`'s `payload_hash` check. Schema bumped to `agentgit.provenance.v1`; `verify_bundle` reconstructs the payload per version so older `v0` bundles still verify. Keystone for the policy engine (`b61g`) and reputation (`am5c`). 8 tests; `bundle.py` coverage 93%.
+
 ## [1.9.0] - 2026-05-28
 
 ### Fixed

--- a/docs/agentgit_mvp.md
+++ b/docs/agentgit_mvp.md
@@ -20,10 +20,45 @@ The bundle records:
 - additions/deletions by file
 - path and size policy decisions
 - required check results
+- a `provenance` block of *what happened* producing the diff (see below)
 - sealed admissibility receipt with the payload hash
 
 Policy failures return a non-zero exit code by default. Use `--warn-only` when
 you want to capture the bundle without blocking the current command.
+
+## Provenance Contents
+
+Beyond the diff and policy verdict, schema `agentgit.provenance.v1` records a
+`provenance` block describing how the change was produced:
+
+- `commands` — commands executed (binary + args, return code, OS `isolation`
+  backend, duration, timeout). Build these from a worktree `CommandResult` via
+  `CommandRecord.from_command_result(result)`.
+- `environment` — model / runtime / version of the producing agent.
+- `dependency_changes` — manifest/lockfile edits (`requirements.txt`,
+  `pyproject.toml`, `package-lock.json`, `Cargo.lock`, `go.sum`, …) detected
+  **automatically** from the diff.
+- `sources` — external sources consulted.
+- `reviews` — reviewer decisions.
+- `overrides` — human overrides.
+
+```python
+from swarm.agentgit import CommandRecord, build_bundle
+
+bundle = build_bundle(
+    ...,
+    commands=[CommandRecord(command=["pytest", "-q"], return_code=0, isolation="bwrap")],
+    environment={"model": "claude-opus-4-7", "runtime": "python3.13"},
+    sources=["https://example.com/issue/123"],
+    reviews=[{"reviewer": "security", "decision": "approve"}],
+)
+```
+
+The `provenance` block is folded into the signed receipt payload, so it is
+**tamper-evident**: editing a recorded command or hiding a dependency change
+makes `verify_bundle` fail the `payload_hash` check. Older `v0` bundles (hashed
+without provenance) still verify — `verify_bundle` reconstructs the payload per
+schema version.
 
 ## Worktree Loop
 

--- a/docs/agentgit_mvp.md
+++ b/docs/agentgit_mvp.md
@@ -31,9 +31,9 @@ you want to capture the bundle without blocking the current command.
 Beyond the diff and policy verdict, schema `agentgit.provenance.v1` records a
 `provenance` block describing how the change was produced:
 
-- `commands` — commands executed (binary + args, return code, OS `isolation`
-  backend, duration, timeout). Build these from a worktree `CommandResult` via
-  `CommandRecord.from_command_result(result)`.
+- `commands` — commands executed (binary + args, `return_code`, OS `isolation`
+  backend, `duration_seconds`, and a `timed_out` flag). Build these from a
+  worktree `CommandResult` via `CommandRecord.from_command_result(result)`.
 - `environment` — model / runtime / version of the producing agent.
 - `dependency_changes` — manifest/lockfile edits (`requirements.txt`,
   `pyproject.toml`, `package-lock.json`, `Cargo.lock`, `go.sum`, …) detected

--- a/swarm/agentgit/__init__.py
+++ b/swarm/agentgit/__init__.py
@@ -5,7 +5,12 @@ task-scoped policy checks and signed provenance bundles for agent-authored
 changes.
 """
 
-from swarm.agentgit.bundle import build_bundle, verify_bundle, write_bundle
+from swarm.agentgit.bundle import (
+    CommandRecord,
+    build_bundle,
+    verify_bundle,
+    write_bundle,
+)
 from swarm.agentgit.capabilities import (
     CAPABILITY_COMMANDS,
     enforced_allowlist_for_chain,
@@ -25,6 +30,7 @@ __all__ = [
     "AgentGitPolicy",
     "AgentIdentity",
     "AgentKeypair",
+    "CommandRecord",
     "DelegationChain",
     "DelegationLink",
     "PolicyDecision",

--- a/swarm/agentgit/bundle.py
+++ b/swarm/agentgit/bundle.py
@@ -8,6 +8,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
+from pydantic import ValidationError
+
 from swarm.agentgit.git import GitSnapshot, collect_snapshot
 from swarm.agentgit.identity import (
     AgentIdentity,
@@ -57,11 +59,15 @@ _DEPENDENCY_FILENAMES = {
 class CommandRecord:
     """One command executed while producing the diff, for the provenance log."""
 
-    command: List[str]
+    command: Sequence[str]
     return_code: Optional[int] = None
     isolation: str = "none"
     duration_seconds: Optional[float] = None
     timed_out: bool = False
+
+    def __post_init__(self) -> None:
+        # Store immutably so a frozen record is truly value-immutable.
+        object.__setattr__(self, "command", tuple(self.command))
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -77,7 +83,7 @@ class CommandRecord:
         """Adapt a worktree ``SandboxExecutor`` result (duck-typed, no import)."""
 
         return cls(
-            command=list(result.command),
+            command=tuple(result.command),
             return_code=result.return_code,
             isolation=getattr(result, "isolation", "none"),
             duration_seconds=getattr(result, "duration_seconds", None),
@@ -197,7 +203,14 @@ def verify_bundle(
     if bundle.get("schema_version") not in _SUPPORTED_SCHEMAS:
         errors.append("unsupported schema_version")
 
-    receipt = AdmissibilityReceipt.model_validate(bundle.get("receipt", {}))
+    # verify_bundle runs over untrusted input; a malformed receipt must fail
+    # gracefully rather than raise out of the verifier.
+    try:
+        receipt = AdmissibilityReceipt.model_validate(bundle.get("receipt", {}))
+    except ValidationError:
+        errors.append("receipt failed schema validation")
+        return False, errors
+
     payload = _payload_from_bundle(bundle)
     expected_hash = AdmissibilityReceipt.hash_payload(payload)
     if receipt.payload_hash != expected_hash:

--- a/swarm/agentgit/bundle.py
+++ b/swarm/agentgit/bundle.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import json
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Sequence
 
 from swarm.agentgit.git import GitSnapshot, collect_snapshot
 from swarm.agentgit.identity import (
@@ -27,6 +27,63 @@ from swarm.attestation.signer import ReceiptSigner, ReceiptVerifier
 
 DEFAULT_DEV_SIGNING_KEY = "0" * 64
 
+SCHEMA_V0 = "agentgit.provenance.v0"
+SCHEMA_V1 = "agentgit.provenance.v1"
+_SUPPORTED_SCHEMAS = {SCHEMA_V0, SCHEMA_V1}
+
+# Manifest / lockfiles whose changes are recorded as dependency changes.
+_DEPENDENCY_FILENAMES = {
+    "requirements.txt",
+    "pyproject.toml",
+    "poetry.lock",
+    "Pipfile",
+    "Pipfile.lock",
+    "setup.py",
+    "setup.cfg",
+    "package.json",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "Cargo.toml",
+    "Cargo.lock",
+    "go.mod",
+    "go.sum",
+    "Gemfile",
+    "Gemfile.lock",
+}
+
+
+@dataclass(frozen=True)
+class CommandRecord:
+    """One command executed while producing the diff, for the provenance log."""
+
+    command: List[str]
+    return_code: Optional[int] = None
+    isolation: str = "none"
+    duration_seconds: Optional[float] = None
+    timed_out: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "command": list(self.command),
+            "return_code": self.return_code,
+            "isolation": self.isolation,
+            "duration_seconds": self.duration_seconds,
+            "timed_out": self.timed_out,
+        }
+
+    @classmethod
+    def from_command_result(cls, result: Any) -> "CommandRecord":
+        """Adapt a worktree ``SandboxExecutor`` result (duck-typed, no import)."""
+
+        return cls(
+            command=list(result.command),
+            return_code=result.return_code,
+            isolation=getattr(result, "isolation", "none"),
+            duration_seconds=getattr(result, "duration_seconds", None),
+            timed_out=getattr(result, "timed_out", False),
+        )
+
 
 def build_bundle(
     *,
@@ -41,6 +98,11 @@ def build_bundle(
     identity: AgentIdentity | None = None,
     agent_keypair: AgentKeypair | None = None,
     delegation: DelegationChain | None = None,
+    commands: Sequence[CommandRecord] | None = None,
+    environment: Dict[str, Any] | None = None,
+    sources: Sequence[str] | None = None,
+    reviews: Sequence[Dict[str, Any]] | None = None,
+    overrides: Sequence[Dict[str, Any]] | None = None,
 ) -> Dict[str, Any]:
     """Build a signed provenance bundle for the current git diff.
 
@@ -48,11 +110,27 @@ def build_bundle(
     key signs the receipt ``payload_hash``, binding a *verifiable* identity to
     this exact diff. An optional ``delegation`` chain records the
     ``human -> org -> agent`` authority under which the agent acted.
+
+    The ``provenance`` block records *what happened* producing the diff —
+    commands run, execution environment, dependency-manifest changes (detected
+    automatically from the diff), external sources consulted, reviewer
+    decisions, and human overrides. It is folded into the signed receipt
+    payload, so it is tamper-evident: altering it fails verification.
     """
 
     snapshot = collect_snapshot(repo, base_ref=base_ref)
     decisions = policy.evaluate(snapshot, check_results=check_results)
-    payload = _payload(task_id, agent_id, snapshot, decisions, check_results or {})
+    provenance = _build_provenance(
+        snapshot,
+        commands=commands,
+        environment=environment,
+        sources=sources,
+        reviews=reviews,
+        overrides=overrides,
+    )
+    payload = _payload(
+        task_id, agent_id, snapshot, decisions, check_results or {}, provenance
+    )
     receipt = _seal_receipt(
         payload=payload,
         agent_id=agent_id,
@@ -62,7 +140,7 @@ def build_bundle(
     )
 
     bundle: Dict[str, Any] = {
-        "schema_version": "agentgit.provenance.v0",
+        "schema_version": SCHEMA_V1,
         "created_at": datetime.now(timezone.utc).isoformat(),
         "task": {"task_id": task_id},
         "agent": {"agent_id": agent_id},
@@ -72,6 +150,7 @@ def build_bundle(
             "decisions": [asdict(decision) for decision in decisions],
         },
         "checks": check_results or {},
+        "provenance": provenance,
         "receipt": receipt.model_dump(mode="json"),
     }
 
@@ -115,7 +194,7 @@ def verify_bundle(
     """Verify bundle hash, receipt signature, and optional policy pass state."""
 
     errors: List[str] = []
-    if bundle.get("schema_version") != "agentgit.provenance.v0":
+    if bundle.get("schema_version") not in _SUPPORTED_SCHEMAS:
         errors.append("unsupported schema_version")
 
     receipt = AdmissibilityReceipt.model_validate(bundle.get("receipt", {}))
@@ -185,6 +264,7 @@ def _payload(
     snapshot: GitSnapshot,
     decisions: list[PolicyDecision],
     check_results: Dict[str, bool],
+    provenance: Dict[str, Any],
 ) -> Dict[str, Any]:
     return {
         "task_id": task_id,
@@ -192,16 +272,54 @@ def _payload(
         "git": _snapshot_dict(snapshot),
         "policy_decisions": [asdict(decision) for decision in decisions],
         "checks": check_results,
+        "provenance": provenance,
     }
 
 
 def _payload_from_bundle(bundle: Dict[str, Any]) -> Dict[str, Any]:
-    return {
+    payload: Dict[str, Any] = {
         "task_id": bundle.get("task", {}).get("task_id"),
         "agent_id": bundle.get("agent", {}).get("agent_id"),
         "git": bundle.get("git", {}),
         "policy_decisions": bundle.get("policy", {}).get("decisions", []),
         "checks": bundle.get("checks", {}),
+    }
+    # The provenance block joined the signed payload in schema v1; v0 bundles
+    # were hashed without it, so reconstruct per version to stay compatible.
+    if bundle.get("schema_version") == SCHEMA_V1:
+        payload["provenance"] = bundle.get("provenance", {})
+    return payload
+
+
+def _detect_dependency_changes(snapshot: GitSnapshot) -> List[Dict[str, Any]]:
+    """Flag changed files that are dependency manifests/lockfiles."""
+
+    changes: List[Dict[str, Any]] = []
+    for changed in snapshot.changed_files:
+        filename = changed.path.rsplit("/", 1)[-1]
+        if filename in _DEPENDENCY_FILENAMES:
+            changes.append({"path": changed.path, "status": changed.status})
+    return changes
+
+
+def _build_provenance(
+    snapshot: GitSnapshot,
+    *,
+    commands: Sequence[CommandRecord] | None,
+    environment: Dict[str, Any] | None,
+    sources: Sequence[str] | None,
+    reviews: Sequence[Dict[str, Any]] | None,
+    overrides: Sequence[Dict[str, Any]] | None,
+) -> Dict[str, Any]:
+    """Assemble the provenance block (all keys always present, for stability)."""
+
+    return {
+        "commands": [record.to_dict() for record in (commands or [])],
+        "environment": dict(environment or {}),
+        "dependency_changes": _detect_dependency_changes(snapshot),
+        "sources": list(sources or []),
+        "reviews": [dict(review) for review in (reviews or [])],
+        "overrides": [dict(override) for override in (overrides or [])],
     }
 
 

--- a/tests/test_agentgit.py
+++ b/tests/test_agentgit.py
@@ -59,7 +59,7 @@ def test_build_bundle_passes_for_allowed_diff(tmp_path):
         check_results={"pytest": True},
     )
 
-    assert bundle["schema_version"] == "agentgit.provenance.v0"
+    assert bundle["schema_version"] == "agentgit.provenance.v1"
     assert bundle["policy"]["passed"] is True
     assert bundle["git"]["totals"]["changed_files"] == 1
     assert bundle["receipt"]["status"] == "sealed"

--- a/tests/test_agentgit_provenance.py
+++ b/tests/test_agentgit_provenance.py
@@ -1,0 +1,209 @@
+"""Tests for the enriched provenance block (issue 8ll9)."""
+
+import subprocess
+from pathlib import Path
+
+from swarm.agentgit.bundle import (
+    SCHEMA_V1,
+    CommandRecord,
+    build_bundle,
+    verify_bundle,
+)
+from swarm.agentgit.policy import AgentGitPolicy
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "a@b.c")
+    _git(repo, "config", "user.name", "t")
+    (repo / "README.md").write_text("base\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "init")
+    return repo
+
+
+def _allowed_diff(repo: Path) -> None:
+    src = repo / "swarm"
+    src.mkdir()
+    (src / "ok.py").write_text("print('ok')\n")
+
+
+def _bundle(repo: Path, **kwargs):
+    return build_bundle(
+        repo=repo,
+        task_id="issue-prov",
+        agent_id="codex",
+        policy=AgentGitPolicy(allowed_paths=["swarm/**", "requirements.txt", "pyproject.toml"]),
+        **kwargs,
+    )
+
+
+# --- CommandRecord ---
+
+
+def test_command_record_to_dict_roundtrip():
+    rec = CommandRecord(command=["pytest", "-q"], return_code=0, isolation="bwrap")
+    d = rec.to_dict()
+    assert d["command"] == ["pytest", "-q"]
+    assert d["return_code"] == 0
+    assert d["isolation"] == "bwrap"
+    assert d["timed_out"] is False
+
+
+def test_command_record_from_command_result_duck_typed():
+    class FakeResult:
+        command = ["python", "-c", "x"]
+        return_code = 1
+        isolation = "sandbox-exec"
+        duration_seconds = 0.4
+        timed_out = False
+
+    rec = CommandRecord.from_command_result(FakeResult())
+    assert rec.command == ["python", "-c", "x"]
+    assert rec.isolation == "sandbox-exec"
+    assert rec.return_code == 1
+
+
+# --- provenance block ---
+
+
+def test_bundle_defaults_to_schema_v1_with_empty_provenance(tmp_path):
+    repo = _init_repo(tmp_path)
+    _allowed_diff(repo)
+    bundle = _bundle(repo)
+    assert bundle["schema_version"] == SCHEMA_V1
+    prov = bundle["provenance"]
+    assert prov["commands"] == []
+    assert prov["dependency_changes"] == []
+    assert set(prov) == {
+        "commands",
+        "environment",
+        "dependency_changes",
+        "sources",
+        "reviews",
+        "overrides",
+    }
+    ok, errors = verify_bundle(bundle)
+    assert ok, errors
+
+
+def test_provenance_records_all_inputs(tmp_path):
+    repo = _init_repo(tmp_path)
+    _allowed_diff(repo)
+    bundle = _bundle(
+        repo,
+        commands=[CommandRecord(command=["pytest"], return_code=0, isolation="bwrap")],
+        environment={"model": "claude-opus-4-7", "runtime": "python3.13"},
+        sources=["https://example.com/spec"],
+        reviews=[{"reviewer": "security", "decision": "approve"}],
+        overrides=[{"by": "alice", "reason": "false positive"}],
+    )
+    prov = bundle["provenance"]
+    assert prov["commands"][0]["command"] == ["pytest"]
+    assert prov["commands"][0]["isolation"] == "bwrap"
+    assert prov["environment"]["model"] == "claude-opus-4-7"
+    assert prov["sources"] == ["https://example.com/spec"]
+    assert prov["reviews"][0]["decision"] == "approve"
+    assert prov["overrides"][0]["by"] == "alice"
+    ok, errors = verify_bundle(bundle)
+    assert ok, errors
+
+
+def test_dependency_changes_detected_automatically(tmp_path):
+    repo = _init_repo(tmp_path)
+    _allowed_diff(repo)
+    (repo / "requirements.txt").write_text("requests>=2\n")
+    (repo / "pyproject.toml").write_text("[project]\nname='x'\n")
+    bundle = _bundle(repo)
+    paths = {c["path"] for c in bundle["provenance"]["dependency_changes"]}
+    assert "requirements.txt" in paths
+    assert "pyproject.toml" in paths
+    # A non-manifest file is not flagged as a dependency change.
+    assert "swarm/ok.py" not in paths
+
+
+# --- tamper-evidence: provenance is in the signed payload ---
+
+
+def test_tampering_with_commands_fails_verification(tmp_path):
+    repo = _init_repo(tmp_path)
+    _allowed_diff(repo)
+    bundle = _bundle(
+        repo, commands=[CommandRecord(command=["pytest"], return_code=0)]
+    )
+    ok, _ = verify_bundle(bundle)
+    assert ok
+    # Forge the command log; the receipt payload_hash should no longer match.
+    bundle["provenance"]["commands"][0]["command"] = ["rm", "-rf", "/"]
+    ok, errors = verify_bundle(bundle)
+    assert not ok
+    assert any("payload_hash does not match" in e for e in errors)
+
+
+def test_tampering_with_dependency_changes_fails_verification(tmp_path):
+    repo = _init_repo(tmp_path)
+    _allowed_diff(repo)
+    (repo / "requirements.txt").write_text("requests>=2\n")
+    bundle = _bundle(repo)
+    ok, _ = verify_bundle(bundle)
+    assert ok
+    bundle["provenance"]["dependency_changes"] = []  # hide the dep change
+    ok, errors = verify_bundle(bundle)
+    assert not ok
+    assert any("payload_hash does not match" in e for e in errors)
+
+
+# --- v0 backward compatibility ---
+
+
+def test_legacy_v0_bundle_still_verifies(tmp_path):
+    """A v0 bundle was hashed without provenance; reconstruction must match."""
+    from dataclasses import asdict
+
+    from swarm.agentgit.bundle import _seal_receipt, _snapshot_dict
+    from swarm.agentgit.git import collect_snapshot
+
+    repo = _init_repo(tmp_path)
+    _allowed_diff(repo)
+    policy = AgentGitPolicy(allowed_paths=["swarm/**"])
+    snapshot = collect_snapshot(repo, base_ref="HEAD")
+    decisions = policy.evaluate(snapshot, check_results={})
+    git_dict = _snapshot_dict(snapshot)
+    decision_dicts = [asdict(d) for d in decisions]
+
+    # Hash a v0-style payload (no provenance) and assemble a v0 bundle by hand.
+    v0_payload = {
+        "task_id": "issue-legacy",
+        "agent_id": "codex",
+        "git": git_dict,
+        "policy_decisions": decision_dicts,
+        "checks": {},
+    }
+    receipt = _seal_receipt(
+        payload=v0_payload,
+        agent_id="codex",
+        signing_key="0" * 64,
+        signer_id="agentgit-local",
+        decisions=decisions,
+    )
+    bundle = {
+        "schema_version": "agentgit.provenance.v0",
+        "task": {"task_id": "issue-legacy"},
+        "agent": {"agent_id": "codex"},
+        "git": git_dict,
+        "policy": {"passed": True, "decisions": decision_dicts},
+        "checks": {},
+        "receipt": receipt.model_dump(mode="json"),
+    }
+    ok, errors = verify_bundle(bundle)
+    assert ok, errors

--- a/tests/test_agentgit_provenance.py
+++ b/tests/test_agentgit_provenance.py
@@ -69,7 +69,7 @@ def test_command_record_from_command_result_duck_typed():
         timed_out = False
 
     rec = CommandRecord.from_command_result(FakeResult())
-    assert rec.command == ["python", "-c", "x"]
+    assert list(rec.command) == ["python", "-c", "x"]
     assert rec.isolation == "sandbox-exec"
     assert rec.return_code == 1
 
@@ -148,6 +148,24 @@ def test_tampering_with_commands_fails_verification(tmp_path):
     ok, errors = verify_bundle(bundle)
     assert not ok
     assert any("payload_hash does not match" in e for e in errors)
+
+
+def test_verify_handles_malformed_receipt_gracefully():
+    # verify_bundle runs over untrusted input; a bad receipt must return
+    # (False, errors), not raise a pydantic ValidationError.
+    bundle = {
+        "schema_version": SCHEMA_V1,
+        "task": {"task_id": "x"},
+        "agent": {"agent_id": "y"},
+        "git": {},
+        "policy": {"passed": True, "decisions": []},
+        "checks": {},
+        "provenance": {},
+        "receipt": {"not": "a valid receipt"},
+    }
+    ok, errors = verify_bundle(bundle)
+    assert not ok
+    assert any("receipt failed schema validation" in e for e in errors)
 
 
 def test_tampering_with_dependency_changes_fails_verification(tmp_path):


### PR DESCRIPTION
## What

AgentGit bundles recorded the diff and the policy verdict, but not *what happened* producing the change. This adds a `provenance` block (schema `agentgit.provenance.v1`) capturing:

- **`commands`** — executed commands (binary + args, return code, OS `isolation` backend, duration, timeout). `CommandRecord.from_command_result(result)` adapts a worktree `SandboxExecutor` result.
- **`environment`** — model / runtime / version of the producing agent.
- **`dependency_changes`** — manifest/lockfile edits (`requirements.txt`, `pyproject.toml`, `package-lock.json`, `Cargo.lock`, `go.sum`, …) detected **automatically** from the diff.
- **`sources`** / **`reviews`** / **`overrides`** — external sources consulted, reviewer decisions, human overrides.

## Tamper-evidence

The block is folded into the **signed receipt payload**, so editing a recorded command or hiding a dependency change fails `verify_bundle`'s `payload_hash` check (two tests assert this). Schema bumped to `v1`; `verify_bundle` reconstructs the payload **per schema version**, so older `v0` bundles still verify (covered by a back-compat test).

## Why now

This is the **keystone** for the rest of the epic: `b61g` (policy engine: "if deps changed → supply-chain scan", "if low confidence → human review") and `am5c` (reputation) both need a bundle that records what the agent actually did.

## Tests

8 new tests (`CommandRecord` roundtrip + duck-typed adapter, full provenance recording, automatic dependency detection, two tamper-evidence checks, v0 back-compat). Full agentgit suite green (54 passed); `bundle.py` coverage 93%; ruff + mypy clean.

## Scope / follow-up
Library + auto dependency detection. Auto-populating `commands` from the worktree CLI's event history is a small follow-up (the library API + `from_command_result` adapter are in place).

Closes `8ll9` (epic `0pvm`). Builds on `enqe` + `7ge5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)