### PR TITLE
fix(scripts): validate -n in kb_graph_query central

### DIFF
--- a/scripts/kb_graph_query.py
+++ b/scripts/kb_graph_query.py
@@ -263,10 +263,16 @@ def cmd_central(g: dict, args: list[str]) -> int:
     if "-n" in args:
         i = args.index("-n")
         if i + 1 < len(args):
+            raw = args[i + 1]
             try:
-                n_show = int(args[i + 1])
+                parsed = int(raw)
             except ValueError:
-                pass
+                print(f"warning: -n expected an integer, got {raw!r}; using default {n_show}", file=sys.stderr)
+            else:
+                if parsed < 1:
+                    print(f"warning: -n must be >= 1, got {parsed}; using default {n_show}", file=sys.stderr)
+                else:
+                    n_show = parsed
     ranked = [n for n in g["nodes"] if kind is None or n["kind"] == kind]
     # pagerank is written by build_kb_graph; fall back to indegree if absent
     # (e.g. an older cached graph json) so the command still does something.


### PR DESCRIPTION
## Summary

Addresses two P3 follow-ups noted in PR #490's review (merged):

- **code-quality**: the prior `except ValueError: pass` in `cmd_central` silently swallowed bad input. Replaced with a stderr warning + fallback to the default `n_show = 20` so the user knows their flag was ignored instead of getting silent default behavior.
- **Copilot**: `central -n 0` / `central -n -5` parsed as ints, then printed `Top -5 central page(s) …` and produced confusing slices (negative slicing shows almost the whole list). Now rejects any non-positive value with a stderr warning and falls back to the default.

Both paths warn to stderr — non-fatal, just informative — so existing pipes/scripts that pass valid `-n` see no behaviour change.

## Test plan

Local smoke tests against the live `docs/assets/kb_graph.json`:

- `central -n 5` → prints `Top 5 central page(s) by PageRank:` and 5 rows (unchanged behaviour).
- `central -n 0` → stderr: `warning: -n must be >= 1, got 0; using default 20`; prints top 20.
- `central -n abc` → stderr: `warning: -n expected an integer, got 'abc'; using default 20`; prints top 20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)