### PR TITLE
chore(calibration): dedupe runner helpers into experiments/_calibration_common

### DIFF
--- a/experiments/_calibration_common.py
+++ b/experiments/_calibration_common.py
@@ -1,0 +1,44 @@
+"""Shared helpers for the calibration experiment runners (arms A/B/D).
+
+Extracted so each runner doesn't re-define `git_rev` and the
+scenario→interactions loader. The fixture generators are imported here
+(rather than in `swarm/`) to keep the test-fixture dependency contained
+within `experiments/` instead of leaking it into the library package.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from tests.fixtures.interactions import (
+    generate_mixed_batch,
+    generate_obfuscation_scenario,
+    generate_self_optimizer_scenario,
+)
+
+# Single source of truth for the scenarios the runners accept. Used both for
+# argparse `choices` and `load_interactions` so the two can't drift.
+SCENARIOS: tuple[str, ...] = ("mixed", "obfuscation", "self_optimizer")
+
+
+def git_rev() -> str:
+    """Short HEAD SHA for run provenance; 'unknown' if git is unavailable."""
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], stderr=subprocess.DEVNULL
+        ).decode().strip()
+    except Exception:
+        return "unknown"
+
+
+def load_interactions(scenario: str, seed: int) -> list:
+    """Generate the interaction pool for a calibration `scenario` at `seed`."""
+    if scenario == "mixed":
+        return generate_mixed_batch(count=500, seed=seed)
+    if scenario == "obfuscation":
+        epochs = generate_obfuscation_scenario(n_epochs=10, seed=seed)
+        return [i for epoch in epochs for i in epoch]
+    if scenario == "self_optimizer":
+        epochs = generate_self_optimizer_scenario(n_epochs=10, seed=seed)
+        return [i for epoch in epochs for i in epoch]
+    raise ValueError(f"unknown scenario: {scenario}")

--- a/experiments/_calibration_common.py
+++ b/experiments/_calibration_common.py
@@ -1,20 +1,15 @@
 """Shared helpers for the calibration experiment runners (arms A/B/D).
 
 Extracted so each runner doesn't re-define `git_rev` and the
