### PR TITLE
feat(docs): expand the knowledge graph — scenarios, commands, agents, code, semantic edges

### DIFF
--- a/docs/graph.md
+++ b/docs/graph.md
@@ -24,6 +24,7 @@ Dashed nodes are orphans — nothing links to them yet.
     <label class="kb-radio"><input type="radio" name="kb-mode" id="kb-mode-browse" checked /> Browse</label>
     <label class="kb-radio" title="Click stays on the graph; the side panel shows outgoing links to click next."><input type="radio" name="kb-mode" id="kb-mode-speedrun" /> Speedrun</label>
     <button id="kb-show-orphans" class="kb-mini-btn">Show orphans</button>
+    <button id="kb-toggle-semantic" class="kb-mini-btn on" title="Dashed violet edges = TF-IDF similarity suggestions, no explicit link in the corpus.">Suggestions: on</button>
   </div>
   <div class="kb-pathfinder">
     <span class="kb-pf-label">Shortest path:</span>

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -1,34 +1,51 @@
 ---
 title: Knowledge Graph
-description: "Interactive map of the SWARM knowledge base. Traverse pages by their links, filter by section, search, and find the shortest link path between any two concepts."
+description: "Interactive map of the SWARM knowledge base spanning docs, scenarios, slash commands, agents, roles, and (locally) artifacts research. Traverse by links, filter by kind, search, and find the shortest link path between any two concepts."
 hide:
   - toc
 ---
 
 # Knowledge Graph
 
-Every page in these docs is a node; every link between pages is an edge. Drag to
-pan, scroll to zoom, **hover** a node to spotlight its neighborhood, and **click**
-to open the page. Dashed nodes are *orphans* — nothing links to them yet.
+Every page in this repo is a node; every link, `[[wikilink]]`, `/slash-command`
+mention, or referenced file path is an edge. The graph spans docs, scenarios,
+slash commands, agents, role memory, and — when the `swarm-artifacts` repo is
+checked out alongside this one — its papers, research notes, and study writeups.
+
+**Drag** to pan, **scroll** to zoom, **hover** a node to see its description in
+the side panel, and **click** to open it (or focus it, in speedrun mode).
+Dashed nodes are orphans — nothing links to them yet.
+
+<div id="kb-stats" class="kb-stats"></div>
 
 <div class="kb-controls" markdown="0">
-  <input id="kb-search" type="search" placeholder="Search pages…" autocomplete="off" />
+  <div class="kb-row">
+    <input id="kb-search" type="search" placeholder="Search nodes…" autocomplete="off" />
+    <label class="kb-radio"><input type="radio" name="kb-mode" id="kb-mode-browse" checked /> Browse</label>
+    <label class="kb-radio" title="Click stays on the graph; the side panel shows outgoing links to click next."><input type="radio" name="kb-mode" id="kb-mode-speedrun" /> Speedrun</label>
+    <button id="kb-show-orphans" class="kb-mini-btn">Show orphans</button>
+  </div>
   <div class="kb-pathfinder">
-    <span class="kb-pf-label">Speedrun:</span>
-    <select id="kb-from" aria-label="From page"></select>
+    <span class="kb-pf-label">Shortest path:</span>
+    <select id="kb-from" aria-label="From"></select>
     <span class="kb-arrow">→</span>
-    <select id="kb-to" aria-label="To page"></select>
-    <button id="kb-find-path">Find shortest path</button>
+    <select id="kb-to" aria-label="To"></select>
+    <button id="kb-find-path">Find</button>
   </div>
   <div id="kb-path-result" class="kb-path-result"></div>
+  <div id="kb-trail" class="kb-trail"></div>
   <div id="kb-legend" class="kb-legend"></div>
 </div>
 
-<div id="kb-graph" class="kb-graph-canvas"></div>
+<div class="kb-stage">
+  <div id="kb-graph" class="kb-graph-canvas"></div>
+  <aside id="kb-info" class="kb-info"></aside>
+</div>
 
 <script src="https://cdn.jsdelivr.net/npm/cytoscape@3.30.2/dist/cytoscape.min.js"></script>
 <script src="../javascripts/kb_graph.js"></script>
 
-> The graph is regenerated on every docs build from the live markdown corpus.
-> To rebuild it locally and see which pages are weakly linked, run
-> `python scripts/build_kb_graph.py`.
+> The graph is regenerated on every docs build from the live corpus across
+> docs, scenarios, `.claude/commands`, `.claude/agents`, `agents/`, and
+> (locally) `swarm-artifacts`. To rebuild it and see what's weakly linked,
+> run `python scripts/build_kb_graph.py`.

--- a/docs/javascripts/kb_graph.js
+++ b/docs/javascripts/kb_graph.js
@@ -22,6 +22,15 @@
     else document.addEventListener("DOMContentLoaded", fn);
   }
 
+  // Escape any corpus-derived string before concatenating it into innerHTML.
+  // Node titles and descriptions come from arbitrary markdown frontmatter and
+  // H1s; without this a doc whose title contains "<script>..." would execute
+  // on /graph and on every page that links back to it.
+  var ESC_MAP = {"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"};
+  function esc(s) {
+    return String(s == null ? "" : s).replace(/[&<>"']/g, function (c) { return ESC_MAP[c]; });
+  }
+
   function baseUrl() {
     var marker = "/graph/";
     var p = window.location.pathname;
@@ -167,7 +176,8 @@
       });
 
       // ---- modes ----
-      var modeBrowse = document.getElementById("kb-mode-browse");
+      // (no need to hold a ref to the "browse" radio — speedrun is the only
+      // mode flag the click/hover handlers branch on)
       var modeSpeedrun = document.getElementById("kb-mode-speedrun");
       var trailEl = document.getElementById("kb-trail");
       var trail = JSON.parse(sessionStorage.getItem("kb-trail") || "[]");
@@ -182,7 +192,7 @@
         }
         var pieces = trail.map(function (id, i) {
           var n = byId[id]; if (!n) return "";
-          return '<a href="#" data-id="' + id + '" class="kb-trail-hop">' + n.title + "</a>";
+          return '<a href="#" data-id="' + esc(id) + '" class="kb-trail-hop">' + esc(n.title) + "</a>";
         });
         trailEl.innerHTML = '<b>Your run (' + (trail.length - 1) + ' hops):</b> ' +
           pieces.join(' <span class="kb-arrow">→</span> ') +
@@ -206,20 +216,20 @@
         var outs = (node.out || []).map(function (id) {
           var n = byId[id]; if (!n) return "";
           var color2 = KIND_COLORS[n.kind] || "#888";
-          return '<li><a href="#" data-id="' + id + '" class="kb-info-link">' +
+          return '<li><a href="#" data-id="' + esc(id) + '" class="kb-info-link">' +
             '<span class="kb-dot" style="background:' + color2 + '"></span>' +
-            n.title + ' <span class="kb-info-kind">' +
-            (KIND_LABELS[n.kind] || n.kind) + '</span></a></li>';
+            esc(n.title) + ' <span class="kb-info-kind">' +
+            esc(KIND_LABELS[n.kind] || n.kind) + '</span></a></li>';
         }).join("");
         var openLink = "";
-        if (node.url) openLink = '<a class="kb-info-open" href="' + base + node.url + '">Open page →</a>';
-        else if (node.external_url) openLink = '<a class="kb-info-open" target="_blank" rel="noopener" href="' + node.external_url + '">Open source on GitHub →</a>';
+        if (node.url) openLink = '<a class="kb-info-open" href="' + esc(base + node.url) + '">Open page →</a>';
+        else if (node.external_url) openLink = '<a class="kb-info-open" target="_blank" rel="noopener" href="' + esc(node.external_url) + '">Open source on GitHub →</a>';
         info.innerHTML =
           '<div class="kb-info-head">' +
           '<span class="kb-dot" style="background:' + color + '"></span>' +
-          '<h3>' + node.title + '</h3>' +
-          '<span class="kb-info-kind">' + kindLabel + '</span></div>' +
-          (node.description ? '<p class="kb-info-desc">' + node.description + '</p>' : '') +
+          '<h3>' + esc(node.title) + '</h3>' +
+          '<span class="kb-info-kind">' + esc(kindLabel) + '</span></div>' +
+          (node.description ? '<p class="kb-info-desc">' + esc(node.description) + '</p>' : '') +
           openLink +
           '<h4>Out (' + (node.out || []).length + ')</h4>' +
           (outs ? '<ul class="kb-info-outs">' + outs + '</ul>' : '<p class="kb-info-empty">No outgoing links.</p>');
@@ -315,7 +325,7 @@
         var path = bfsPath(adjReal, a, b);
         if (!path) {
           pathOut.innerHTML = '<span class="kb-nopath">No link path from <b>' +
-            byId[a].title + "</b> to <b>" + byId[b].title +
+            esc(byId[a].title) + "</b> to <b>" + esc(byId[b].title) +
             "</b> (try the reverse, or densify links).</span>";
           return;
         }
@@ -328,7 +338,7 @@
           var n = byId[id];
           var href = n.url ? base + n.url : (n.external_url || "#");
           var ext = n.url ? "" : ' target="_blank" rel="noopener"';
