### PR TITLE
fix(release): run release tests in parallel with a timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,10 @@ jobs:
 
       - run: mypy swarm/
 
-      - run: pytest tests/ -v --cov=swarm --cov-fail-under=70
+      # Mirror ci.yml's full-test runner: -n auto (parallel; serial took ~60min
+      # and could hang) and --timeout=300 (a hung test is killed, not left to
+      # stall the release forever). Coverage gate retained for releases.
+      - run: pytest tests/ -v -n auto --dist=loadfile --timeout=300 --cov=swarm --cov-fail-under=70
 
   build:
     needs: test


### PR DESCRIPTION
## Problem

After #470 and #473, the v1.9.0 release got through `validate` but the `test` job ran **~60 min and stalled** — `release.yml` runs `pytest tests/ -v --cov ...` with **no `-n auto`** (serial) and **no `--timeout`**, so a hanging test (e.g. a networked one) never gets killed. `ci.yml`'s full-test job — which passes in ~9 min — uses `-n auto --dist=loadfile --timeout=300`.

## Fix

Align the release test command with ci.yml:
`pytest tests/ -v -n auto --dist=loadfile --timeout=300 --cov=swarm --cov-fail-under=70`

Parallel (fast) + per-test timeout (no hangs), coverage gate retained.

After merge, re-tagging `v1.9.0` should run `test` in ~10 min and proceed through build → publish → release. The packaging (#473) and extras (#470) fixes are already verified locally via `python -m build` + `twine check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)