-scenario→interactions loader. The fixture generators are imported here
-(rather than in `swarm/`) to keep the test-fixture dependency contained
-within `experiments/` instead of leaking it into the library package.
+scenario→interactions loader. The fixture generators are imported lazily
+inside `load_interactions` (not at module top) so importing this module for
+`git_rev` alone — as `calibration_fidelity` does — doesn't require the
+`tests/` package to be importable (e.g. from an installed/minimal checkout).
 """
 
 from __future__ import annotations
 
 import subprocess
-
-from tests.fixtures.interactions import (
-    generate_mixed_batch,
-    generate_obfuscation_scenario,
-    generate_self_optimizer_scenario,
-)
 
 # Single source of truth for the scenarios the runners accept. Used both for
 # argparse `choices` and `load_interactions` so the two can't drift.
@@ -27,12 +22,20 @@ def git_rev() -> str:
         return subprocess.check_output(
             ["git", "rev-parse", "--short", "HEAD"], stderr=subprocess.DEVNULL
         ).decode().strip()
-    except Exception:
+    except (subprocess.SubprocessError, OSError):
         return "unknown"
 
 
 def load_interactions(scenario: str, seed: int) -> list:
     """Generate the interaction pool for a calibration `scenario` at `seed`."""
+    # Imported here, not at module top, so `git_rev`-only importers like
+    # calibration_fidelity don't depend on tests/ being on the path.
+    from tests.fixtures.interactions import (
+        generate_mixed_batch,
+        generate_obfuscation_scenario,
+        generate_self_optimizer_scenario,
+    )
+
     if scenario == "mixed":
         return generate_mixed_batch(count=500, seed=seed)
     if scenario == "obfuscation":

--- a/experiments/calibration_fidelity.py
+++ b/experiments/calibration_fidelity.py
@@ -25,25 +25,16 @@ from __future__ import annotations
 import argparse
 import csv
 import json
-import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+from experiments._calibration_common import git_rev
 from swarm.calibration.fidelity import sweep_sigmoid_k
 
 
 def _parse_floats(arg: str) -> list[float]:
     return [float(x) for x in arg.split(",") if x.strip()]
-
-
-def _git_rev() -> str:
-    try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "--short", "HEAD"], stderr=subprocess.DEVNULL
-        ).decode().strip()
-    except Exception:
-        return "unknown"
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -88,7 +79,7 @@ def main(argv: list[str] | None = None) -> int:
 
     config = {
         "ts_utc": ts,
-        "git_rev": _git_rev(),
+        "git_rev": git_rev(),
         "p_grid": args.p_grid,
         "k_values": args.k_values,
         "per_bin": args.per_bin,

--- a/experiments/calibration_judge.py
+++ b/experiments/calibration_judge.py
@@ -29,11 +29,11 @@ import csv
 import hashlib
 import json
 import os
-import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+from experiments._calibration_common import SCENARIOS, git_rev, load_interactions
 from swarm.judges import (
     RUBRIC_PATH,
     RUBRIC_VERSION,
@@ -43,36 +43,10 @@ from swarm.judges import (
     make_view,
     stratified_sample,
 )
-from tests.fixtures.interactions import (
-    generate_mixed_batch,
-    generate_obfuscation_scenario,
-    generate_self_optimizer_scenario,
-)
-
-
-def _git_rev() -> str:
-    try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "--short", "HEAD"], stderr=subprocess.DEVNULL
-        ).decode().strip()
-    except Exception:
-        return "unknown"
 
 
 def _rubric_hash() -> str:
     return hashlib.sha256(RUBRIC_PATH.read_bytes()).hexdigest()[:16]
-
-
-def _load_interactions(scenario: str, seed: int) -> list:
-    if scenario == "mixed":
-        return generate_mixed_batch(count=500, seed=seed)
-    if scenario == "obfuscation":
-        epochs = generate_obfuscation_scenario(n_epochs=10, seed=seed)
-        return [i for epoch in epochs for i in epoch]
-    if scenario == "self_optimizer":
-        epochs = generate_self_optimizer_scenario(n_epochs=10, seed=seed)
-        return [i for epoch in epochs for i in epoch]
-    raise ValueError(f"unknown scenario: {scenario}")
 
 
 # Built-in judge specs. Provider + default model. Caller can override
@@ -117,7 +91,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--scenario",
-        choices=["mixed", "obfuscation", "self_optimizer"],
+        choices=list(SCENARIOS),
         default="obfuscation",
         help="Fixture to draw interactions from",
     )
@@ -146,7 +120,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    interactions = _load_interactions(args.scenario, args.seed)
+    interactions = load_interactions(args.scenario, args.seed)
     sample = stratified_sample(interactions, per_bin=args.per_bin, seed=args.seed)
     judges, judge_models = _build_judges(args.judges)
 
@@ -156,7 +130,7 @@ def main(argv: list[str] | None = None) -> int:
 
     config = {
         "ts_utc": ts,
-        "git_rev": _git_rev(),
+        "git_rev": git_rev(),
         "scenario": args.scenario,
         "judges": args.judges,
         # Resolved provider + model per judge so the run is reproducible from


### PR DESCRIPTION
## Summary

The calibration experiment runners each re-defined the same helpers. This extracts them into a single `experiments/_calibration_common.py` so the runners import instead of copy-pasting.

**Duplication removed:**
- `git_rev()` — was byte-identical in `calibration_fidelity.py` and `calibration_judge.py` (and a third copy lives on the arm-D branch / #487).
- `load_interactions(scenario, seed)` — duplicated between `calibration_judge.py` and #487's `calibration_join.py`.
- The `("mixed", "obfuscation", "self_optimizer")` scenario list — repeated in argparse `choices` and the loader; now a single `SCENARIOS` constant so the two can't drift.

**Why `experiments/` and not `swarm/`:** `load_interactions` depends on `tests.fixtures.interactions`. Keeping the shared module under `experiments/` contains that test-fixture dependency where it already lives rather than leaking it into the `swarm` library package.

## Scope notes

- Forked from `main`, which already has the arm A + arm B runners merged. `calibration_join.py` (arm D, #487) is not on `main` yet; it still carries its own `git_rev`/`load_interactions` copies and should adopt this module once #487 lands (happy to push that follow-up to the #487 branch).
- No behaviour change — pure refactor.

## Verification

- `ruff check experiments/` — clean
- `mypy` (both runners + new module) — clean
- Smoke runs: `calibration_judge --judges mock` and `calibration_fidelity` both produce identical output to before
- `pytest tests/test_judges.py tests/test_calibration_fidelity.py` — 36 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013epKJw2RYtrvyV4JdsLzAY)_