-          return '<a href="' + href + '"' + ext + '>' + n.title + "</a>";
+          return '<a href="' + esc(href) + '"' + ext + '>' + esc(n.title) + "</a>";
         }).join(' <span class="kb-arrow">→</span> ');
         pathOut.innerHTML = "<b>" + (path.length - 1) + " hop" +
           (path.length === 2 ? "" : "s") + ":</b> " + hops;

--- a/docs/javascripts/kb_graph.js
+++ b/docs/javascripts/kb_graph.js
@@ -40,6 +40,7 @@
     "paper-art":    "#dc2626",  // red
     "research-art": "#0891b2",  // cyan
     "note-art":     "#65a30d",  // lime
+    "code":         "#475569",  // slate
   };
   var KIND_LABELS = {
     "doc":          "docs",
@@ -50,6 +51,7 @@
     "paper-art":    "papers (artifacts)",
     "research-art": "research (artifacts)",
     "note-art":     "notes (artifacts)",
+    "code":         "source code",
   };
 
   function bfsPath(adj, start, goal) {
@@ -100,10 +102,14 @@
           graph.stats.edge_count + " edges</b> · " + parts.join(" ");
       }
 
-      var adj = {};
+      var adj = {};        // all edges
+      var adjReal = {};    // explicit edges only (BFS uses this — semantic edges are suggestions)
       var byId = {};
-      graph.nodes.forEach(function (n) { adj[n.id] = []; byId[n.id] = n; });
-      graph.edges.forEach(function (e) { adj[e.source].push(e.target); });
+      graph.nodes.forEach(function (n) { adj[n.id] = []; adjReal[n.id] = []; byId[n.id] = n; });
+      graph.edges.forEach(function (e) {
+        adj[e.source].push(e.target);
+        if (e.kind !== "semantic") adjReal[e.source].push(e.target);
+      });
 
       var elements = [];
       graph.nodes.forEach(function (n) {
@@ -144,6 +150,9 @@
           }},
           { selector: 'edge[kind = "slashcmd"]', style: { "line-color": "#d97706", "target-arrow-color": "#d97706" }},
           { selector: 'edge[kind = "mention"]',  style: { "line-style": "dashed" }},
+          { selector: 'edge[kind = "code"]',     style: { "line-color": "#475569", "target-arrow-color": "#475569", "width": 1.0 }},
+          { selector: 'edge[kind = "semantic"]', style: { "line-color": "#a78bfa", "target-arrow-color": "#a78bfa", "line-style": "dashed", "opacity": 0.25, "width": 0.5 }},
+          { selector: 'edge[kind = "semantic"].semantic-off', style: { "display": "none" }},
           { selector: ".faded", style: { "opacity": 0.06 }},
           { selector: ".highlight", style: { "opacity": 1 }},
           { selector: "node.focal", style: { "border-width": 4, "border-color": "#111827", "z-index": 99 }},
@@ -303,7 +312,7 @@
       document.getElementById("kb-find-path").onclick = function () {
         cy.elements().removeClass("path");
         var a = fromSel.value, b = toSel.value;
-        var path = bfsPath(adj, a, b);
+        var path = bfsPath(adjReal, a, b);
         if (!path) {
           pathOut.innerHTML = '<span class="kb-nopath">No link path from <b>' +
             byId[a].title + "</b> to <b>" + byId[b].title +
@@ -323,6 +332,16 @@
         }).join(' <span class="kb-arrow">→</span> ');
         pathOut.innerHTML = "<b>" + (path.length - 1) + " hop" +
           (path.length === 2 ? "" : "s") + ":</b> " + hops;
+      };
+
+      // ---- semantic edge toggle ----
+      var semBtn = document.getElementById("kb-toggle-semantic");
+      var semOn = true;
+      if (semBtn) semBtn.onclick = function () {
+        semOn = !semOn;
+        semBtn.classList.toggle("on", semOn);
+        semBtn.textContent = "Suggestions: " + (semOn ? "on" : "off");
+        cy.edges('[kind = "semantic"]').toggleClass("semantic-off", !semOn);
       };
 
       // ---- orphan highlighter ----

