### PR TITLE
docs(release): rewrite /release skill for the real publish flow + sync versions

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,62 +1,82 @@
 # /release
 
-Tag a commit and create a GitHub release with auto-generated notes.
+Cut a `swarm-safety` release end-to-end: bump versions, finalize the CHANGELOG via a Release PR, tag `main`, and shepherd the `release.yml` pipeline through to the **PyPI publish** and GitHub release — then verify it actually landed.
+
+Pushing a `v*` tag triggers `.github/workflows/release.yml`: `validate → test → build → publish (PyPI, OIDC trusted publishing) → github-release`. This command's job is to make that pipeline succeed on the first tag and to recover cleanly if it doesn't.
 
 ## Usage
 
 `/release [version] [--commit SHA]`
 
 Examples:
-- `/release` (auto-increment from latest tag)
-- `/release v1.1.0` (explicit version)
-- `/release v1.0.1 --commit abc1234` (tag a specific commit)
+- `/release` (minor-bump from the latest tag, confirm with user)
+- `/release 1.9.0`
+- `/release --recover` (a tag exists but its run failed before publishing — re-validate, fix, re-point the tag)
 
-## Behavior
+## Critical invariants (these silently broke 1.6.0–1.8.0)
 
-1) **Determine version**:
-- If `<version>` is provided, use it (must start with `v`).
-- Otherwise, find the latest tag with `git tag -l 'v*' --sort=-v:refname | head -1`.
-  - If no tags exist, default to `v0.1.0`.
-  - Otherwise, bump the minor version (e.g. `v1.0.0` → `v1.1.0`).
-  - Ask the user to confirm or override.
+Before tagging, confirm all three or the publish will fail *after* a 10–60 min CI run:
 
-2) **Determine commit**:
-- If `--commit SHA` is provided, use that commit.
-- Otherwise, use HEAD.
-- Show the commit message and ask the user to confirm.
+1. **`release.yml` test extras** — the test job must install `.[dev,runtime,api,analysis,gamescape]` (matches `ci.yml`). A bare `.[dev,runtime]` misses `matplotlib` etc. → 14 collection errors → build/publish silently skipped.
+2. **No direct-URL deps in `pyproject.toml`** — PyPI rejects PEP 508 direct refs (`pkg @ git+https://…`) with a 400 *after* build. Keep such deps out of declared extras (document a manual install instead).
+3. **`release.yml` test runs `-n auto --dist=loadfile --timeout=300`** — serial + no timeout means ~60 min and a networked test can hang forever.
 
-3) **Generate release notes**:
-- List all commits since the previous tag (or all commits if first release): `git log <prev-tag>..HEAD --oneline`
-- Group commits by prefix pattern:
-  - `Add/Create` → "New"
-  - `Fix` → "Fixes"
-  - `Update/Refactor/Enhance` → "Improvements"
-  - `Remove/Delete` → "Removed"
-  - Everything else → "Other"
-- Include a "Quick Start" section with install + run instructions.
+## Steps
 
-4) **Update CHANGELOG.md**:
-- Read `CHANGELOG.md`.
-- Convert the `## [Unreleased]` section into a versioned entry: `## [<version>] - <YYYY-MM-DD>`.
-- Organize entries under Keep a Changelog categories (`### Added`, `### Changed`, `### Fixed`, `### Removed`). Use the grouped commits from step 3 as a starting point, but **read the actual diffs** to write human-quality descriptions rather than echoing raw commit messages. Highlight:
-  - New modules, handlers, bridges, or agent types
-  - New scenario configs or governance levers
-  - Test count changes (e.g. "2922 tests" → "2950 tests")
-  - Breaking changes or renamed APIs
-- Add a fresh empty `## [Unreleased]` section above the new entry.
-- Commit the CHANGELOG update: `git add CHANGELOG.md && git commit -m "Update CHANGELOG for <version>"`.
-- If pyproject.toml version doesn't match `<version>` (without the `v` prefix), update it and amend the commit.
+1. **Pre-flight**: be on `main`, clean tree, synced (`git fetch origin main`; `HEAD == origin/main`). Determine the version: default = minor bump of `git tag -l 'v*' --sort=-v:refname | head -1`; confirm with the user. Must be valid semver.
 
-5) **Create tag and release**:
-- `git tag <version> <commit> -m "<version>: <summary>"`
-- `git push origin <version>`
-- `gh release create <version> --title "<version>: <summary>" --notes "<generated notes>"`
+2. **Bump versions** — run `/bump_version <X.Y.Z>` (updates `pyproject.toml`, `CITATION.cff`, `skill.md`). All three MUST match the tag, or `validate` fails.
 