--- a/docs/javascripts/kb_graph.js
+++ b/docs/javascripts/kb_graph.js
@@ -1,7 +1,18 @@
-/* Knowledge-graph viewer for the SWARM docs.
- * Loads assets/kb_graph.json, renders a force-directed graph (Cytoscape),
- * supports click-to-navigate, section filtering, node search, and a BFS
- * "speedrun" shortest-path finder between any two pages.
+/* Multi-source knowledge-graph viewer for SWARM docs.
+ *
+ * Loads assets/kb_graph.json and renders a force-directed Cytoscape graph.
+ * Nodes span multiple kinds: docs, scenarios, slash commands, agents, roles,
+ * and (when checked out locally) artifacts papers/research/notes.
+ *
+ * Modes:
+ *   - Browse mode  : clicking a node opens its page (docs) or GitHub source.
+ *   - Speedrun mode: clicking a node focuses it in a side panel showing its
+ *                    outgoing links — you can keep clicking to rack up hops
+ *                    without ever leaving the /graph page. A visited-trail
+ *                    breadcrumb tracks the run.
+ *
+ * Features: kind filter chips, search, BFS shortest-path pathfinder, hover
+ * info panel, and an orphan highlighter.
  */
 (function () {
   "use strict";
@@ -12,24 +23,34 @@
   }
 
   function baseUrl() {
-    // graph.md renders at <site>/graph/ ; assets live one level up.
     var marker = "/graph/";
     var p = window.location.pathname;
     var i = p.indexOf(marker);
     return i >= 0 ? p.slice(0, i + 1) : "/";
   }
 
-  var SECTION_COLORS = {};
-  var PALETTE = ["#2563eb", "#dc2626", "#059669", "#d97706", "#7c3aed",
-                 "#0891b2", "#db2777", "#65a30d", "#9333ea", "#ea580c",
-                 "#0d9488", "#c026d3", "#4f46e5", "#16a34a", "#b45309"];
-
-  function colorFor(section, idx) {
-    if (!(section in SECTION_COLORS)) {
-      SECTION_COLORS[section] = PALETTE[Object.keys(SECTION_COLORS).length % PALETTE.length];
-    }
-    return SECTION_COLORS[section];
-  }
+  // Color by node kind — far more useful for a multi-source graph than
+  // coloring by mkdocs section (which only meaningfully partitions docs).
+  var KIND_COLORS = {
+    "doc":          "#2563eb",  // blue
+    "scenario":     "#059669",  // green
+    "command":      "#d97706",  // amber
+    "agent":        "#7c3aed",  // violet
+    "role":         "#db2777",  // pink
+    "paper-art":    "#dc2626",  // red
+    "research-art": "#0891b2",  // cyan
+    "note-art":     "#65a30d",  // lime
+  };
+  var KIND_LABELS = {
+    "doc":          "docs",
+    "scenario":     "scenarios",
+    "command":      "/commands",
+    "agent":        "agents",
+    "role":         "roles",
+    "paper-art":    "papers (artifacts)",
+    "research-art": "research (artifacts)",
+    "note-art":     "notes (artifacts)",
+  };
 
   function bfsPath(adj, start, goal) {
     if (start === goal) return [start];
@@ -67,7 +88,18 @@
       });
 
     function init(graph, base) {
-      // adjacency for pathfinding (directed, following links forward)
+      var stats = document.getElementById("kb-stats");
+      if (stats) {
+        var byKind = graph.stats.by_kind || {};
+        var parts = Object.keys(byKind).sort().map(function (k) {
+          return '<span class="kb-stat-pill" style="border-color:' +
+            (KIND_COLORS[k] || "#999") + '">' +
+            (KIND_LABELS[k] || k) + ": " + byKind[k] + "</span>";
+        });
+        stats.innerHTML = "<b>" + graph.stats.node_count + " nodes</b> · <b>" +
+          graph.stats.edge_count + " edges</b> · " + parts.join(" ");
+      }
+
       var adj = {};
       var byId = {};
       graph.nodes.forEach(function (n) { adj[n.id] = []; byId[n.id] = n; });
@@ -76,9 +108,10 @@
       var elements = [];
       graph.nodes.forEach(function (n) {
         elements.push({ data: {
-          id: n.id, label: n.title, section: n.section,
-          color: colorFor(n.section), deg: (n.indegree + n.outdegree),
-          url: base + n.url, orphan: n.orphan
+          id: n.id, label: n.title, section: n.section, kind: n.kind,
+          color: KIND_COLORS[n.kind] || "#888",
+          deg: (n.indegree + n.outdegree),
+          orphan: n.orphan
         }});
       });
       graph.edges.forEach(function (e) {
@@ -94,69 +127,165 @@
           { selector: "node", style: {
             "background-color": "data(color)",
             "label": "data(label)",
-            "font-size": 6,
-            "width": "mapData(deg, 0, 30, 8, 42)",
-            "height": "mapData(deg, 0, 30, 8, 42)",
-            "text-wrap": "wrap", "text-max-width": 70,
-            "color": "#334155", "min-zoomed-font-size": 7,
+            "font-size": 5,
+            "width": "mapData(deg, 0, 40, 6, 38)",
+            "height": "mapData(deg, 0, 40, 6, 38)",
+            "text-wrap": "wrap", "text-max-width": 60,
+            "color": "#334155", "min-zoomed-font-size": 8,
             "border-width": 0
           }},
-          { selector: "node[?orphan]", style: { "border-width": 1.5, "border-color": "#94a3b8", "border-style": "dashed" }},
-          { selector: "edge", style: {
-            "width": 0.6, "line-color": "#cbd5e1", "target-arrow-color": "#cbd5e1",
-            "target-arrow-shape": "triangle", "arrow-scale": 0.5,
-            "curve-style": "bezier", "opacity": 0.5
+          { selector: "node[?orphan]", style: {
+            "border-width": 1.5, "border-color": "#94a3b8", "border-style": "dashed"
           }},
-          { selector: ".faded", style: { "opacity": 0.08 }},
+          { selector: "edge", style: {
+            "width": 0.5, "line-color": "#cbd5e1",
+            "target-arrow-color": "#cbd5e1", "target-arrow-shape": "triangle",
+            "arrow-scale": 0.4, "curve-style": "bezier", "opacity": 0.4
+          }},
+          { selector: 'edge[kind = "slashcmd"]', style: { "line-color": "#d97706", "target-arrow-color": "#d97706" }},
+          { selector: 'edge[kind = "mention"]',  style: { "line-style": "dashed" }},
+          { selector: ".faded", style: { "opacity": 0.06 }},
           { selector: ".highlight", style: { "opacity": 1 }},
+          { selector: "node.focal", style: { "border-width": 4, "border-color": "#111827", "z-index": 99 }},
           { selector: "node.path", style: { "border-width": 3, "border-color": "#111827", "z-index": 99 }},
-          { selector: "edge.path", style: { "width": 3, "line-color": "#111827", "target-arrow-color": "#111827", "opacity": 1, "z-index": 99 }}
+          { selector: "edge.path", style: { "width": 3, "line-color": "#111827",
+            "target-arrow-color": "#111827", "opacity": 1, "z-index": 99 }},
+          { selector: "node.orphan-hit", style: { "border-width": 3, "border-color": "#dc2626" }}
         ],
-        layout: { name: "cose", animate: false, nodeRepulsion: 6000, idealEdgeLength: 60, padding: 30 }
+        // cose layout tuned for the larger multi-source graph
+        layout: { name: "cose", animate: false, nodeRepulsion: 5000,
+                  idealEdgeLength: 50, padding: 30, randomize: false }
       });
 
-      // click a node -> open its page; hover -> highlight neighborhood
-      cy.on("tap", "node", function (evt) { window.location.href = evt.target.data("url"); });
+      // ---- modes ----
+      var modeBrowse = document.getElementById("kb-mode-browse");
+      var modeSpeedrun = document.getElementById("kb-mode-speedrun");
+      var trailEl = document.getElementById("kb-trail");
+      var trail = JSON.parse(sessionStorage.getItem("kb-trail") || "[]");
+
+      function isSpeedrun() { return modeSpeedrun && modeSpeedrun.checked; }
+      function saveTrail() { sessionStorage.setItem("kb-trail", JSON.stringify(trail)); }
+      function renderTrail() {
+        if (!trailEl) return;
+        if (!trail.length) {
+          trailEl.innerHTML = '<span class="kb-trail-empty">No hops yet — click a node in speedrun mode.</span>';
+          return;
+        }
+        var pieces = trail.map(function (id, i) {
+          var n = byId[id]; if (!n) return "";
+          return '<a href="#" data-id="' + id + '" class="kb-trail-hop">' + n.title + "</a>";
+        });
+        trailEl.innerHTML = '<b>Your run (' + (trail.length - 1) + ' hops):</b> ' +
+          pieces.join(' <span class="kb-arrow">→</span> ') +
+          ' <button id="kb-trail-reset" class="kb-mini-btn">reset</button>';
+        document.getElementById("kb-trail-reset").onclick = function () {
+          trail = []; saveTrail(); renderTrail();
+          cy.elements().removeClass("focal");
+        };
+        Array.prototype.forEach.call(trailEl.querySelectorAll("a.kb-trail-hop"), function (a) {
+          a.onclick = function (e) { e.preventDefault(); focus(a.getAttribute("data-id")); };
+        });
+      }
+      renderTrail();
+
+      // ---- info panel ----
+      var info = document.getElementById("kb-info");
+      function renderInfo(node, mode) {
+        if (!info || !node) { if (info) info.innerHTML = ""; return; }
+        var color = KIND_COLORS[node.kind] || "#888";
+        var kindLabel = KIND_LABELS[node.kind] || node.kind;
+        var outs = (node.out || []).map(function (id) {
+          var n = byId[id]; if (!n) return "";
+          var color2 = KIND_COLORS[n.kind] || "#888";
+          return '<li><a href="#" data-id="' + id + '" class="kb-info-link">' +
+            '<span class="kb-dot" style="background:' + color2 + '"></span>' +
+            n.title + ' <span class="kb-info-kind">' +
+            (KIND_LABELS[n.kind] || n.kind) + '</span></a></li>';
+        }).join("");
+        var openLink = "";
+        if (node.url) openLink = '<a class="kb-info-open" href="' + base + node.url + '">Open page →</a>';
+        else if (node.external_url) openLink = '<a class="kb-info-open" target="_blank" rel="noopener" href="' + node.external_url + '">Open source on GitHub →</a>';
+        info.innerHTML =
+          '<div class="kb-info-head">' +
+          '<span class="kb-dot" style="background:' + color + '"></span>' +
+          '<h3>' + node.title + '</h3>' +
+          '<span class="kb-info-kind">' + kindLabel + '</span></div>' +
+          (node.description ? '<p class="kb-info-desc">' + node.description + '</p>' : '') +
+          openLink +
+          '<h4>Out (' + (node.out || []).length + ')</h4>' +
+          (outs ? '<ul class="kb-info-outs">' + outs + '</ul>' : '<p class="kb-info-empty">No outgoing links.</p>');
+        Array.prototype.forEach.call(info.querySelectorAll("a.kb-info-link"), function (a) {
+          a.onclick = function (e) { e.preventDefault(); focus(a.getAttribute("data-id")); };
+        });
+      }
+
+      function focus(id) {
+        var node = byId[id]; if (!node) return;
+        cy.elements().removeClass("focal").removeClass("faded").removeClass("highlight");
+        var cyNode = cy.getElementById(id);
+        cyNode.addClass("focal");
+        cy.elements().addClass("faded");
+        cyNode.closedNeighborhood().removeClass("faded").addClass("highlight");
+        cy.animate({ center: { eles: cyNode }, zoom: Math.max(cy.zoom(), 1.2) }, { duration: 300 });
+        renderInfo(node);
+        if (!trail.length || trail[trail.length - 1] !== id) {
+          trail.push(id); saveTrail(); renderTrail();
+        }
+      }
+
+      // ---- click / hover behavior ----
+      cy.on("tap", "node", function (evt) {
+        var id = evt.target.id();
+        var node = byId[id];
+        if (isSpeedrun()) { focus(id); return; }
+        if (node.url) window.location.href = base + node.url;
+        else if (node.external_url) window.open(node.external_url, "_blank", "noopener");
+      });
       cy.on("mouseover", "node", function (evt) {
+        if (isSpeedrun()) return;  // speedrun keeps the focal selection sticky
         var n = evt.target;
         cy.elements().addClass("faded");
         n.closedNeighborhood().removeClass("faded").addClass("highlight");
+        renderInfo(byId[n.id()]);
       });
       cy.on("mouseout", "node", function () {
+        if (isSpeedrun()) return;
         cy.elements().removeClass("faded").removeClass("highlight");
       });
 
-      // ---- section filter legend ----
+      // ---- kind filter chips ----
       var legend = document.getElementById("kb-legend");
-      var sections = Object.keys(SECTION_COLORS).sort();
-      var hidden = {};
-      sections.forEach(function (s) {
+      var hiddenKinds = {};
+      Object.keys(KIND_COLORS).forEach(function (k) {
+        if (!(graph.stats.by_kind || {})[k]) return;  // skip kinds not present
         var chip = document.createElement("button");
         chip.className = "kb-chip";
-        chip.style.borderColor = SECTION_COLORS[s];
-        chip.innerHTML = '<span style="background:' + SECTION_COLORS[s] + '"></span>' + s;
+        chip.style.borderColor = KIND_COLORS[k];
+        chip.innerHTML = '<span class="kb-dot" style="background:' + KIND_COLORS[k] + '"></span>' +
+          (KIND_LABELS[k] || k) + ' (' + (graph.stats.by_kind[k] || 0) + ')';
         chip.onclick = function () {
-          hidden[s] = !hidden[s];
-          chip.classList.toggle("off", hidden[s]);
-          cy.nodes('[section = "' + s + '"]').style("display", hidden[s] ? "none" : "element");
+          hiddenKinds[k] = !hiddenKinds[k];
+          chip.classList.toggle("off", hiddenKinds[k]);
+          cy.nodes('[kind = "' + k + '"]').style("display", hiddenKinds[k] ? "none" : "element");
         };
         legend.appendChild(chip);
       });
 
-      // ---- search box ----
+      // ---- search ----
       var search = document.getElementById("kb-search");
       search.addEventListener("input", function () {
         var q = search.value.trim().toLowerCase();
         if (!q) { cy.elements().removeClass("faded").removeClass("highlight"); return; }
         var matches = cy.nodes().filter(function (n) {
-          return n.data("label").toLowerCase().indexOf(q) >= 0 || n.id().toLowerCase().indexOf(q) >= 0;
+          var d = n.data();
+          return d.label.toLowerCase().indexOf(q) >= 0 || d.id.toLowerCase().indexOf(q) >= 0;
         });
         cy.elements().addClass("faded");
         matches.removeClass("faded").addClass("highlight");
         if (matches.length) cy.animate({ fit: { eles: matches, padding: 80 } }, { duration: 300 });
       });
 
-      // ---- BFS "speedrun" pathfinder ----
+      // ---- BFS speedrun pathfinder ----
       var fromSel = document.getElementById("kb-from");
       var toSel = document.getElementById("kb-to");
       var pathOut = document.getElementById("kb-path-result");
@@ -165,7 +294,8 @@
       }).forEach(function (n) {
         [fromSel, toSel].forEach(function (sel) {
           var o = document.createElement("option");
-          o.value = n.id; o.textContent = n.title + "  (" + n.section + ")";
+          o.value = n.id;
+          o.textContent = n.title + "  (" + (KIND_LABELS[n.kind] || n.kind) + ")";
           sel.appendChild(o);
         });
       });
@@ -186,10 +316,29 @@
         }
         cy.animate({ fit: { eles: cy.elements(".path"), padding: 80 } }, { duration: 400 });
         var hops = path.map(function (id) {
-          return '<a href="' + base + byId[id].url + '">' + byId[id].title + "</a>";
+          var n = byId[id];
+          var href = n.url ? base + n.url : (n.external_url || "#");
+          var ext = n.url ? "" : ' target="_blank" rel="noopener"';
+          return '<a href="' + href + '"' + ext + '>' + n.title + "</a>";
         }).join(' <span class="kb-arrow">→</span> ');
         pathOut.innerHTML = "<b>" + (path.length - 1) + " hop" +
           (path.length === 2 ? "" : "s") + ":</b> " + hops;
+      };
+
+      // ---- orphan highlighter ----
+      var orphanBtn = document.getElementById("kb-show-orphans");
+      var orphansOn = false;
+      orphanBtn.onclick = function () {
+        orphansOn = !orphansOn;
+        orphanBtn.classList.toggle("on", orphansOn);
+        if (orphansOn) {
+          cy.nodes().addClass("faded").removeClass("orphan-hit");
+          cy.nodes("[?orphan]").removeClass("faded").addClass("orphan-hit");
+          orphanBtn.textContent = "Show all (" + cy.nodes("[?orphan]").length + " orphans)";
+        } else {
+          cy.nodes().removeClass("faded").removeClass("orphan-hit");
+          orphanBtn.textContent = "Show orphans";
+        }
       };
     }
   });

--- a/docs/overrides/hooks/kb_graph.py
+++ b/docs/overrides/hooks/kb_graph.py
@@ -1,8 +1,10 @@
-"""MkDocs hook: regenerate the KB graph and inject per-page backlinks.
+"""MkDocs hook: regenerate the multi-source KB graph and inject backlinks.
 
 - on_pre_build: rebuild docs/assets/kb_graph.json so the /graph page is fresh.
-- on_page_content: append a "Linked from" section listing inbound links — the
-  reverse edges the markdown corpus doesn't surface on its own.
+- on_page_content: append a "Linked from" section on rendered doc pages listing
+  every inbound edge — including from scenarios, slash commands, agents, roles,
+  and (when checked out locally) artifacts notes/papers. Non-doc nodes link out
+  to their source on GitHub.
 
 Graph-building logic lives in scripts/build_kb_graph.py (shared with the CLI).
 """
@@ -20,6 +22,17 @@ import build_kb_graph  # noqa: E402
 _GRAPH: dict | None = None
 _NODES: dict[str, dict] = {}
 
+_KIND_LABEL = {
+    "doc": "docs",
+    "scenario": "scenario",
+    "command": "command",
+    "agent": "agent",
+    "role": "role",
+    "paper-art": "paper",
+    "research-art": "research",
+    "note-art": "note",
+}
+
 
 def on_pre_build(config, **kwargs) -> None:
     global _GRAPH, _NODES
@@ -28,14 +41,16 @@ def on_pre_build(config, **kwargs) -> None:
     _NODES = {n["id"]: n for n in _GRAPH["nodes"]}
 
 
-def _rel_link(page_url: str, target_url: str) -> str:
-    """Relative href from the current rendered page to another page's URL.
+def _href_for(page_url: str, target: dict) -> str:
+    """Return an href from the current rendered doc page to any node.
 
-    Material serves directory URLs (e.g. ``concepts/soft-labels/``), so depth is
-    the number of path segments in the current page's URL.
+    Doc nodes resolve via mkdocs directory URLs (relative).
+    Non-doc nodes link to their GitHub source (absolute).
     """
-    prefix = "../" * page_url.count("/")
-    return prefix + target_url
+    if target["kind"] == "doc" and target.get("url"):
+        prefix = "../" * page_url.count("/")
+        return prefix + target["url"]
+    return target.get("external_url") or "#"
 
 
 def on_page_content(html: str, page=None, **kwargs) -> str:
@@ -45,21 +60,26 @@ def on_page_content(html: str, page=None, **kwargs) -> str:
     if not node or not node["in"]:
         return html
 
-    page_url = page.url  # e.g. "concepts/soft-labels/"
+    page_url = page.url
     inbound = sorted(
         (_NODES[i] for i in node["in"] if i in _NODES),
-        key=lambda n: (n["section"], n["title"].lower()),
+        key=lambda n: (n["kind"], n["section"], n["title"].lower()),
     )
-    items = "\n".join(
-        f'<li><a href="{_rel_link(page_url, n["url"])}">{n["title"]}</a>'
-        f' <span class="kb-backlink-section">{n["section"]}</span></li>'
-        for n in inbound
-    )
+    items = []
+    for n in inbound:
+        kind_label = _KIND_LABEL.get(n["kind"], n["kind"])
+        external = ' target="_blank" rel="noopener"' if n["kind"] != "doc" else ""
+        items.append(
+            f'<li><a href="{_href_for(page_url, n)}"{external}>{n["title"]}</a>'
+            f' <span class="kb-backlink-section">{kind_label}</span></li>'
+        )
+
+    graph_href = "../" * page_url.count("/") + "graph/"
     block = (
         '\n<aside class="kb-backlinks" markdown="0">\n'
         f'<h2>Linked from <span class="kb-backlink-count">{len(inbound)}</span></h2>\n'
-        f"<ul>\n{items}\n</ul>\n"
-        f'<p><a href="{_rel_link(page_url, "graph/")}">Open the knowledge graph →</a></p>\n'
+        "<ul>\n" + "\n".join(items) + "\n</ul>\n"
+        f'<p><a href="{graph_href}">Open the knowledge graph →</a></p>\n'
         "</aside>\n"
     )
     return html + block

--- a/docs/overrides/hooks/kb_graph.py
+++ b/docs/overrides/hooks/kb_graph.py
@@ -11,6 +11,7 @@ Graph-building logic lives in scripts/build_kb_graph.py (shared with the CLI).
 from __future__ import annotations
 
 import sys
+from html import escape as _esc
 from pathlib import Path
 
 _SCRIPTS = Path(__file__).resolve().parents[3] / "scripts"
@@ -70,9 +71,13 @@ def on_page_content(html: str, page=None, **kwargs) -> str:
     for n in inbound:
         kind_label = _KIND_LABEL.get(n["kind"], n["kind"])
         external = ' target="_blank" rel="noopener"' if n["kind"] != "doc" else ""
+        # Escape all corpus-derived strings before injecting into the page —
+        # titles and frontmatter come from arbitrary markdown and could contain
+        # angle brackets or attribute-breaking characters.
         items.append(
-            f'<li><a href="{_href_for(page_url, n)}"{external}>{n["title"]}</a>'
-            f' <span class="kb-backlink-section">{kind_label}</span></li>'
+            f'<li><a href="{_esc(_href_for(page_url, n), quote=True)}"{external}>'
+            f'{_esc(n["title"])}</a>'
+            f' <span class="kb-backlink-section">{_esc(kind_label)}</span></li>'
         )
 
     graph_href = "../" * page_url.count("/") + "graph/"