-6) **Print the release URL**.
+3. **Finalize CHANGELOG** — roll `## [Unreleased]` → `## [X.Y.Z] - <YYYY-MM-DD>`, add a fresh empty `## [Unreleased]`. Read the diffs since the last tag and write human-quality entries under `### Added/Changed/Fixed/Removed`.
+
+4. **Local pre-validation (BEFORE tagging — this catches the publish-blockers cheaply):**
+   ```bash
+   python -m build && python -m twine check dist/*
+   ```
+   Then inspect the built metadata for direct-URL deps that PyPI will reject:
+   ```bash
+   python -c "import zipfile,glob; w=glob.glob('dist/*.whl')[0]; m=[n for n in zipfile.ZipFile(w).namelist() if n.endswith('METADATA')][0]; t=zipfile.ZipFile(w).read(m).decode(); print('DIRECT-URL DEPS:', [l for l in t.splitlines() if 'git+' in l or '@ http' in l] or 'none')"
+   ```
+   If `twine check` fails or any direct-URL dep prints, fix `pyproject.toml` before proceeding (invariant 2).
+
+5. **Release PR** — open `Release vX.Y.Z: finalize CHANGELOG, bump version` with the bump + CHANGELOG changes. Wait for CI green, then merge to `main` (squash). `git fetch origin main`.
+
+6. **Tag & push** — tag the merged `main` commit and push:
+   ```bash
+   git tag -a vX.Y.Z origin/main -m "swarm-safety X.Y.Z"
+   git push origin vX.Y.Z
+   ```
+   Do **NOT** run `gh release create` yourself — `release.yml`'s `github-release` job owns it. The tag version must equal `pyproject.toml`'s.
+
+7. **Watch the pipeline** — `gh run watch` (or poll) the `release.yml` run. Expect `test` ~10 min. Report each job: `validate → test → build → publish → github-release`.
+
+8. **Verify it landed**:
+   ```bash
+   curl -s https://pypi.org/pypi/swarm-safety/json | python -c "import sys,json;print('PyPI latest:', json.load(sys.stdin)['info']['version'])"
+   # fresh-venv install + import as a smoke test:
+   python -m venv /tmp/rel-check && /tmp/rel-check/bin/pip install -q "swarm-safety==X.Y.Z" && /tmp/rel-check/bin/python -c "import swarm; print('import OK')"
+   gh release view vX.Y.Z --json tagName,url --jq '.tagName + " " + .url'
+   ```
+
+## Recovery (`--recover`): a tag exists but the run failed before publishing
+
+If `publish` did **not** run (failure at `validate`/`test`/`build`), the version was never uploaded, so the tag can be safely re-pointed:
+1. Diagnose: `gh run view <id> --log-failed`. Fix the cause on `main` via a PR (e.g. a `release.yml` extras/timeout fix, or a `pyproject` direct-dep) and merge.
+2. Re-point the tag to the fixed commit:
+   ```bash
+   git push origin :refs/tags/vX.Y.Z   # delete remote tag
+   git tag -d vX.Y.Z
+   git fetch origin main
+   git tag -a vX.Y.Z origin/main -m "swarm-safety X.Y.Z"
+   git push origin vX.Y.Z              # re-triggers release.yml
+   ```
+3. Re-watch (step 7) and verify (step 8).
+
+If `publish` itself failed with a PyPI **400 direct-dependency** error → invariant 2 (fix the extra, recover as above). If it failed because the **version already exists on PyPI**, that version is burned — bump to the next patch and start over (PyPI never lets a version be reused).
 
 ## Constraints
 
-- Never overwrite an existing tag. If the version already exists, abort and tell the user.
-- Never force-push tags.
-- Always confirm the version and commit with the user before tagging.
-- If `gh` CLI is not available, fall back to just creating the local tag and pushing it.
+- **Re-pointing a tag is allowed ONLY if that version never published to PyPI.** Check first (`curl …/pypi/swarm-safety/json`). Never move a tag whose version is already live — bump instead.
+- Never manually `gh release create` — `release.yml` owns the GitHub release (doing both double-creates).
+- Never force-push `main`. Always confirm the version with the user before tagging.
+- Pre-validate locally (step 4) before every tag — a failed tagged run costs a full CI cycle.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ title: "SWARM: System-Wide Assessment of Risk in Multi-agent systems"
 type: software
 authors:
   - name: "Raeli Savitt"
-version: "1.7.0"
+version: "1.9.0"
 date-released: "2026-02-05"
 license: "MIT"
 url: "https://swarm-ai.org"

--- a/skill.md
+++ b/skill.md
@@ -1,6 +1,6 @@
 ---
 name: swarm-safety
-version: 1.7.0
+version: 1.9.0
 description: "SWARM: System-Wide Assessment of Risk in Multi-agent systems. Simulate multi-agent dynamics, test governance, study emergent risks."
 homepage: https://github.com/swarm-ai-safety/swarm
 metadata: {"category":"safety","license":"MIT","author":"Raeli Savitt"}


### PR DESCRIPTION
## Why

Cutting v1.9.0 exposed that the release pipeline had been **silently broken since 1.6.0** (PyPI stuck at 1.5.0; GitHub releases backfilled separately). The old `/release` command contributed: it manually ran `gh release create` (conflicting with `release.yml`'s own `github-release` job), did no pre-tag build/metadata validation, was unaware the tag triggers a PyPI publish, and its "never overwrite a tag — abort" rule actively blocked the recovery that was actually needed.

## What

Rewrites `.claude/commands/release.md` to encode the flow that actually shipped 1.9.0:
- **Critical invariants** up front (the three that broke 1.6–1.8): full test extras, no PEP 508 direct-URL deps, `-n auto --timeout=300`.
- **Local pre-validation before tagging** (`python -m build && twine check` + a direct-URL metadata grep) — catches PyPI 400s without burning a tag/CI cycle.
- **Release PR → merge → tag `main`**; the tag triggers `release.yml` (validate→test→build→**publish**→github-release). Stops the manual `gh release create`.
- **`--recover`**: re-point the tag after a pre-publish failure (safe only while the version hasn't published — checked against PyPI).
- **Verify**: PyPI serves the version + fresh-venv install imports.

Also syncs `CITATION.cff` and `skill.md` `1.7.0 → 1.9.0` (drifted because prior releases only bumped `pyproject.toml`; `/bump_version` keeps all three together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)