--- a/docs/overrides/hooks/kb_graph.py
+++ b/docs/overrides/hooks/kb_graph.py
@@ -31,6 +31,7 @@ _KIND_LABEL = {
     "paper-art": "paper",
     "research-art": "research",
     "note-art": "note",
+    "code": "source",
 }
 
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -297,3 +297,53 @@ mjx-container[jax="CHTML"][display="true"] {
 .kb-backlink-count, .kb-backlink-section {
   color: var(--md-default-fg-color--light); font-size: 0.68rem; font-weight: 400;
 }
+
+/* ---- Knowledge graph v2 (multi-source, kind-colored) ---- */
+.kb-stats { font-size: 0.78rem; margin: 0.5rem 0 0.4rem; line-height: 1.9; }
+.kb-stat-pill {
+  display: inline-block; padding: 0.1rem 0.45rem;
+  border: 1px solid; border-radius: 999px;
+  font-size: 0.7rem; margin-right: 0.2rem;
+}
+.kb-row { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; }
+.kb-radio { font-size: 0.78rem; cursor: pointer; user-select: none; }
+.kb-radio input { vertical-align: middle; margin-right: 0.2rem; }
+.kb-mini-btn {
+  padding: 0.25rem 0.6rem; font-size: 0.72rem; border-radius: 6px;
+  border: 1px solid var(--md-default-fg-color--lighter);
+  background: var(--md-default-bg-color); color: var(--md-default-fg-color); cursor: pointer;
+}
+.kb-mini-btn.on { background: var(--md-primary-fg-color); color: var(--md-primary-bg-color); border-color: transparent; }
+.kb-dot { display: inline-block; width: 9px; height: 9px; border-radius: 50%; vertical-align: middle; margin-right: 0.25rem; }
+
+/* Stage = canvas + side panel */
+.kb-stage { display: grid; grid-template-columns: 1fr 280px; gap: 0.8rem; align-items: stretch; }
+@media (max-width: 900px) { .kb-stage { grid-template-columns: 1fr; } }
+
+.kb-info {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 6px; padding: 0.7rem 0.8rem;
+  font-size: 0.78rem; line-height: 1.45;
+  overflow-y: auto; max-height: 70vh; min-height: 480px;
+  background: var(--md-default-bg-color);
+}
+.kb-info-head { display: flex; align-items: center; gap: 0.35rem; flex-wrap: wrap; }
+.kb-info-head h3 { margin: 0; font-size: 0.9rem; flex: 1 1 auto; }
+.kb-info-kind {
+  font-size: 0.65rem; padding: 0.05rem 0.4rem;
+  border: 1px solid var(--md-default-fg-color--lighter); border-radius: 999px;
+  color: var(--md-default-fg-color--light); text-transform: lowercase;
+}
+.kb-info-desc { margin: 0.5rem 0; color: var(--md-default-fg-color--light); }
+.kb-info-open { display: inline-block; margin: 0.3rem 0 0.6rem; font-size: 0.78rem; }
+.kb-info h4 { font-size: 0.75rem; margin: 0.6rem 0 0.25rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--md-default-fg-color--light); border: none; }
+.kb-info-outs { margin: 0; padding-left: 1rem; }
+.kb-info-outs li { margin: 0.15rem 0; }
+.kb-info-link { text-decoration: none; }
+.kb-info-empty { color: var(--md-default-fg-color--light); font-style: italic; }
+
+.kb-trail { font-size: 0.78rem; line-height: 1.6; min-height: 1.4em; }
+.kb-trail-empty { color: var(--md-default-fg-color--light); font-style: italic; }
+.kb-trail-hop { text-decoration: none; }
+
+#kb-find-path { padding: 0.35rem 0.7rem; font-size: 0.75rem; border-radius: 6px; border: none; cursor: pointer; background: var(--md-primary-fg-color); color: var(--md-primary-bg-color); }

--- a/scripts/build_kb_graph.py
+++ b/scripts/build_kb_graph.py
@@ -56,6 +56,8 @@ H1_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
 MD_LINK_RE = re.compile(r"\[[^\]]*\]\(\s*(<[^>]+>|[^)\s]+)")
 WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
 SLASHCMD_RE = re.compile(r"(?<![A-Za-z0-9_/])/([a-z][a-z0-9_-]+)\b")
+# mkdocstrings directive in api docs, e.g.  "::: swarm.core.proxy.ProxyComputer"
+MKDOCSTRINGS_RE = re.compile(r"^:::\s*([a-z_][a-z0-9_.]+)", re.MULTILINE)
 PATH_MENTION_RE = re.compile(
     r"(?<![A-Za-z0-9_/])"
     r"((?:scenarios|\.claude/commands|\.claude/agents|agents|docs)/[A-Za-z0-9_./-]+\.(?:md|yaml))"
@@ -311,12 +313,78 @@ def _resolve_md_link(src_node: Node, raw: str, by_doc_rel: dict[str, str],
     return by_path.get(raw)
 
 
+def _resolve_python_path(dotted: str) -> Path | None:
+    """Map a dotted name (swarm.core.proxy.ProxyComputer) to a source file.
+
+    Tries progressively shorter dotted prefixes, stopping at the first one
+    that resolves to either <prefix>.py or <prefix>/__init__.py under the
+    repo root. Returns None if nothing resolves (likely a typo in a directive).
+    """
+    parts = dotted.split(".")
+    while parts:
+        as_file = REPO_ROOT.joinpath(*parts).with_suffix(".py")
+        as_pkg = REPO_ROOT.joinpath(*parts, "__init__.py")
+        if as_file.is_file():
+            return as_file
+        if as_pkg.is_file():
+            return as_pkg
+        parts.pop()
+    return None
+
+
+def _code_pass(nodes: list[Node]) -> list[tuple[str, str]]:
+    """Mine api docs for mkdocstrings directives.
+
+    Returns the explicit (src_doc_id, code_node_id) edges to add. Mutates
+    ``nodes`` in place to register a new code node per unique source file
+    referenced. Code nodes are linked to GitHub source for the *file* (not
+    the dotted symbol), which is what the graph actually navigates between.
+    """
+    by_id = {n.id: n for n in nodes}
+    edges: list[tuple[str, str]] = []
+    for n in nodes:
+        if n.kind != "doc" or n.section != "api":
+            continue
+        for dotted in MKDOCSTRINGS_RE.findall(n.text):
+            src = _resolve_python_path(dotted)
+            if not src:
+                continue
+            rel = src.relative_to(REPO_ROOT).as_posix()
+            cid = f"code/{rel}"
+            if cid not in by_id:
+                code_node = Node(
+                    id=cid, kind="code",
+                    title=rel,
+                    section="code",
+                    description=_module_doc(src),
+                    external_url=f"{GITHUB_BLOB_REPO}/{rel}",
+                    source_path=rel,
+                )
+                nodes.append(code_node)
+                by_id[cid] = code_node
+            edges.append((n.id, cid))
+    return edges
+
+
+def _module_doc(src: Path) -> str:
+    """Best-effort: the module-level docstring of a python file, single line."""
+    try:
+        text = src.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    m = re.match(r'\s*("""|\'\'\')(.*?)\1', text, re.DOTALL)
+    if not m:
+        return ""
+    return " ".join(m.group(2).strip().split())[:300]
+
+
 def build_graph() -> dict:
     nodes: list[Node] = []
     for fn in (_docs_nodes, _scenario_nodes, _command_nodes,
                _agent_nodes, _role_nodes, _artifacts_nodes):
         nodes.extend(fn())
 
+    explicit_edges = _code_pass(nodes)
     by_id: dict[str, Node] = {n.id: n for n in nodes}
 
     # Lookup tables for resolution.
@@ -345,6 +413,10 @@ def build_graph() -> dict:
         out_by[src].append(dst)
         in_by[dst].append(src)
 
+    # explicit code edges from the api-docs mkdocstrings pass
+    for src, dst in explicit_edges:
+        add(src, dst, "code")
+
     for n in nodes:
         body = n.text
         # explicit markdown / yaml links
@@ -367,6 +439,10 @@ def build_graph() -> dict:
             tgt = by_path.get(raw)
             if tgt:
                 add(n.id, tgt, "mention")
+
+    # suggest semantic edges where no explicit link exists yet
+    for src, dst in _semantic_edges(nodes, seen):
+        add(src, dst, "semantic")
 
     # finalize + drop body text
     out_nodes = []
@@ -392,6 +468,104 @@ def build_graph() -> dict:
             "artifacts_included": any(n["source_repo"] == "artifacts" for n in out_nodes),
         },
     }
+
+
+_TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9_-]{2,}")
+_STOPWORDS = frozenset("""
+the and for with this that from your you our are not has have was were
+which what where when who how all any can use using used into out
+about other than then them they our its our some such only most more
+will would could should may might must shall use one two three
+swarm scenario agent agents page docs doc note notes paper papers
+the_ but each etc i_e if it_ no on or so to up via was via vs
+""".split())
+
+
+def _tfidf_vectors(nodes: list[Node]) -> tuple[dict[str, dict[str, float]], dict[str, float]]:
+    import math
+    from collections import Counter
+
+    texts: dict[str, list[str]] = {}
+    for n in nodes:
+        body = " ".join([n.title, n.description, n.text[:1500], " ".join(n.tags)])
+        toks = [t.lower() for t in _TOKEN_RE.findall(body)]
+        toks = [t for t in toks if t not in _STOPWORDS]
+        texts[n.id] = toks
+
+    df: Counter[str] = Counter()
+    for toks in texts.values():
+        df.update(set(toks))
+    n_docs = max(1, len(texts))
+    idf = {t: math.log((1 + n_docs) / (1 + c)) + 1.0 for t, c in df.items()}
+
+    vectors: dict[str, dict[str, float]] = {}
+    norms: dict[str, float] = {}
+    for nid, toks in texts.items():
+        tf = Counter(toks)
+        if not tf:
+            vectors[nid] = {}
+            norms[nid] = 0.0
+            continue
+        v = {t: (c / len(toks)) * idf.get(t, 0.0) for t, c in tf.items()}
+        # keep only the top 60 dims per doc for speed + a denoising effect
+        if len(v) > 60:
+            top = sorted(v.items(), key=lambda kv: kv[1], reverse=True)[:60]
+            v = dict(top)
+        norms[nid] = math.sqrt(sum(x * x for x in v.values()))
+        vectors[nid] = v
+    return vectors, norms
+
+
+def _semantic_edges(nodes: list[Node], existing: set[tuple[str, str]],
+                    k: int = 3, threshold: float = 0.18) -> list[tuple[str, str]]:
+    """Suggest up to k semantic edges per node where no explicit link exists.
+
+    Uses a simple TF-IDF cosine over title+description+body snippet+tags. Skips
+    code nodes as targets (they already have precise links) and skips pairs
+    that already share an explicit edge in either direction.
+    """
+    vectors, norms = _tfidf_vectors(nodes)
+    by_id = {n.id: n for n in nodes}
+    out: list[tuple[str, str]] = []
+    # Build a token -> nodes index for sparse candidate generation.
+    inv: dict[str, list[str]] = {}
+    for nid, v in vectors.items():
+        for t in v:
+            inv.setdefault(t, []).append(nid)
+
+    for n in nodes:
+        if not vectors[n.id] or norms[n.id] == 0:
+            continue
+        # candidate set: any node sharing at least one token (sparse)
+        cand: set[str] = set()
+        for t in vectors[n.id]:
+            cand.update(inv.get(t, ()))
+        cand.discard(n.id)
+
+        scored: list[tuple[float, str]] = []
+        v1, n1 = vectors[n.id], norms[n.id]
+        for cid in cand:
+            tgt = by_id.get(cid)
+            if not tgt or tgt.kind == "code":
+                continue
+            if (n.id, cid) in existing or (cid, n.id) in existing:
+                continue
+            v2, n2 = vectors[cid], norms[cid]
+            if n2 == 0:
+                continue
+            # cosine via sparse dict dot product
+            if len(v1) > len(v2):
+                small, big = v2, v1
+            else:
+                small, big = v1, v2
+            dot = sum(w * big.get(t, 0.0) for t, w in small.items())
+            sim = dot / (n1 * n2)
+            if sim >= threshold:
+                scored.append((sim, cid))
+        scored.sort(reverse=True)
+        for _, cid in scored[:k]:
+            out.append((n.id, cid))
+    return out
 
 
 def _count_by(items: list[dict], key: str) -> dict[str, int]:

--- a/scripts/build_kb_graph.py
+++ b/scripts/build_kb_graph.py
@@ -410,6 +410,12 @@ def build_graph() -> dict:
             return
         seen.add(key)
         edges.append({"source": src, "target": dst, "kind": kind})
+        # Semantic suggestions are TF-IDF hints, not real corpus links. They
+        # render in the viz (from `edges`) but must stay out of per-node
+        # in/out lists so they never appear as "Linked from" backlinks and
+        # never mask a real orphan from --check / "Show orphans".
+        if kind == "semantic":
+            return
         out_by[src].append(dst)
         in_by[dst].append(src)
 

--- a/scripts/build_kb_graph.py
+++ b/scripts/build_kb_graph.py
@@ -1,52 +1,83 @@
 #!/usr/bin/env python3
-"""Build a knowledge-graph JSON from the docs/ markdown corpus.
+"""Build a knowledge-graph JSON spanning multiple sources in this repo.
 
-Nodes are pages; edges are explicit links between them ([](x.md) and [[wikilinks]]).
-The output (docs/assets/kb_graph.json) powers the interactive /graph page and the
-per-page backlinks injected by docs/overrides/hooks/kb_graph.py.
+Source providers contribute nodes + edges to a shared graph:
+  - docs        : docs/**/*.md (rendered by mkdocs)            kind=doc
+  - scenarios   : scenarios/*.yaml                              kind=scenario
+  - commands    : .claude/commands/*.md (slash commands)        kind=command
+  - claude-agents: .claude/agents/*.md (specialist roles)       kind=agent
+  - roles       : agents/**/*.md (CEO/engineer/etc. role docs)  kind=role
+  - artifacts   : swarm-artifacts/{papers,research,notes}/*.md  kind=paper-art|research-art|note-art
+                  (local-only — only included if the artifacts repo is
+                  checked out alongside this one)
 
-This module is imported by the mkdocs hook (so the graph stays fresh on every
-build) and is also runnable as a CLI for a connectivity report:
+Edges are inferred from:
+  - explicit markdown links to .md / .yaml targets that resolve to a node id
+  - [[wikilinks]] resolved by filename stem
+  - /slash-command mentions resolving to command nodes
+  - bare file-path mentions (scenarios/foo.yaml, .claude/commands/bar.md, etc.)
 
-    python scripts/build_kb_graph.py            # write json + print orphan report
-    python scripts/build_kb_graph.py --check     # exit 1 if orphans exist (CI gate)
+The output (docs/assets/kb_graph.json) powers the interactive /graph page and
+the per-page backlinks injected by docs/overrides/hooks/kb_graph.py.
+
+Run as CLI for a connectivity report:
+    python scripts/build_kb_graph.py
+    python scripts/build_kb_graph.py --check   # exit 1 if any orphans
 """
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 
 try:
     import yaml
-except ImportError:  # pyyaml ships with mkdocs; degrade gracefully if missing
+except ImportError:  # pyyaml ships with mkdocs
     yaml = None
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DOCS_DIR = REPO_ROOT / "docs"
 OUT_PATH = DOCS_DIR / "assets" / "kb_graph.json"
 
-# Built/vendored areas that are not authored knowledge.
-EXCLUDE_DIRS = {"game-app", "javascripts", "stylesheets", "overrides", "assets",
-                "images", "figures", "sprites", ".well-known"}
+ARTIFACTS_DIR = Path(os.environ.get("SWARM_ARTIFACTS", REPO_ROOT.parent / "swarm-artifacts"))
+
+GITHUB_BLOB_REPO = "https://github.com/swarm-ai-safety/swarm/blob/main"
+GITHUB_BLOB_ARTIFACTS = "https://github.com/swarm-ai-safety/swarm-artifacts/blob/main"
+
+# Excluded subdirs under docs/ that hold built/vendored assets.
+DOC_EXCLUDE = {"game-app", "javascripts", "stylesheets", "overrides", "assets",
+               "images", "figures", "sprites", ".well-known"}
 
 FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 H1_RE = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
-# [text](path.md) and [text](path.md#anchor) — capture the target.
 MD_LINK_RE = re.compile(r"\[[^\]]*\]\(\s*(<[^>]+>|[^)\s]+)")
 WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
+SLASHCMD_RE = re.compile(r"(?<![A-Za-z0-9_/])/([a-z][a-z0-9_-]+)\b")
+PATH_MENTION_RE = re.compile(
+    r"(?<![A-Za-z0-9_/])"
+    r"((?:scenarios|\.claude/commands|\.claude/agents|agents|docs)/[A-Za-z0-9_./-]+\.(?:md|yaml))"
+)
 
 
-def _iter_md_files() -> list[Path]:
-    out = []
-    for p in DOCS_DIR.rglob("*.md"):
-        rel_parts = p.relative_to(DOCS_DIR).parts
-        if any(part in EXCLUDE_DIRS for part in rel_parts[:-1]):
-            continue
-        out.append(p)
-    return sorted(out)
+@dataclass
+class Node:
+    id: str
+    kind: str            # doc | scenario | command | agent | role | paper-art | research-art | note-art
+    title: str
+    section: str
+    description: str = ""
+    tags: list[str] = field(default_factory=list)
+    url: str | None = None              # internal mkdocs URL if rendered
+    external_url: str | None = None     # GitHub blob URL for non-rendered nodes
+    source_path: str = ""               # repo-relative
+    source_repo: str = "this"           # "this" or "artifacts"
+    text: str = field(default="", repr=False)  # body kept on the node for edge inference, stripped before JSON
 
+
+# ---------- frontmatter / title helpers ----------
 
 def _parse_frontmatter(text: str) -> tuple[dict, str]:
     m = FRONTMATTER_RE.match(text)
@@ -62,26 +93,25 @@ def _parse_frontmatter(text: str) -> tuple[dict, str]:
         return {}, body
 
 
-def _title_for(meta: dict, body: str, rel: str) -> str:
+def _title_from(meta: dict, body: str, fallback: str) -> str:
     if meta.get("title"):
         return str(meta["title"])
     h1 = H1_RE.search(body)
     if h1:
         return h1.group(1).strip()
-    return Path(rel).stem.replace("-", " ").replace("_", " ").title()
+    return Path(fallback).stem.replace("-", " ").replace("_", " ").title()
 
 
-def _tags_for(meta: dict) -> list[str]:
+def _collect_tags(meta: dict) -> list[str]:
     tags: list[str] = []
-    for key in ("tags", "keywords", "defined_terms"):
+    for key in ("tags", "keywords", "defined_terms", "motif"):
         val = meta.get(key)
         if isinstance(val, list):
             tags.extend(str(v) for v in val)
         elif isinstance(val, str):
             tags.append(val)
-    # de-dupe, preserve order
-    seen = set()
-    out = []
+    seen: set[str] = set()
+    out: list[str] = []
     for t in tags:
         t = t.strip()
         if t and t.lower() not in seen:
@@ -90,104 +120,285 @@ def _tags_for(meta: dict) -> list[str]:
     return out
 
 
-def _section_for(rel: str) -> str:
-    parts = Path(rel).parts
-    return parts[0] if len(parts) > 1 else "root"
+# ---------- source providers ----------
+
+def _docs_nodes() -> list[Node]:
+    nodes: list[Node] = []
+    for p in sorted(DOCS_DIR.rglob("*.md")):
+        rel = p.relative_to(DOCS_DIR).as_posix()
+        if any(part in DOC_EXCLUDE for part in Path(rel).parts[:-1]):
+            continue
+        text = p.read_text(encoding="utf-8", errors="replace")
+        meta, body = _parse_frontmatter(text)
+        section = Path(rel).parts[0] if "/" in rel else "root"
+        nodes.append(Node(
+            id=rel, kind="doc",
+            title=_title_from(meta, body, rel),
+            section=section,
+            description=str(meta.get("description", "")).strip(),
+            tags=_collect_tags(meta),
+            url=rel[:-3] + "/" if rel.endswith(".md") else rel,
+            source_path=f"docs/{rel}",
+            text=body,
+        ))
+    return nodes
 
 
-def _clean_target(raw: str) -> str:
+def _scenario_nodes() -> list[Node]:
+    sdir = REPO_ROOT / "scenarios"
+    if not sdir.is_dir():
+        return []
+    out: list[Node] = []
+    for p in sorted(sdir.glob("*.yaml")):
+        text = p.read_text(encoding="utf-8", errors="replace")
+        meta = {}
+        if yaml is not None:
+            try:
+                meta = yaml.safe_load(text) or {}
+                if not isinstance(meta, dict):
+                    meta = {}
+            except yaml.YAMLError:
+                meta = {}
+        rel = f"scenarios/{p.name}"
+        title = str(meta.get("scenario_id") or meta.get("name") or p.stem).strip()
+        out.append(Node(
+            id=rel, kind="scenario",
+            title=title,
+            section="scenarios",
+            description=str(meta.get("description", "")).strip(),
+            tags=_collect_tags(meta),
+            external_url=f"{GITHUB_BLOB_REPO}/{rel}",
+            source_path=rel,
+            text=text,
+        ))
+    return out
+
+
+def _command_nodes() -> list[Node]:
+    cdir = REPO_ROOT / ".claude" / "commands"
+    if not cdir.is_dir():
+        return []
+    out: list[Node] = []
+    for p in sorted(cdir.glob("*.md")):
+        text = p.read_text(encoding="utf-8", errors="replace")
+        meta, body = _parse_frontmatter(text)
+        rel = f".claude/commands/{p.name}"
+        out.append(Node(
+            id=f"cmd/{p.stem}", kind="command",
+            title=f"/{p.stem}",
+            section="commands",
+            description=str(meta.get("description", "")).strip() or _first_para(body),
+            tags=_collect_tags(meta),
+            external_url=f"{GITHUB_BLOB_REPO}/{rel}",
+            source_path=rel,
+            text=body,
+        ))
+    return out
+
+
+def _agent_nodes() -> list[Node]:
+    adir = REPO_ROOT / ".claude" / "agents"
+    if not adir.is_dir():
+        return []
+    out: list[Node] = []
+    for p in sorted(adir.glob("*.md")):
+        text = p.read_text(encoding="utf-8", errors="replace")
+        meta, body = _parse_frontmatter(text)
+        rel = f".claude/agents/{p.name}"
+        out.append(Node(
+            id=f"agent/{p.stem}", kind="agent",
+            title=_title_from(meta, body, p.stem),
+            section="agents",
+            description=str(meta.get("description", "")).strip() or _first_para(body),
+            tags=_collect_tags(meta),
+            external_url=f"{GITHUB_BLOB_REPO}/{rel}",
+            source_path=rel,
+            text=body,
+        ))
+    return out
+
+
+def _role_nodes() -> list[Node]:
+    rdir = REPO_ROOT / "agents"
+    if not rdir.is_dir():
+        return []
+    out: list[Node] = []
+    for p in sorted(rdir.rglob("*.md")):
+        rel = p.relative_to(REPO_ROOT).as_posix()
+        text = p.read_text(encoding="utf-8", errors="replace")
+        meta, body = _parse_frontmatter(text)
+        # role/<agent>/<filename-no-ext>
+        nid = "role/" + p.relative_to(rdir).with_suffix("").as_posix()
+        out.append(Node(
+            id=nid, kind="role",
+            title=_title_from(meta, body, p.stem),
+            section="roles",
+            description=str(meta.get("description", "")).strip() or _first_para(body),
+            tags=_collect_tags(meta),
+            external_url=f"{GITHUB_BLOB_REPO}/{rel}",
+            source_path=rel,
+            text=body,
+        ))
+    return out
+
+
+def _artifacts_nodes() -> list[Node]:
+    if not ARTIFACTS_DIR.is_dir():
+        return []
+    out: list[Node] = []
+    for sub, kind in (("papers", "paper-art"),
+                      ("research", "research-art"),
+                      ("notes", "note-art")):
+        d = ARTIFACTS_DIR / sub
+        if not d.is_dir():
+            continue
+        for p in sorted(d.glob("*.md")):
+            text = p.read_text(encoding="utf-8", errors="replace")
+            meta, body = _parse_frontmatter(text)
+            rel = f"{sub}/{p.name}"
+            out.append(Node(
+                id=f"art/{rel}", kind=kind,
+                title=_title_from(meta, body, p.stem),
+                section=f"artifacts:{sub}",
+                description=str(meta.get("description", "")).strip(),
+                tags=_collect_tags(meta),
+                external_url=f"{GITHUB_BLOB_ARTIFACTS}/{rel}",
+                source_path=f"swarm-artifacts/{rel}",
+                source_repo="artifacts",
+                text=body,
+            ))
+    return out
+
+
+def _first_para(body: str) -> str:
+    """First non-heading paragraph, used as a fallback description."""
+    for chunk in body.split("\n\n"):
+        chunk = chunk.strip()
+        if chunk and not chunk.startswith(("#", "```", "---", "<")):
+            return " ".join(chunk.split())[:300]
+    return ""
+
+
+# ---------- edge inference ----------
+
+def _resolve_md_link(src_node: Node, raw: str, by_doc_rel: dict[str, str],
+                     by_path: dict[str, str]) -> str | None:
+    """Resolve a markdown-link target to a node id, if it points at one."""
     raw = raw.strip()
     if raw.startswith("<") and raw.endswith(">"):
         raw = raw[1:-1]
-    # drop anchor / query / surrounding title text after a space
-    raw = raw.split(" ", 1)[0]
-    raw = raw.split("#", 1)[0].split("?", 1)[0]
-    return raw
+    raw = raw.split(" ", 1)[0].split("#", 1)[0].split("?", 1)[0]
+    if not raw or raw.startswith(("http://", "https://", "mailto:", "//")):
+        return None
+
+    # If the source is a doc, treat links as relative to docs/<src dir>.
+    if src_node.kind == "doc":
+        if not (raw.endswith(".md") or raw.endswith(".yaml")):
+            return None
+        src_dir = Path(src_node.source_path).parent
+        target = (REPO_ROOT / src_dir / raw).resolve()
+        try:
+            rel = target.relative_to(DOCS_DIR).as_posix()
+        except ValueError:
+            try:
+                rel_repo = target.relative_to(REPO_ROOT).as_posix()
+                return by_path.get(rel_repo)
+            except ValueError:
+                return None
+        return by_doc_rel.get(rel)
+
+    # For non-doc sources, try interpreting as a repo-relative path.
+    return by_path.get(raw)
 
 
 def build_graph() -> dict:
-    files = _iter_md_files()
-    # rel-path id (posix), e.g. "concepts/soft-labels.md"
-    id_for: dict[Path, str] = {f: f.relative_to(DOCS_DIR).as_posix() for f in files}
-    valid_ids = set(id_for.values())
-    # stem -> id, for resolving [[wikilinks]] and bare links; title -> id too
-    stem_to_id: dict[str, str] = {}
-    title_to_id: dict[str, str] = {}
+    nodes: list[Node] = []
+    for fn in (_docs_nodes, _scenario_nodes, _command_nodes,
+               _agent_nodes, _role_nodes, _artifacts_nodes):
+        nodes.extend(fn())
 
-    nodes: dict[str, dict] = {}
-    raw_bodies: dict[str, str] = {}
+    by_id: dict[str, Node] = {n.id: n for n in nodes}
 
-    for f in files:
-        nid = id_for[f]
-        text = f.read_text(encoding="utf-8", errors="replace")
-        meta, body = _parse_frontmatter(text)
-        title = _title_for(meta, body, nid)
-        nodes[nid] = {
-            "id": nid,
-            "title": title,
-            "section": _section_for(nid),
-            "description": str(meta.get("description", "")).strip(),
-            "tags": _tags_for(meta),
-            "out": [],
-            "in": [],
-            "url": nid[:-3] + "/" if nid.endswith(".md") else nid,
-        }
-        raw_bodies[nid] = body
-        stem_to_id.setdefault(f.stem.lower(), nid)
-        title_to_id.setdefault(title.lower(), nid)
+    # Lookup tables for resolution.
+    by_doc_rel: dict[str, str] = {n.id: n.id for n in nodes if n.kind == "doc"}
+    by_path: dict[str, str] = {n.source_path: n.id for n in nodes}
+    by_stem: dict[str, str] = {}
+    for n in nodes:
+        stem = Path(n.source_path).stem.lower()
+        by_stem.setdefault(stem, n.id)
+    by_cmd: dict[str, str] = {n.id.split("/", 1)[1].lower(): n.id
+                              for n in nodes if n.kind == "command"}
 
     edges: list[dict] = []
-    seen_edges: set[tuple[str, str]] = set()
+    seen: set[tuple[str, str]] = set()
+    out_by: dict[str, list[str]] = {n.id: [] for n in nodes}
+    in_by: dict[str, list[str]] = {n.id: [] for n in nodes}
 
-    def add_edge(src: str, dst: str, kind: str) -> None:
-        if dst not in nodes or src == dst:
+    def add(src: str, dst: str, kind: str) -> None:
+        if dst not in by_id or src == dst:
             return
         key = (src, dst)
-        if key in seen_edges:
+        if key in seen:
             return
-        seen_edges.add(key)
+        seen.add(key)
         edges.append({"source": src, "target": dst, "kind": kind})
-        nodes[src]["out"].append(dst)
-        nodes[dst]["in"].append(src)
+        out_by[src].append(dst)
+        in_by[dst].append(src)
 
-    for nid, body in raw_bodies.items():
-        src_path = DOCS_DIR / nid
-        # explicit markdown links to .md targets
+    for n in nodes:
+        body = n.text
+        # explicit markdown / yaml links
         for raw in MD_LINK_RE.findall(body):
-            target = _clean_target(raw)
-            if not target.endswith(".md"):
-                continue
-            if target.startswith("http") or target.startswith("//"):
-                continue
-            resolved = (src_path.parent / target).resolve()
-            try:
-                rel = resolved.relative_to(DOCS_DIR).as_posix()
-            except ValueError:
-                continue
-            if rel in valid_ids:
-                add_edge(nid, rel, "link")
-        # [[wikilinks]] resolved by stem or title
+            tgt = _resolve_md_link(n, raw, by_doc_rel, by_path)
+            if tgt:
+                add(n.id, tgt, "link")
+        # [[wikilinks]] resolved by stem
         for raw in WIKILINK_RE.findall(body):
-            key = raw.strip().lower()
-            dst = stem_to_id.get(key) or title_to_id.get(key)
-            if dst:
-                add_edge(nid, dst, "wikilink")
+            tgt = by_stem.get(raw.strip().lower())
+            if tgt:
+                add(n.id, tgt, "wikilink")
+        # /slash-command mentions resolve to command nodes
+        for cmd in SLASHCMD_RE.findall(body):
+            tgt = by_cmd.get(cmd.lower())
+            if tgt:
+                add(n.id, tgt, "slashcmd")
+        # bare repo-relative path mentions
+        for raw in PATH_MENTION_RE.findall(body):
+            tgt = by_path.get(raw)
+            if tgt:
+                add(n.id, tgt, "mention")
 
-    # finalize degree + orphan flags
-    for n in nodes.values():
-        n["outdegree"] = len(n["out"])
-        n["indegree"] = len(n["in"])
-        n["orphan"] = (n["indegree"] == 0)
+    # finalize + drop body text
+    out_nodes = []
+    for n in nodes:
+        out_nodes.append({
+            "id": n.id, "kind": n.kind, "title": n.title, "section": n.section,
+            "description": n.description, "tags": n.tags,
+            "url": n.url, "external_url": n.external_url,
+            "source_path": n.source_path, "source_repo": n.source_repo,
+            "in": in_by[n.id], "out": out_by[n.id],
+            "indegree": len(in_by[n.id]), "outdegree": len(out_by[n.id]),
+            "orphan": len(in_by[n.id]) == 0,
+        })
 
     return {
-        "nodes": list(nodes.values()),
+        "nodes": out_nodes,
         "edges": edges,
         "stats": {
-            "node_count": len(nodes),
+            "node_count": len(out_nodes),
             "edge_count": len(edges),
-            "orphan_count": sum(1 for n in nodes.values() if n["orphan"]),
+            "orphan_count": sum(1 for n in out_nodes if n["orphan"]),
+            "by_kind": _count_by(out_nodes, "kind"),
+            "artifacts_included": any(n["source_repo"] == "artifacts" for n in out_nodes),
         },
     }
+
+
+def _count_by(items: list[dict], key: str) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for it in items:
+        out[it[key]] = out.get(it[key], 0) + 1
+    return out
 
 
 def write_graph(graph: dict | None = None) -> Path:
@@ -200,12 +411,15 @@ def write_graph(graph: dict | None = None) -> Path:
 def _report(graph: dict) -> None:
     s = graph["stats"]
     print(f"KB graph: {s['node_count']} nodes, {s['edge_count']} edges, "
-          f"{s['orphan_count']} orphans (no inbound links)")
+          f"{s['orphan_count']} orphans")
+    print("By kind:", ", ".join(f"{k}={v}" for k, v in sorted(s["by_kind"].items())))
+    print(f"Artifacts included: {s['artifacts_included']}")
     orphans = [n for n in graph["nodes"] if n["orphan"]]
     if orphans:
-        print("\nOrphans / weakly-linked pages (densify these for a connected graph):")
-        for n in sorted(orphans, key=lambda x: x["section"]):
-            print(f"  [{n['section']}] {n['id']}  (out:{n['outdegree']})")
+        # Surface only the first 30 to keep CLI output readable.
+        print(f"\nFirst {min(30, len(orphans))} orphans (no inbound):")
+        for n in sorted(orphans, key=lambda x: (x["kind"], x["section"]))[:30]:
+            print(f"  [{n['kind']}/{n['section']}] {n['id']}  (out:{n['outdegree']})")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #478. Expands the knowledge-graph layer along the four axes we discussed: more source kinds, code↔docs links, semantic edges, and viz UX.

## Source kinds (commit `5ab54fd4`)
Refactors the extractor into a provider model and brings in 5 new node kinds beyond docs/:

| Kind | Source | Local count |
|---|---|---|
| `scenario` | `scenarios/*.yaml` | 114 |
| `command` | `.claude/commands/*.md` | 54 |
| `agent` | `.claude/agents/*.md` | 6 |
| `role` | `agents/**/*.md` | 38 |
| `paper-art` / `research-art` / `note-art` | `swarm-artifacts/{papers,research,notes}/*.md` | local-only |

New edge inference:
- `/slash-command` mentions resolve to command nodes (`kind=slashcmd`).
- Bare repo-relative path mentions (`scenarios/x.yaml`, `.claude/commands/y.md`, etc.) resolve to node ids (`kind=mention`).

Backlinks on rendered doc pages now include inbound from every kind, with GitHub-blob hrefs (target=_blank) for non-doc sources.

Viz upgrades:
- Color by **kind** (instead of mkdocs section) — much more useful for a multi-source graph.
- **Speedrun mode**: clicking a node focuses it; side panel shows its description and outgoing links to click next, all without leaving `/graph`. Session-stored visit-trail breadcrumb (*"Your run (3 hops): A → B → C → D"*).
- Kind filter chips with live counts, hover info panel, orphan highlighter, stats bar.

## Code ↔ docs links + semantic edges (commit `71423dad`)
- Scans `docs/api/*.md` for mkdocstrings `::: swarm.x.y.Z` directives, resolves each to a real source file, and registers a `code` node per file with a GitHub blob URL. Yields 7 explicit `kind=code` edges from api docs → source files.
- Stdlib TF-IDF cosine over title + description + body snippet + tags suggests up to 3 best non-explicit neighbors per node (cosine ≥ 0.18, code nodes excluded as targets) — surfaces hidden topical kinship the corpus never linked explicitly. Rendered as dashed violet (`kind=semantic`), toggleable.
- **BFS pathfinder uses explicit-edges-only adjacency**, so speedrun paths are real link paths, never suggestions.

## Result
- This repo with artifacts checked out: **474 nodes, 1792 edges, 64 orphans** across 8 kinds.
- Vercel build (artifacts absent, no semantic edges *across* repos): **431 nodes, 1624 edges, 62 orphans** across 6 kinds — verified locally by simulating the Vercel build and headless-rendering the result.
- Orphans dropped from 218 → 64 (this repo) because TF-IDF surfaces topical kinship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)