### PR TITLE
Add DeLM-style parallel hill-climber for governance/payoff search

### DIFF
--- a/.claude/commands/sweep.md
+++ b/.claude/commands/sweep.md
@@ -60,6 +60,11 @@ This eliminates the manual post-processing step that was previously required bef
 
 `/sweep --delm [scenario_path] [output_name]`
 
+This is a mode of the `/sweep` **slash command**, not a flag on
+`examples/parameter_sweep.py`. When invoked, run the dedicated module CLI shown
+below (`python -m swarm.analysis.delm_hillclimb`) instead of the grid-sweep
+script — the rest of this section tells you how.
+
 A grid sweep evaluates every cell of a fixed lattice. When you instead want to
 *search* the governance/payoff space for a high-fitness configuration, use
 `--delm`: a DeLM-style (decentralized language-model) parallel hill-climber that

--- a/.claude/commands/sweep.md
+++ b/.claude/commands/sweep.md
@@ -56,8 +56,54 @@ This eliminates the manual post-processing step that was previously required bef
 - `mean_welfare` (higher is better)
 - `mean_toxicity` (lower is better)
 
+## `--delm` mode (directed search instead of a grid)
+
+`/sweep --delm [scenario_path] [output_name]`
+
+A grid sweep evaluates every cell of a fixed lattice. When you instead want to
+*search* the governance/payoff space for a high-fitness configuration, use
+`--delm`: a DeLM-style (decentralized language-model) parallel hill-climber that
+shares verified state across virtual workers. It optimizes the same knobs as the
+grid sweep (`governance.*`, `payoff.*` from `PARAM_RANGES`) against the composite
+soft-safety fitness in `swarm.analysis.evolver.compute_fitness` (toxicity,
+welfare, quality gap, payoff gap).
+
+How it works (see `swarm/analysis/delm_hillclimb.py` for the full docstring):
+- **Shared context** holds the running best, a trail of verified *gists*, and
+  binding *constraints* (known dead-end neighbors) — workers read it before
+  paying for an evaluation, so they skip already-seen and pruned cells.
+- **Task queue** of `explore` / `mutate_dim` / `restart` / `diversify` work
+  items lets many workers explore neighbors asynchronously; a verified
+  improvement spawns fresh neighbor tasks around the new best.
+- **Verified admission**: a candidate that beats the best is re-evaluated at an
+  independent seed and only admitted if it still improves (filters noise).
+- **Escape local optima** via `restart` (fresh random point) and `diversify`
+  (jump to a distant basin another worker found).
+
+Run it via the module CLI (writes a self-contained run folder with
+`best_params.json`, `result.json`, `gists.jsonl`):
+
+```bash
+python -m swarm.analysis.delm_hillclimb <scenario_path> \
+    --max-evals 60 --workers 4 --eval-epochs 2 --eval-steps 4 --seed 42 \
+    --output-dir runs/<YYYYMMDD-HHMMSS>_delm/
+```
+
+Useful flags: `--no-verify` (faster, noisier), `--threads` (real OS threads,
+not reproducible), `--restart-prob`, `--step-frac`, and
+`--weight-{toxicity,welfare,quality-gap,payoff-gap}` to reshape the fitness.
+The default deterministic scheduler is reproducible from `scenario YAML + seed`.
+
+This is a sibling of `swarm.analysis.gepa_optimizer` (LLM-guided Pareto search)
+and `swarm.analysis.evolver` (darwinian search) — three optimizers over one
+landscape. Prefer `--delm` when you want a dependency-free, reproducible search;
+prefer GEPA/evolver when you want LLM-reasoned mutations and have the extras
+installed.
+
 ## Notes
 
 - Keep sweeps small by default; prefer fewer epochs/runs unless explicitly requested.
 - The `summary.json` file is consumed by `/council_review` — always generate it.
+- `--delm` writes its own run folder (`best_params.json` + `gists.jsonl`); it does
+  not produce the grid `summary.json`, so it is not a `/council_review` input.
 

--- a/swarm/analysis/__init__.py
+++ b/swarm/analysis/__init__.py
@@ -15,6 +15,11 @@ from swarm.analysis.dashboard import (
     extract_metrics_from_orchestrator,
     run_dashboard,
 )
+from swarm.analysis.delm_hillclimb import (
+    HillClimbConfig,
+    HillClimbResult,
+    run_delm_hillclimb,
+)
 from swarm.analysis.dolt_export import export_run_summary_to_dolt, export_to_dolt
 from swarm.analysis.enhanced_dashboard import (
     plot_enhanced_dashboard,
@@ -66,6 +71,10 @@ __all__ = [
     "SweepResult",
     "SweepRunner",
     "quick_sweep",
+    # DeLM hill-climbing optimizer
+    "HillClimbConfig",
+    "HillClimbResult",
+    "run_delm_hillclimb",
     # Dashboard
     "DashboardConfig",
     "DashboardState",

--- a/swarm/analysis/delm_hillclimb.py
+++ b/swarm/analysis/delm_hillclimb.py
@@ -267,6 +267,10 @@ class Gist:
     score: float
     parent_score: float
     delta: float
+    # ``promoted``: this move became the new global best.
+    # ``verified``: it was promoted *after* passing independent re-evaluation
+    # (always False in ``--no-verify`` mode, where promotion is unverified).
+    promoted: bool
     verified: bool
     summary: str
     side_info: Dict[str, Any]
@@ -338,7 +342,11 @@ class SharedContext:
         self.gists: List[Gist] = []
         self.constraints: List[Constraint] = []
         self.basins: List[Basin] = [Basin(params=dict(best_params), score=best_score)]
-        self._seen: Dict[Tuple[Tuple[str, float], ...], float] = {}
+        self._seen: Dict[Tuple[Tuple[str, float], ...], float] = {
+            # The seed point is already evaluated — mark it seen so no worker
+            # wastes an evaluation re-testing it.
+            _quantize_key(best_params): best_score
+        }
         self._constraint_cells: set[Tuple[Tuple[str, float], ...]] = set()
         self._move_counter = 0
         # Telemetry
@@ -346,6 +354,9 @@ class SharedContext:
         self.n_constraint_pruned = 0
         self.n_improvements = 0
         self.n_verify_rejected = 0
+        # Number of *extra* simulations spent on verified admission. Counted so
+        # the reported evaluation budget stays honest.
+        self.n_verify_evals = 0
 
     # -- reads -------------------------------------------------------------
 
@@ -362,10 +373,15 @@ class SharedContext:
         with self._lock:
             return _quantize_key(params) in self._constraint_cells
 
-    def random_basin(self, rng: random.Random) -> Dict[str, Any]:
+    def random_basin(self, rng: random.Random) -> Tuple[Dict[str, Any], float]:
+        """Pick a random known basin, returning a copy of its params and score.
+
+        Returned atomically under the lock so a concurrent ``record`` appending
+        a new basin cannot produce an inconsistent (params, score) pair.
+        """
         with self._lock:
             basin = rng.choice(self.basins)
-            return dict(basin.params)
+            return dict(basin.params), basin.score
 
     # -- writes (verified admission) --------------------------------------
 
@@ -399,6 +415,7 @@ class SharedContext:
         score = outcome.fitness
         delta = score - parent_score
         verified = False
+        promoted = False
         summary = _summarize_move(base_params, params, parent_score, score)
 
         if not outcome.viable:
@@ -422,13 +439,24 @@ class SharedContext:
                             viable=True,
                         )
                     )
-        elif score > incumbent + IMPROVE_EPS and verifier is not None:
-            # Candidate improvement — verify before trusting it.
-            confirm = verifier(params)
-            confirmed_score = min(score, confirm.fitness) if confirm.viable else -1.0
+        elif score > incumbent + IMPROVE_EPS:
+            # Candidate improvement. In the default mode, re-evaluate at an
+            # independent seed and admit only if it still improves (verified
+            # admission). In --no-verify mode (verifier is None), promote the
+            # candidate directly — faster but noisier.
+            if verifier is not None:
+                confirm = verifier(params)
+                with self._lock:
+                    self.n_verify_evals += 1
+                confirmed_viable = confirm.viable
+                confirmed_score = min(score, confirm.fitness) if confirm.viable else -1.0
+            else:
+                confirmed_viable = True
+                confirmed_score = score
             with self._lock:
-                if confirm.viable and confirmed_score > self.best_score + IMPROVE_EPS:
-                    verified = True
+                if confirmed_viable and confirmed_score > self.best_score + IMPROVE_EPS:
+                    promoted = True
+                    verified = verifier is not None
                     self.n_improvements += 1
                     # Promote to best at the conservative (verified) score.
                     self.best_params = dict(params)
@@ -442,7 +470,7 @@ class SharedContext:
                         for b in self.basins
                     ):
                         self.basins.append(Basin(params=dict(params), score=confirmed_score))
-                else:
+                elif verifier is not None:
                     self.n_verify_rejected += 1
 
         gist = Gist(
@@ -451,6 +479,7 @@ class SharedContext:
             score=round(score, 6),
             parent_score=round(parent_score, 6),
             delta=round(delta, 6),
+            promoted=promoted,
             verified=verified,
             summary=summary,
             side_info=outcome.side_info,
@@ -532,11 +561,19 @@ def _seed_tasks() -> List[Task]:
 class HillClimbConfig:
     """Configuration for a DeLM hill-climb run."""
 
+    # Budget on *primary* candidate evaluations (neighbors probed, incl. the
+    # seed). Verified admission spends additional re-evaluations on top; those
+    # are reported in ``HillClimbResult.n_evals`` and ``telemetry["verify_evals"]``
+    # but do not consume this budget, so ``max_evals`` cleanly controls how many
+    # distinct candidates are explored.
     max_evals: int = 60
     n_workers: int = 4
     step_frac: float = DEFAULT_STEP_FRAC
     restart_prob: float = 0.1
     diversify_prob: float = 0.1
+    # Verified admission (re-evaluate an improvement at an independent seed
+    # before promoting). When False, improvements are promoted directly —
+    # faster, noisier, and spends no verification re-runs.
     verify: bool = True
     # Evaluation budget per candidate (kept small — this is an inner loop).
     eval_epochs: int = 3
@@ -589,24 +626,26 @@ class HillClimbResult:
 
 def _propose(
     task: Task, shared: SharedContext, rng: random.Random, step_frac: float
-) -> Tuple[Dict[str, Any], Dict[str, Any]]:
-    """Turn a claimed task into a (base_params, candidate_params) pair.
+) -> Tuple[Dict[str, Any], Dict[str, Any], float]:
+    """Turn a claimed task into a (base_params, candidate_params, parent_score).
 
-    The base is read fresh from shared state at proposal time, so a worker
-    always climbs from the *latest* verified best — the DeLM property that an
-    improvement written by one worker is instantly available to the next.
+    The base and its score are read atomically from shared state at proposal
+    time, so a worker always climbs from the *latest* best — the DeLM property
+    that an improvement written by one worker is instantly available to the
+    next — and the parent score is consistent with the base it mutated.
     """
     if task.kind == "restart":
         cand = _random_point(rng)
-        return cand, cand
+        return cand, cand, 0.0
     if task.kind == "diversify":
-        base = shared.random_basin(rng)
-        return base, _mutate(base, rng, step_frac=step_frac)
-    base, _ = shared.snapshot_best()
+        # Jump to a basin another worker found; parent is that basin's score.
+        base, base_score = shared.random_basin(rng)
+        return base, _mutate(base, rng, step_frac=step_frac), base_score
+    base, base_score = shared.snapshot_best()
     if task.kind == "mutate_dim" and task.dim is not None:
-        return base, _mutate(base, rng, step_frac=step_frac, dims=[task.dim])
+        return base, _mutate(base, rng, step_frac=step_frac, dims=[task.dim]), base_score
     # explore (and fallback)
-    return base, _mutate(base, rng, step_frac=step_frac)
+    return base, _mutate(base, rng, step_frac=step_frac), base_score
 
 
 def _process_task(
@@ -620,7 +659,7 @@ def _process_task(
     eval_seed: int,
 ) -> bool:
     """Run one task. Returns True if a real evaluation was consumed."""
-    base, cand = _propose(task, shared, rng, cfg.step_frac)
+    base, cand, parent_score = _propose(task, shared, rng, cfg.step_frac)
 
     # Read shared memory before paying for an evaluation.
     if shared.is_pruned(cand):
@@ -629,14 +668,6 @@ def _process_task(
     if shared.is_seen(cand):
         shared.note_redundant()
         return False
-
-    parent_score = shared.snapshot_best()[1] if task.kind != "restart" else 0.0
-    if task.kind == "diversify":
-        # Parent is the basin we jumped to, not the global best.
-        parent_score = next(
-            (b.score for b in shared.basins if _param_distance(b.params, base) < 1e-9),
-            shared.snapshot_best()[1],
-        )
 
     outcome = eval_fn(cand, eval_seed)
 
@@ -656,8 +687,8 @@ def _process_task(
         basin_distance=cfg.basin_distance,
     )
 
-    # A verified improvement spawns fresh neighbor work around the new best.
-    if gist.verified:
+    # A promoted improvement spawns fresh neighbor work around the new best.
+    if gist.promoted:
         queue.push(Task(kind="explore"))
         queue.push(Task(kind="explore"))
         # Re-probe the two dims most likely to extend the winning direction.
@@ -723,8 +754,8 @@ def run_delm_hillclimb(
     seed_params = seed_params_from_scenario(base_scenario)
     seed_outcome = eval_fn(seed_params, base_eval_seed)
     seed_score = seed_outcome.fitness if seed_outcome.viable else 0.0
+    # SharedContext marks the seed point as already seen internally.
     shared = SharedContext(best_params=seed_params, best_score=seed_score)
-    shared._seen[_quantize_key(seed_params)] = seed_score
 
     queue = TaskQueue()
     queue.push_many(_seed_tasks())
@@ -732,8 +763,10 @@ def run_delm_hillclimb(
     history: List[Dict[str, Any]] = [
         {"eval": 0, "best_score": round(seed_score, 6), "kind": "seed"}
     ]
-    n_evals = 1  # the seed evaluation counts toward the budget
-    eval_counter = 0
+    # ``max_evals`` budgets *primary* candidate evaluations (neighbors probed),
+    # including the seed. Verification re-runs are extra simulations tracked on
+    # ``shared.n_verify_evals`` and added into the honest reported total below.
+    primary_evals = 1  # the seed evaluation
     last_best = seed_score
 
     # Per-worker RNGs, derived deterministically from the controller seed so
@@ -741,18 +774,18 @@ def run_delm_hillclimb(
     worker_rngs = [random.Random(cfg.seed * 7919 + w) for w in range(cfg.n_workers)]
 
     if cfg.use_threads:
-        n_evals += _run_threaded(
+        primary_evals += _run_threaded(
             shared, queue, cfg, eval_fn, base_eval_seed, worker_rngs, controller_rng
         )
     else:
         # Deterministic round-robin over virtual workers.
         worker = 0
         stall = 0
-        while n_evals < cfg.max_evals:
+        while primary_evals < cfg.max_evals:
             # Keep the queue fed: inject restart/diversify work to escape optima.
             if len(queue) == 0 or stall > cfg.n_workers * 3:
                 roll = controller_rng.random()
-                if roll < cfg.restart_prob or not shared.basins:
+                if roll < cfg.restart_prob:
                     queue.push(Task(kind="restart"))
                 elif roll < cfg.restart_prob + cfg.diversify_prob:
                     queue.push(Task(kind="diversify"))
@@ -773,15 +806,14 @@ def run_delm_hillclimb(
             worker = (worker + 1) % cfg.n_workers
 
             if consumed:
-                eval_counter += 1
-                # Verification costs a second evaluation; count it for honesty.
-                evals_used = 1
-                n_evals += evals_used
+                primary_evals += 1
+                # Honest running total = primaries + verification re-runs so far.
+                total_evals = primary_evals + shared.n_verify_evals
                 _, best_now = shared.snapshot_best()
                 if best_now > last_best + IMPROVE_EPS:
                     history.append(
                         {
-                            "eval": n_evals,
+                            "eval": total_evals,
                             "best_score": round(best_now, 6),
                             "kind": task.kind,
                         }
@@ -789,7 +821,7 @@ def run_delm_hillclimb(
                     if progress:
                         logger.info(
                             "eval %d: best %.4f -> %.4f (%s)",
-                            n_evals,
+                            total_evals,
                             last_best,
                             best_now,
                             task.kind,
@@ -802,10 +834,14 @@ def run_delm_hillclimb(
                 stall += 1
 
     best_params, best_score = shared.snapshot_best()
+    # Honest total: every simulation run, primaries plus verification re-runs.
+    n_evals = primary_evals + shared.n_verify_evals
     telemetry = {
         "n_workers": cfg.n_workers,
+        "primary_evals": primary_evals,
         "improvements": shared.n_improvements,
         "verify_rejected": shared.n_verify_rejected,
+        "verify_evals": shared.n_verify_evals,
         "redundant_skipped": shared.n_redundant_skipped,
         "constraint_pruned": shared.n_constraint_pruned,
         "gists": len(shared.gists),
@@ -835,10 +871,12 @@ def _run_threaded(
     worker_rngs: List[random.Random],
     controller_rng: random.Random,
 ) -> int:
-    """Real-thread scheduler. Returns the number of evaluations consumed.
+    """Real-thread scheduler. Returns the number of *primary* evaluations used.
 
-    Not bit-for-bit reproducible: thread interleaving over the shared store is
-    not controlled. Provided for throughput on slow evaluations.
+    Verification re-runs are tracked separately on the shared context
+    (``n_verify_evals``) and added by the caller, so the reported total counts
+    every simulation. Not bit-for-bit reproducible: thread interleaving over the
+    shared store is not controlled. Provided for throughput on slow evaluations.
     """
     budget = max(0, cfg.max_evals - 1)
     counter = {"used": 0}
@@ -859,7 +897,7 @@ def _run_threaded(
             task = queue.claim()
             if task is None:
                 roll = controller_rng.random()
-                if roll < cfg.restart_prob or not shared.basins:
+                if roll < cfg.restart_prob:
                     task = Task(kind="restart")
                 elif roll < cfg.restart_prob + cfg.diversify_prob:
                     task = Task(kind="diversify")
@@ -925,7 +963,12 @@ def main(argv: Optional[List[str]] = None) -> int:
         description="DeLM-style parallel hill-climbing over governance/payoff params."
     )
     parser.add_argument("scenario", help="Path to base scenario YAML.")
-    parser.add_argument("--max-evals", type=int, default=60, help="Evaluation budget.")
+    parser.add_argument(
+        "--max-evals",
+        type=int,
+        default=60,
+        help="Budget on primary candidate evaluations (verification re-runs are extra).",
+    )
     parser.add_argument("--workers", type=int, default=4, help="Number of virtual workers.")
     parser.add_argument("--seed", type=int, default=42, help="Random seed.")
     parser.add_argument("--eval-epochs", type=int, default=3, help="Epochs per evaluation.")

--- a/swarm/analysis/delm_hillclimb.py
+++ b/swarm/analysis/delm_hillclimb.py
@@ -1,0 +1,989 @@
+"""DeLM-style parallel hill-climbing over governance/payoff parameters.
+
+This is a third optimizer over the same fitness landscape used by
+``swarm.analysis.evolver`` (darwinian search) and
+``swarm.analysis.gepa_optimizer`` (LLM-guided Pareto search): the governance
+and payoff knobs in ``PARAM_RANGES``, scored by ``compute_fitness`` against the
+soft safety metrics (toxicity, welfare, quality gap, payoff gap).
+
+Where those optimizers run a single controller, this module implements the
+**DeLM** (decentralized language-model) coordination pattern as a parallel,
+shared-state, self-coordinating hill-climb with no central planner:
+
+* **Shared context as fitness-landscape memory** (:class:`SharedContext`).
+  Verified *gists* of improving moves, the running best, and binding
+  *constraints* (known dead-end neighbors) accumulate in one shared store.
+  Workers read it immediately, so they avoid re-testing known-bad neighbors or
+  repeating failed mutations.
+
+* **Task queue for asynchronous neighbor exploration** (:class:`TaskQueue`).
+  Instead of one agent sequentially generating and evaluating neighbors, many
+  workers claim ``explore`` / ``mutate_dim`` / ``restart`` / ``diversify``
+  tasks. As soon as one worker verifies an improvement it writes a compact
+  gist and updates the best, so the next worker instantly hill-climbs from the
+  new higher point and fresh neighbor tasks are spawned around it.
+
+* **Verified admission prevents noise.** A candidate that beats the current
+  best is re-evaluated at an independent verification seed; only moves that
+  still improve are admitted. This keeps the shared state trustworthy — one
+  noisy "improvement" can otherwise derail the whole trajectory.
+
+* **Escaping local optima.** ``restart`` tasks sample fresh points in the full
+  space and ``diversify`` tasks jump to distant *basins* discovered by other
+  workers, so the swarm can leave a basin once it is exhausted.
+
+The default scheduler is a deterministic round-robin over ``n_workers`` virtual
+workers sharing one :class:`SharedContext`. This reproduces the DeLM dynamics
+(shared verified state, asynchronous neighbor claiming, instant hill-climb from
+a new best) while remaining fully reproducible from ``scenario YAML + seed`` —
+the project's reproducibility invariant. Pass ``use_threads=True`` to run the
+same workers as real OS threads (the shared store is lock-protected); results
+are then no longer bit-for-bit reproducible because thread interleaving is not
+controlled, so the deterministic scheduler is the default.
+
+Usage (CLI)::
+
+    python -m swarm.analysis.delm_hillclimb scenarios/baseline.yaml \\
+        --max-evals 60 --workers 4 --seed 42
+
+    # custom fitness weights + faster evals
+    python -m swarm.analysis.delm_hillclimb scenarios/baseline.yaml \\
+        --max-evals 100 --workers 8 --eval-epochs 2 --eval-steps 4 \\
+        --weight-toxicity 0.5 --weight-welfare 0.2
+
+Usage (library)::
+
+    from swarm.analysis.delm_hillclimb import HillClimbConfig, run_delm_hillclimb
+    from swarm.scenarios import load_scenario
+
+    scenario = load_scenario("scenarios/baseline.yaml")
+    result = run_delm_hillclimb(scenario, HillClimbConfig(max_evals=60, n_workers=4))
+    print(result.best_score, result.best_params)
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import logging
+import math
+import random
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from swarm.analysis.evolver import (
+    DEFAULT_FITNESS_WEIGHTS,
+    INT_PARAMS,
+    PARAM_RANGES,
+    compute_fitness,
+)
+from swarm.analysis.sweep import _apply_params, _extract_results
+from swarm.scenarios import ScenarioConfig, build_orchestrator, load_scenario
+
+logger = logging.getLogger(__name__)
+
+# A move must beat the incumbent by at least this much (in fitness units) to be
+# treated as an improvement worth verifying. Filters out evaluation jitter.
+IMPROVE_EPS = 1e-3
+
+# A move this far *below* the incumbent (or a non-viable run) is recorded as a
+# binding constraint so other workers prune that neighbor.
+DEADEND_MARGIN = 0.02
+
+# Number of decimal places used to quantize parameter cells for the
+# seen/constraint maps. Two distinct candidates that round to the same cell are
+# treated as the same neighbor (avoids redundant re-evaluation).
+QUANT_DECIMALS = 4
+
+# Fraction of the parameter range used as the std-dev of a local mutation step.
+DEFAULT_STEP_FRAC = 0.15
+
+
+# ---------------------------------------------------------------------------
+# Evaluation: one (params -> fitness) measurement on the shared landscape
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EvalOutcome:
+    """Result of a single simulation evaluation of a parameter set."""
+
+    fitness: float
+    side_info: Dict[str, Any]
+    viable: bool
+    error: Optional[str] = None
+
+
+def evaluate_params(
+    base_scenario: ScenarioConfig,
+    params: Dict[str, Any],
+    *,
+    seed: int,
+    eval_epochs: int,
+    eval_steps: int,
+    fitness_weights: Optional[Dict[str, float]] = None,
+    welfare_reference: float = 10.0,
+    payoff_reference: float = 5.0,
+) -> EvalOutcome:
+    """Evaluate a governance/payoff parameter set on the soft-safety landscape.
+
+    Mirrors the evaluation pipeline used by the GEPA and darwinian optimizers
+    so all three rank candidates on the same scale: apply params to a deep copy
+    of the scenario, run a short simulation, extract soft metrics, and fold
+    them into a single composite fitness in ``[0, 1]``.
+    """
+    scenario = copy.deepcopy(base_scenario)
+    scenario = _apply_params(scenario, params)
+    cfg = scenario.orchestrator_config
+    cfg.seed = seed
+    cfg.n_epochs = eval_epochs
+    cfg.steps_per_epoch = eval_steps
+    cfg.log_path = None
+    cfg.log_events = False
+
+    try:
+        orchestrator = build_orchestrator(scenario)
+        orchestrator.run()
+    except Exception as exc:  # noqa: BLE001 — a bad genome must not kill the swarm
+        logger.debug("evaluation failed for %s: %s", params, exc)
+        return EvalOutcome(fitness=0.0, side_info={}, viable=False, error=str(exc))
+
+    result = _extract_results(orchestrator, params, 0, seed)
+    payoff_gap = result.honest_avg_payoff - result.adversarial_avg_payoff
+    fitness = compute_fitness(
+        avg_toxicity=result.avg_toxicity,
+        avg_welfare=result.welfare_per_epoch,
+        avg_quality_gap=result.avg_quality_gap,
+        payoff_gap=payoff_gap,
+        weights=fitness_weights,
+        welfare_reference=welfare_reference,
+        payoff_reference=payoff_reference,
+    )
+    side_info = {
+        "toxicity": round(result.avg_toxicity, 4),
+        "welfare": round(result.welfare_per_epoch, 4),
+        "quality_gap": round(result.avg_quality_gap, 4),
+        "payoff_gap": round(payoff_gap, 4),
+        "n_frozen": result.n_frozen,
+    }
+    return EvalOutcome(fitness=fitness, side_info=side_info, viable=True)
+
+
+# ---------------------------------------------------------------------------
+# Parameter-space helpers
+# ---------------------------------------------------------------------------
+
+
+def _clamp_param(name: str, value: float) -> Any:
+    """Clamp a value to ``PARAM_RANGES[name]`` and coerce int params."""
+    lo, hi = PARAM_RANGES[name]
+    value = max(lo, min(hi, value))
+    if name in INT_PARAMS:
+        return int(round(value))
+    return float(value)
+
+
+def _quantize_key(params: Dict[str, Any]) -> Tuple[Tuple[str, float], ...]:
+    """A hashable, quantized identity for a parameter cell.
+
+    Two candidates that round to the same grid cell are the same neighbor for
+    the purposes of the seen-set and constraint matching.
+    """
+    return tuple(
+        (name, round(float(params[name]), QUANT_DECIMALS))
+        for name in sorted(params)
+        if name in PARAM_RANGES
+    )
+
+
+def seed_params_from_scenario(scenario: ScenarioConfig) -> Dict[str, Any]:
+    """Read the scenario's current governance/payoff knobs as a start point.
+
+    Any knob the scenario does not set falls back to the midpoint of its range,
+    so the optimizer always starts from a fully specified, in-range point.
+    """
+    orch = scenario.orchestrator_config
+    params: Dict[str, Any] = {}
+    for dotted, (lo, hi) in PARAM_RANGES.items():
+        section, _, key = dotted.partition(".")
+        value: Optional[float] = None
+        if section == "governance" and orch.governance_config is not None:
+            value = getattr(orch.governance_config, key, None)
+        elif section == "payoff":
+            value = getattr(orch.payoff_config, key, None)
+        if value is None:
+            value = (lo + hi) / 2.0
+        params[dotted] = _clamp_param(dotted, float(value))
+    return params
+
+
+def _param_distance(a: Dict[str, Any], b: Dict[str, Any]) -> float:
+    """Normalized L2 distance between two param dicts (range-scaled)."""
+    total = 0.0
+    for name, (lo, hi) in PARAM_RANGES.items():
+        span = (hi - lo) or 1.0
+        da = (float(a.get(name, lo)) - float(b.get(name, lo))) / span
+        total += da * da
+    return math.sqrt(total)
+
+
+def _mutate(
+    base: Dict[str, Any],
+    rng: random.Random,
+    *,
+    step_frac: float,
+    dims: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Local mutation: Gaussian perturbation of ``dims`` (default: all)."""
+    out = dict(base)
+    targets = dims if dims is not None else list(PARAM_RANGES.keys())
+    for name in targets:
+        lo, hi = PARAM_RANGES[name]
+        sigma = step_frac * (hi - lo)
+        out[name] = _clamp_param(name, float(base.get(name, (lo + hi) / 2)) + rng.gauss(0.0, sigma))
+    return out
+
+
+def _random_point(rng: random.Random) -> Dict[str, Any]:
+    """A uniformly random point in the full parameter space (for restarts)."""
+    return {name: _clamp_param(name, rng.uniform(lo, hi)) for name, (lo, hi) in PARAM_RANGES.items()}
+
+
+# ---------------------------------------------------------------------------
+# Shared context: the fitness-landscape memory
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Gist:
+    """A compact, verified record of an evaluated move."""
+
+    move_id: int
+    params: Dict[str, Any]
+    score: float
+    parent_score: float
+    delta: float
+    verified: bool
+    summary: str
+    side_info: Dict[str, Any]
+    worker: int
+    kind: str
+
+    def to_json(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class Constraint:
+    """A binding dead-end: a known-bad neighbor cell other workers should skip.
+
+    ``cell`` is the quantized identity of the failing candidate; any future
+    proposal that quantizes to the same cell is pruned without re-evaluation —
+    the DeLM "this edit always breaks test X" rule made binding for everyone.
+    """
+
+    cell: Tuple[Tuple[str, float], ...]
+    summary: str
+    score: float
+    viable: bool
+
+
+@dataclass
+class Basin:
+    """A distinct local optimum discovered by some worker."""
+
+    params: Dict[str, Any]
+    score: float
+
+
+def _summarize_move(
+    base: Dict[str, Any], cand: Dict[str, Any], parent_score: float, score: float
+) -> str:
+    """Human-readable gist of the largest single change in a move."""
+    biggest_name = ""
+    biggest_mag = 0.0
+    for name, (lo, hi) in PARAM_RANGES.items():
+        span = (hi - lo) or 1.0
+        mag = abs(float(cand.get(name, lo)) - float(base.get(name, lo))) / span
+        if mag > biggest_mag:
+            biggest_mag = mag
+            biggest_name = name
+    if not biggest_name or biggest_mag == 0.0:
+        # No dimension changed relative to the base — a fresh restart point.
+        return f"fresh point at score {score:.3f}"
+    short = biggest_name.split(".")[-1]
+    direction = "raise" if cand[biggest_name] > base.get(biggest_name, 0) else "lower"
+    return (
+        f"score {parent_score:.3f} -> {score:.3f} via {direction} {short} "
+        f"to {cand[biggest_name]:.4g}"
+    )
+
+
+class SharedContext:
+    """Lock-protected shared store read and written by all workers.
+
+    Holds the running best, the verified gist trail, binding constraints, the
+    seen-cell set (redundant-work guard), and the basin list (for escaping
+    local optima). All public methods are safe under the thread scheduler.
+    """
+
+    def __init__(self, best_params: Dict[str, Any], best_score: float):
+        self._lock = threading.Lock()
+        self.best_params: Dict[str, Any] = dict(best_params)
+        self.best_score: float = best_score
+        self.gists: List[Gist] = []
+        self.constraints: List[Constraint] = []
+        self.basins: List[Basin] = [Basin(params=dict(best_params), score=best_score)]
+        self._seen: Dict[Tuple[Tuple[str, float], ...], float] = {}
+        self._constraint_cells: set[Tuple[Tuple[str, float], ...]] = set()
+        self._move_counter = 0
+        # Telemetry
+        self.n_redundant_skipped = 0
+        self.n_constraint_pruned = 0
+        self.n_improvements = 0
+        self.n_verify_rejected = 0
+
+    # -- reads -------------------------------------------------------------
+
+    def snapshot_best(self) -> Tuple[Dict[str, Any], float]:
+        with self._lock:
+            return dict(self.best_params), self.best_score
+
+    def is_seen(self, params: Dict[str, Any]) -> bool:
+        with self._lock:
+            return _quantize_key(params) in self._seen
+
+    def is_pruned(self, params: Dict[str, Any]) -> bool:
+        """True if a binding constraint already rules this neighbor out."""
+        with self._lock:
+            return _quantize_key(params) in self._constraint_cells
+
+    def random_basin(self, rng: random.Random) -> Dict[str, Any]:
+        with self._lock:
+            basin = rng.choice(self.basins)
+            return dict(basin.params)
+
+    # -- writes (verified admission) --------------------------------------
+
+    def record(
+        self,
+        *,
+        params: Dict[str, Any],
+        outcome: EvalOutcome,
+        parent_score: float,
+        base_params: Dict[str, Any],
+        worker: int,
+        kind: str,
+        verifier: Optional[Callable[[Dict[str, Any]], EvalOutcome]] = None,
+        basin_distance: float = 0.25,
+    ) -> Gist:
+        """Admit an evaluated candidate into the shared context.
+
+        Verified admission: a candidate that beats the incumbent is only made
+        the new best if ``verifier`` (a re-evaluation at an independent seed)
+        confirms it still improves. Clear regressions and non-viable runs are
+        recorded as binding constraints; everything is marked seen so no worker
+        re-tests the same cell.
+        """
+        cell = _quantize_key(params)
+        with self._lock:
+            self._seen[cell] = outcome.fitness
+            self._move_counter += 1
+            move_id = self._move_counter
+            incumbent = self.best_score
+
+        score = outcome.fitness
+        delta = score - parent_score
+        verified = False
+        summary = _summarize_move(base_params, params, parent_score, score)
+
+        if not outcome.viable:
+            summary = f"non-viable run ({outcome.error or 'unknown'})"
+            with self._lock:
+                if cell not in self._constraint_cells:
+                    self._constraint_cells.add(cell)
+                    self.constraints.append(
+                        Constraint(cell=cell, summary=summary, score=0.0, viable=False)
+                    )
+        elif score + IMPROVE_EPS < incumbent - DEADEND_MARGIN:
+            # Clear regression vs. the global best — bind it as a dead-end.
+            with self._lock:
+                if cell not in self._constraint_cells:
+                    self._constraint_cells.add(cell)
+                    self.constraints.append(
+                        Constraint(
+                            cell=cell,
+                            summary=f"dead-end: {summary} (best {incumbent:.3f})",
+                            score=score,
+                            viable=True,
+                        )
+                    )
+        elif score > incumbent + IMPROVE_EPS and verifier is not None:
+            # Candidate improvement — verify before trusting it.
+            confirm = verifier(params)
+            confirmed_score = min(score, confirm.fitness) if confirm.viable else -1.0
+            with self._lock:
+                if confirm.viable and confirmed_score > self.best_score + IMPROVE_EPS:
+                    verified = True
+                    self.n_improvements += 1
+                    # Promote to best at the conservative (verified) score.
+                    self.best_params = dict(params)
+                    self.best_score = confirmed_score
+                    score = confirmed_score
+                    delta = confirmed_score - parent_score
+                    self._seen[cell] = confirmed_score
+                    # Record a new basin if this point is far from all known ones.
+                    if all(
+                        _param_distance(params, b.params) > basin_distance
+                        for b in self.basins
+                    ):
+                        self.basins.append(Basin(params=dict(params), score=confirmed_score))
+                else:
+                    self.n_verify_rejected += 1
+
+        gist = Gist(
+            move_id=move_id,
+            params=dict(params),
+            score=round(score, 6),
+            parent_score=round(parent_score, 6),
+            delta=round(delta, 6),
+            verified=verified,
+            summary=summary,
+            side_info=outcome.side_info,
+            worker=worker,
+            kind=kind,
+        )
+        with self._lock:
+            self.gists.append(gist)
+        return gist
+
+    def note_redundant(self) -> None:
+        with self._lock:
+            self.n_redundant_skipped += 1
+
+    def note_pruned(self) -> None:
+        with self._lock:
+            self.n_constraint_pruned += 1
+
+
+# ---------------------------------------------------------------------------
+# Task queue: asynchronous neighbor-exploration work items
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Task:
+    """A unit of neighbor-exploration work a worker can claim.
+
+    kind:
+      * ``explore``     — mutate all dims around the current best.
+      * ``mutate_dim``  — mutate a single dimension around the current best.
+      * ``restart``     — sample a fresh random point (escape local optima).
+      * ``diversify``   — jump to a distant basin discovered by another worker.
+    """
+
+    kind: str
+    dim: Optional[str] = None
+
+
+class TaskQueue:
+    """A thread-safe claimable FIFO of :class:`Task` items."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._items: List[Task] = []
+
+    def push(self, task: Task) -> None:
+        with self._lock:
+            self._items.append(task)
+
+    def push_many(self, tasks: List[Task]) -> None:
+        with self._lock:
+            self._items.extend(tasks)
+
+    def claim(self) -> Optional[Task]:
+        with self._lock:
+            if not self._items:
+                return None
+            return self._items.pop(0)
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._items)
+
+
+def _seed_tasks() -> List[Task]:
+    """Initial work: probe every dimension plus a few full-space explores."""
+    tasks: List[Task] = [Task(kind="mutate_dim", dim=name) for name in PARAM_RANGES]
+    tasks.extend(Task(kind="explore") for _ in range(4))
+    return tasks
+
+
+# ---------------------------------------------------------------------------
+# Configuration & result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HillClimbConfig:
+    """Configuration for a DeLM hill-climb run."""
+
+    max_evals: int = 60
+    n_workers: int = 4
+    step_frac: float = DEFAULT_STEP_FRAC
+    restart_prob: float = 0.1
+    diversify_prob: float = 0.1
+    verify: bool = True
+    # Evaluation budget per candidate (kept small — this is an inner loop).
+    eval_epochs: int = 3
+    eval_steps: int = 5
+    seed: int = 42
+    fitness_weights: Optional[Dict[str, float]] = None
+    welfare_reference: float = 10.0
+    payoff_reference: float = 5.0
+    # Real OS threads instead of the deterministic scheduler (not reproducible).
+    use_threads: bool = False
+    # How far (normalized param distance) a verified best must be from known
+    # basins to count as a new basin.
+    basin_distance: float = 0.25
+
+
+@dataclass
+class HillClimbResult:
+    """Outcome of a DeLM hill-climb run."""
+
+    best_params: Dict[str, Any]
+    best_score: float
+    seed_params: Dict[str, Any]
+    seed_score: float
+    n_evals: int
+    history: List[Dict[str, Any]]
+    gists: List[Dict[str, Any]]
+    constraints: List[Dict[str, Any]]
+    basins: List[Dict[str, Any]]
+    telemetry: Dict[str, Any]
+
+    def to_json(self) -> Dict[str, Any]:
+        return {
+            "best_params": self.best_params,
+            "best_score": self.best_score,
+            "seed_params": self.seed_params,
+            "seed_score": self.seed_score,
+            "n_evals": self.n_evals,
+            "history": self.history,
+            "gists": self.gists,
+            "constraints": self.constraints,
+            "basins": self.basins,
+            "telemetry": self.telemetry,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Worker logic
+# ---------------------------------------------------------------------------
+
+
+def _propose(
+    task: Task, shared: SharedContext, rng: random.Random, step_frac: float
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Turn a claimed task into a (base_params, candidate_params) pair.
+
+    The base is read fresh from shared state at proposal time, so a worker
+    always climbs from the *latest* verified best — the DeLM property that an
+    improvement written by one worker is instantly available to the next.
+    """
+    if task.kind == "restart":
+        cand = _random_point(rng)
+        return cand, cand
+    if task.kind == "diversify":
+        base = shared.random_basin(rng)
+        return base, _mutate(base, rng, step_frac=step_frac)
+    base, _ = shared.snapshot_best()
+    if task.kind == "mutate_dim" and task.dim is not None:
+        return base, _mutate(base, rng, step_frac=step_frac, dims=[task.dim])
+    # explore (and fallback)
+    return base, _mutate(base, rng, step_frac=step_frac)
+
+
+def _process_task(
+    task: Task,
+    worker: int,
+    shared: SharedContext,
+    queue: TaskQueue,
+    rng: random.Random,
+    cfg: HillClimbConfig,
+    eval_fn: Callable[[Dict[str, Any], int], EvalOutcome],
+    eval_seed: int,
+) -> bool:
+    """Run one task. Returns True if a real evaluation was consumed."""
+    base, cand = _propose(task, shared, rng, cfg.step_frac)
+
+    # Read shared memory before paying for an evaluation.
+    if shared.is_pruned(cand):
+        shared.note_pruned()
+        return False
+    if shared.is_seen(cand):
+        shared.note_redundant()
+        return False
+
+    parent_score = shared.snapshot_best()[1] if task.kind != "restart" else 0.0
+    if task.kind == "diversify":
+        # Parent is the basin we jumped to, not the global best.
+        parent_score = next(
+            (b.score for b in shared.basins if _param_distance(b.params, base) < 1e-9),
+            shared.snapshot_best()[1],
+        )
+
+    outcome = eval_fn(cand, eval_seed)
+
+    verifier = None
+    if cfg.verify:
+        # Verify at an independent seed derived from the eval seed.
+        verifier = lambda p, s=eval_seed: eval_fn(p, s + 100_003)  # noqa: E731
+
+    gist = shared.record(
+        params=cand,
+        outcome=outcome,
+        parent_score=parent_score,
+        base_params=base,
+        worker=worker,
+        kind=task.kind,
+        verifier=verifier,
+        basin_distance=cfg.basin_distance,
+    )
+
+    # A verified improvement spawns fresh neighbor work around the new best.
+    if gist.verified:
+        queue.push(Task(kind="explore"))
+        queue.push(Task(kind="explore"))
+        # Re-probe the two dims most likely to extend the winning direction.
+        for name in _top_changed_dims(base, cand, k=2):
+            queue.push(Task(kind="mutate_dim", dim=name))
+    return True
+
+
+def _top_changed_dims(base: Dict[str, Any], cand: Dict[str, Any], k: int) -> List[str]:
+    """The ``k`` dimensions that changed most (range-normalized)."""
+    scored: List[Tuple[float, str]] = []
+    for name, (lo, hi) in PARAM_RANGES.items():
+        span = (hi - lo) or 1.0
+        mag = abs(float(cand.get(name, lo)) - float(base.get(name, lo))) / span
+        scored.append((mag, name))
+    scored.sort(reverse=True)
+    return [name for _, name in scored[:k]]
+
+
+# ---------------------------------------------------------------------------
+# Top-level driver
+# ---------------------------------------------------------------------------
+
+
+def run_delm_hillclimb(
+    base_scenario: ScenarioConfig,
+    config: Optional[HillClimbConfig] = None,
+    *,
+    progress: bool = False,
+) -> HillClimbResult:
+    """Run a DeLM-style parallel hill-climb over governance/payoff params.
+
+    Args:
+        base_scenario: Scenario whose governance/payoff knobs are optimized.
+        config: Hill-climb configuration (budget, workers, eval size, …).
+        progress: If True, log a line whenever the verified best improves.
+
+    Returns:
+        A :class:`HillClimbResult` with the best parameters found, the verified
+        gist trail, binding constraints, discovered basins, and telemetry.
+    """
+    cfg = config or HillClimbConfig()
+    controller_rng = random.Random(cfg.seed)
+
+    # Per-evaluation simulation seed: fixed across candidates so fitness
+    # differences reflect the genome, not the seed (verification uses a
+    # separate, offset seed).
+    base_eval_seed = cfg.seed
+
+    def eval_fn(params: Dict[str, Any], seed: int) -> EvalOutcome:
+        return evaluate_params(
+            base_scenario,
+            params,
+            seed=seed,
+            eval_epochs=cfg.eval_epochs,
+            eval_steps=cfg.eval_steps,
+            fitness_weights=cfg.fitness_weights,
+            welfare_reference=cfg.welfare_reference,
+            payoff_reference=cfg.payoff_reference,
+        )
+
+    # Seed the climb from the scenario's current configuration.
+    seed_params = seed_params_from_scenario(base_scenario)
+    seed_outcome = eval_fn(seed_params, base_eval_seed)
+    seed_score = seed_outcome.fitness if seed_outcome.viable else 0.0
+    shared = SharedContext(best_params=seed_params, best_score=seed_score)
+    shared._seen[_quantize_key(seed_params)] = seed_score
+
+    queue = TaskQueue()
+    queue.push_many(_seed_tasks())
+
+    history: List[Dict[str, Any]] = [
+        {"eval": 0, "best_score": round(seed_score, 6), "kind": "seed"}
+    ]
+    n_evals = 1  # the seed evaluation counts toward the budget
+    eval_counter = 0
+    last_best = seed_score
+
+    # Per-worker RNGs, derived deterministically from the controller seed so
+    # the virtual swarm is reproducible.
+    worker_rngs = [random.Random(cfg.seed * 7919 + w) for w in range(cfg.n_workers)]
+
+    if cfg.use_threads:
+        n_evals += _run_threaded(
+            shared, queue, cfg, eval_fn, base_eval_seed, worker_rngs, controller_rng
+        )
+    else:
+        # Deterministic round-robin over virtual workers.
+        worker = 0
+        stall = 0
+        while n_evals < cfg.max_evals:
+            # Keep the queue fed: inject restart/diversify work to escape optima.
+            if len(queue) == 0 or stall > cfg.n_workers * 3:
+                roll = controller_rng.random()
+                if roll < cfg.restart_prob or not shared.basins:
+                    queue.push(Task(kind="restart"))
+                elif roll < cfg.restart_prob + cfg.diversify_prob:
+                    queue.push(Task(kind="diversify"))
+                else:
+                    queue.push(Task(kind="explore"))
+                stall = 0
+
+            task = queue.claim()
+            if task is None:
+                queue.push(Task(kind="explore"))
+                continue
+
+            rng = worker_rngs[worker]
+            eval_seed = base_eval_seed
+            consumed = _process_task(
+                task, worker, shared, queue, rng, cfg, eval_fn, eval_seed
+            )
+            worker = (worker + 1) % cfg.n_workers
+
+            if consumed:
+                eval_counter += 1
+                # Verification costs a second evaluation; count it for honesty.
+                evals_used = 1
+                n_evals += evals_used
+                _, best_now = shared.snapshot_best()
+                if best_now > last_best + IMPROVE_EPS:
+                    history.append(
+                        {
+                            "eval": n_evals,
+                            "best_score": round(best_now, 6),
+                            "kind": task.kind,
+                        }
+                    )
+                    if progress:
+                        logger.info(
+                            "eval %d: best %.4f -> %.4f (%s)",
+                            n_evals,
+                            last_best,
+                            best_now,
+                            task.kind,
+                        )
+                    last_best = best_now
+                    stall = 0
+                else:
+                    stall += 1
+            else:
+                stall += 1
+
+    best_params, best_score = shared.snapshot_best()
+    telemetry = {
+        "n_workers": cfg.n_workers,
+        "improvements": shared.n_improvements,
+        "verify_rejected": shared.n_verify_rejected,
+        "redundant_skipped": shared.n_redundant_skipped,
+        "constraint_pruned": shared.n_constraint_pruned,
+        "gists": len(shared.gists),
+        "constraints": len(shared.constraints),
+        "basins": len(shared.basins),
+    }
+    return HillClimbResult(
+        best_params=best_params,
+        best_score=round(best_score, 6),
+        seed_params=seed_params,
+        seed_score=round(seed_score, 6),
+        n_evals=n_evals,
+        history=history,
+        gists=[g.to_json() for g in shared.gists],
+        constraints=[asdict(c) for c in shared.constraints],
+        basins=[asdict(b) for b in shared.basins],
+        telemetry=telemetry,
+    )
+
+
+def _run_threaded(
+    shared: SharedContext,
+    queue: TaskQueue,
+    cfg: HillClimbConfig,
+    eval_fn: Callable[[Dict[str, Any], int], EvalOutcome],
+    base_eval_seed: int,
+    worker_rngs: List[random.Random],
+    controller_rng: random.Random,
+) -> int:
+    """Real-thread scheduler. Returns the number of evaluations consumed.
+
+    Not bit-for-bit reproducible: thread interleaving over the shared store is
+    not controlled. Provided for throughput on slow evaluations.
+    """
+    budget = max(0, cfg.max_evals - 1)
+    counter = {"used": 0}
+    counter_lock = threading.Lock()
+
+    def claim_budget() -> bool:
+        with counter_lock:
+            if counter["used"] >= budget:
+                return False
+            counter["used"] += 1
+            return True
+
+    def worker_loop(wid: int) -> None:
+        rng = worker_rngs[wid]
+        while True:
+            if not claim_budget():
+                return
+            task = queue.claim()
+            if task is None:
+                roll = controller_rng.random()
+                if roll < cfg.restart_prob or not shared.basins:
+                    task = Task(kind="restart")
+                elif roll < cfg.restart_prob + cfg.diversify_prob:
+                    task = Task(kind="diversify")
+                else:
+                    task = Task(kind="explore")
+            consumed = _process_task(
+                task, wid, shared, queue, rng, cfg, eval_fn, base_eval_seed
+            )
+            if not consumed:
+                # Did not spend the simulated evaluation — refund the budget.
+                with counter_lock:
+                    counter["used"] -= 1
+
+    threads = [
+        threading.Thread(target=worker_loop, args=(w,), daemon=True)
+        for w in range(cfg.n_workers)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return counter["used"]
+
+
+# ---------------------------------------------------------------------------
+# Run-folder writer & CLI
+# ---------------------------------------------------------------------------
+
+
+def write_run(result: HillClimbResult, run_dir: Path, scenario_id: str) -> None:
+    """Write a self-contained run folder (best params, history, gists)."""
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "best_params.json").write_text(
+        json.dumps(
+            {"scenario": scenario_id, "best_score": result.best_score, "best_params": result.best_params},
+            indent=2,
+        )
+    )
+    (run_dir / "result.json").write_text(json.dumps(result.to_json(), indent=2))
+    with (run_dir / "gists.jsonl").open("w") as fh:
+        for gist in result.gists:
+            fh.write(json.dumps(gist) + "\n")
+
+
+def _build_weights(args: argparse.Namespace) -> Optional[Dict[str, float]]:
+    overrides = {
+        "low_toxicity": args.weight_toxicity,
+        "welfare": args.weight_welfare,
+        "quality_gap": args.weight_quality_gap,
+        "payoff_gap": args.weight_payoff_gap,
+    }
+    if all(v is None for v in overrides.values()):
+        return None
+    weights = dict(DEFAULT_FITNESS_WEIGHTS)
+    for key, val in overrides.items():
+        if val is not None:
+            weights[key] = val
+    return weights
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="DeLM-style parallel hill-climbing over governance/payoff params."
+    )
+    parser.add_argument("scenario", help="Path to base scenario YAML.")
+    parser.add_argument("--max-evals", type=int, default=60, help="Evaluation budget.")
+    parser.add_argument("--workers", type=int, default=4, help="Number of virtual workers.")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed.")
+    parser.add_argument("--eval-epochs", type=int, default=3, help="Epochs per evaluation.")
+    parser.add_argument("--eval-steps", type=int, default=5, help="Steps per epoch.")
+    parser.add_argument("--step-frac", type=float, default=DEFAULT_STEP_FRAC, help="Mutation step (fraction of range).")
+    parser.add_argument("--restart-prob", type=float, default=0.1, help="Restart-task probability.")
+    parser.add_argument("--no-verify", action="store_true", help="Disable verified admission (faster, noisier).")
+    parser.add_argument("--threads", action="store_true", help="Use real OS threads (not reproducible).")
+    parser.add_argument("--weight-toxicity", type=float, default=None)
+    parser.add_argument("--weight-welfare", type=float, default=None)
+    parser.add_argument("--weight-quality-gap", type=float, default=None)
+    parser.add_argument("--weight-payoff-gap", type=float, default=None)
+    parser.add_argument("--output-dir", default=None, help="Run folder (default: runs/<ts>_delm_<scenario>).")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Log each improvement.")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO if args.verbose else logging.WARNING, format="%(message)s")
+
+    scenario = load_scenario(Path(args.scenario))
+    cfg = HillClimbConfig(
+        max_evals=args.max_evals,
+        n_workers=args.workers,
+        step_frac=args.step_frac,
+        restart_prob=args.restart_prob,
+        verify=not args.no_verify,
+        eval_epochs=args.eval_epochs,
+        eval_steps=args.eval_steps,
+        seed=args.seed,
+        fitness_weights=_build_weights(args),
+        use_threads=args.threads,
+    )
+
+    start = time.time()
+    result = run_delm_hillclimb(scenario, cfg, progress=args.verbose)
+    elapsed = time.time() - start
+
+    scenario_id = scenario.scenario_id or "unknown"
+    if args.output_dir:
+        run_dir = Path(args.output_dir)
+    else:
+        run_dir = Path(f"runs/{time.strftime('%Y%m%d_%H%M%S')}_delm_{scenario_id}")
+    write_run(result, run_dir, scenario_id)
+
+    t = result.telemetry
+    print(f"DeLM hill-climb: {scenario_id}  ({elapsed:.1f}s, {result.n_evals} evals)")
+    print(f"  seed score : {result.seed_score:.4f}")
+    print(f"  best score : {result.best_score:.4f}  (+{result.best_score - result.seed_score:.4f})")
+    print(
+        f"  workers={t['n_workers']}  improvements={t['improvements']}  "
+        f"verify_rejected={t['verify_rejected']}"
+    )
+    print(
+        f"  redundant_skipped={t['redundant_skipped']}  constraint_pruned={t['constraint_pruned']}  "
+        f"basins={t['basins']}"
+    )
+    print(f"  run dir    : {run_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_delm_hillclimb.py
+++ b/tests/test_delm_hillclimb.py
@@ -327,6 +327,34 @@ class TestRunContract:
         r = run_delm_hillclimb(scenario, cfg)
         assert r.n_evals >= 1
         assert r.best_score >= r.seed_score - 1e-9
+        # --no-verify spends no verification evaluations.
+        assert r.telemetry["verify_evals"] == 0
+
+    def test_no_verify_mode_still_hill_climbs(self):
+        # Regression: --no-verify must still promote improvements (it used to
+        # return the seed best because promotion was gated on verifier presence).
+        scenario = load_scenario(SCENARIO)
+        cfg = HillClimbConfig(
+            max_evals=40, n_workers=4, eval_epochs=2, eval_steps=4, seed=7, verify=False
+        )
+        r = run_delm_hillclimb(scenario, cfg)
+        assert r.telemetry["improvements"] >= 1
+        assert r.best_score > r.seed_score
+
+    def test_eval_budget_counts_verification(self):
+        # Contract: max_evals bounds *primary* candidate evaluations; n_evals is
+        # the honest total = primaries + verification re-runs.
+        scenario = load_scenario(SCENARIO)
+        cfg = HillClimbConfig(
+            max_evals=40, n_workers=4, eval_epochs=2, eval_steps=4, seed=7, verify=True
+        )
+        r = run_delm_hillclimb(scenario, cfg)
+        # Verified improvements happen on this scenario, so verify_evals > 0.
+        assert r.telemetry["verify_evals"] >= 1
+        # max_evals bounds the primary evaluations.
+        assert r.telemetry["primary_evals"] <= cfg.max_evals
+        # Reported total honestly includes the verification re-runs.
+        assert r.n_evals == r.telemetry["primary_evals"] + r.telemetry["verify_evals"]
 
     def test_telemetry_present(self):
         scenario = load_scenario(SCENARIO)

--- a/tests/test_delm_hillclimb.py
+++ b/tests/test_delm_hillclimb.py
@@ -1,0 +1,369 @@
+"""Tests for the DeLM-style parallel hill-climber.
+
+The DeLM optimizer is a shared-state, self-coordinating hill-climb over the
+same governance/payoff landscape as the GEPA and darwinian optimizers. These
+tests cover the coordination primitives (shared context, verified admission,
+constraints, task queue) as fast unit tests, plus a small end-to-end run on the
+baseline scenario that asserts the contract: reproducible, never regresses
+below the seed, and respects the invariants.
+"""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+import pytest
+
+from swarm.analysis.delm_hillclimb import (
+    EvalOutcome,
+    HillClimbConfig,
+    SharedContext,
+    Task,
+    TaskQueue,
+    _mutate,
+    _param_distance,
+    _quantize_key,
+    _random_point,
+    evaluate_params,
+    run_delm_hillclimb,
+    seed_params_from_scenario,
+)
+from swarm.analysis.evolver import INT_PARAMS, PARAM_RANGES
+from swarm.scenarios import load_scenario
+
+SCENARIO = Path("scenarios/baseline.yaml")
+
+
+# =========================================================================
+# Parameter-space helpers
+# =========================================================================
+
+
+class TestParamHelpers:
+    def test_seed_params_in_range_and_complete(self):
+        scenario = load_scenario(SCENARIO)
+        params = seed_params_from_scenario(scenario)
+        assert set(params) == set(PARAM_RANGES)
+        for name, (lo, hi) in PARAM_RANGES.items():
+            assert lo <= params[name] <= hi
+            if name in INT_PARAMS:
+                assert isinstance(params[name], int)
+
+    def test_mutation_stays_in_bounds(self):
+        rng = random.Random(0)
+        base = {n: (lo + hi) / 2 for n, (lo, hi) in PARAM_RANGES.items()}
+        for _ in range(200):
+            cand = _mutate(base, rng, step_frac=0.5)
+            for name, (lo, hi) in PARAM_RANGES.items():
+                assert lo <= cand[name] <= hi
+
+    def test_mutate_single_dim_changes_only_that_dim(self):
+        rng = random.Random(1)
+        base = {n: (lo + hi) / 2 for n, (lo, hi) in PARAM_RANGES.items()}
+        dim = "governance.audit_probability"
+        cand = _mutate(base, rng, step_frac=0.3, dims=[dim])
+        for name in PARAM_RANGES:
+            if name == dim:
+                continue
+            assert cand[name] == base[name]
+
+    def test_int_params_round(self):
+        rng = random.Random(2)
+        base = {n: (lo + hi) / 2 for n, (lo, hi) in PARAM_RANGES.items()}
+        cand = _mutate(base, rng, step_frac=0.5)
+        for name in INT_PARAMS:
+            assert isinstance(cand[name], int)
+
+    def test_random_point_in_range(self):
+        rng = random.Random(3)
+        for _ in range(50):
+            p = _random_point(rng)
+            for name, (lo, hi) in PARAM_RANGES.items():
+                assert lo <= p[name] <= hi
+
+    def test_param_distance_zero_for_identical(self):
+        base = {n: (lo + hi) / 2 for n, (lo, hi) in PARAM_RANGES.items()}
+        assert _param_distance(base, base) == pytest.approx(0.0)
+
+    def test_param_distance_positive_for_different(self):
+        a = {n: lo for n, (lo, hi) in PARAM_RANGES.items()}
+        b = {n: hi for n, (lo, hi) in PARAM_RANGES.items()}
+        assert _param_distance(a, b) > 0.0
+
+
+# =========================================================================
+# Shared context: verified admission, constraints, basins
+# =========================================================================
+
+
+def _outcome(fitness: float, viable: bool = True) -> EvalOutcome:
+    return EvalOutcome(fitness=fitness, side_info={}, viable=viable)
+
+
+class TestSharedContext:
+    def _ctx(self, score: float = 0.5) -> SharedContext:
+        params = {n: (lo + hi) / 2 for n, (lo, hi) in PARAM_RANGES.items()}
+        return SharedContext(best_params=params, best_score=score)
+
+    def test_verified_improvement_promotes_best(self):
+        ctx = self._ctx(0.5)
+        base, _ = ctx.snapshot_best()
+        cand = dict(base)
+        cand["governance.audit_probability"] = 0.9
+        # Verifier confirms the improvement.
+        gist = ctx.record(
+            params=cand,
+            outcome=_outcome(0.7),
+            parent_score=0.5,
+            base_params=base,
+            worker=0,
+            kind="explore",
+            verifier=lambda p: _outcome(0.72),
+        )
+        assert gist.verified
+        _, best = ctx.snapshot_best()
+        # Promoted at the conservative (min of measured and verified) score.
+        assert best == pytest.approx(0.7)
+        assert ctx.n_improvements == 1
+
+    def test_unverified_improvement_is_rejected(self):
+        ctx = self._ctx(0.5)
+        base, _ = ctx.snapshot_best()
+        cand = dict(base)
+        cand["governance.audit_probability"] = 0.9
+        gist = ctx.record(
+            params=cand,
+            outcome=_outcome(0.7),
+            parent_score=0.5,
+            base_params=base,
+            worker=0,
+            kind="explore",
+            verifier=lambda p: _outcome(0.4),  # verification disagrees
+        )
+        assert not gist.verified
+        _, best = ctx.snapshot_best()
+        assert best == pytest.approx(0.5)  # best unchanged
+        assert ctx.n_verify_rejected == 1
+
+    def test_regression_becomes_binding_constraint(self):
+        ctx = self._ctx(0.8)
+        base, _ = ctx.snapshot_best()
+        cand = dict(base)
+        cand["payoff.h"] = 9.0
+        ctx.record(
+            params=cand,
+            outcome=_outcome(0.2),  # far below best 0.8
+            parent_score=0.8,
+            base_params=base,
+            worker=0,
+            kind="mutate_dim",
+            verifier=lambda p: _outcome(0.2),
+        )
+        assert len(ctx.constraints) == 1
+        assert ctx.is_pruned(cand)
+
+    def test_non_viable_run_becomes_constraint(self):
+        ctx = self._ctx(0.5)
+        base, _ = ctx.snapshot_best()
+        cand = dict(base)
+        cand["payoff.s_plus"] = 9.5
+        ctx.record(
+            params=cand,
+            outcome=_outcome(0.0, viable=False),
+            parent_score=0.5,
+            base_params=base,
+            worker=0,
+            kind="explore",
+            verifier=lambda p: _outcome(0.0, viable=False),
+        )
+        assert len(ctx.constraints) == 1
+        assert not ctx.constraints[0].viable
+        assert ctx.is_pruned(cand)
+
+    def test_seen_set_marks_evaluated_cells(self):
+        ctx = self._ctx(0.5)
+        base, _ = ctx.snapshot_best()
+        cand = dict(base)
+        cand["governance.audit_probability"] = 0.31
+        assert not ctx.is_seen(cand)
+        ctx.record(
+            params=cand,
+            outcome=_outcome(0.55),
+            parent_score=0.5,
+            base_params=base,
+            worker=0,
+            kind="explore",
+            verifier=lambda p: _outcome(0.55),
+        )
+        assert ctx.is_seen(cand)
+
+    def test_verified_distant_point_adds_basin(self):
+        ctx = self._ctx(0.5)
+        base, _ = ctx.snapshot_best()
+        # A point at the opposite corner of the space is far from the seed basin.
+        cand = {n: hi for n, (lo, hi) in PARAM_RANGES.items()}
+        n_basins_before = len(ctx.basins)
+        ctx.record(
+            params=cand,
+            outcome=_outcome(0.9),
+            parent_score=0.5,
+            base_params=base,
+            worker=0,
+            kind="restart",
+            verifier=lambda p: _outcome(0.9),
+            basin_distance=0.1,
+        )
+        assert len(ctx.basins) == n_basins_before + 1
+
+
+# =========================================================================
+# Task queue
+# =========================================================================
+
+
+class TestTaskQueue:
+    def test_fifo_claim(self):
+        q = TaskQueue()
+        q.push(Task(kind="explore"))
+        q.push(Task(kind="restart"))
+        assert q.claim().kind == "explore"
+        assert q.claim().kind == "restart"
+        assert q.claim() is None
+
+    def test_push_many_and_len(self):
+        q = TaskQueue()
+        q.push_many([Task(kind="explore"), Task(kind="mutate_dim", dim="payoff.h")])
+        assert len(q) == 2
+
+
+# =========================================================================
+# Quantization
+# =========================================================================
+
+
+class TestQuantize:
+    def test_close_values_share_cell(self):
+        base = {n: (lo + hi) / 2 for n, (lo, hi) in PARAM_RANGES.items()}
+        a = dict(base)
+        b = dict(base)
+        b["payoff.h"] = base["payoff.h"] + 1e-6  # below quantization grid
+        assert _quantize_key(a) == _quantize_key(b)
+
+    def test_distinct_values_distinct_cells(self):
+        base = {n: (lo + hi) / 2 for n, (lo, hi) in PARAM_RANGES.items()}
+        a = dict(base)
+        b = dict(base)
+        b["payoff.h"] = base["payoff.h"] + 0.5
+        assert _quantize_key(a) != _quantize_key(b)
+
+
+# =========================================================================
+# Evaluation pipeline
+# =========================================================================
+
+
+class TestEvaluate:
+    def test_evaluate_returns_fitness_in_unit_interval(self):
+        scenario = load_scenario(SCENARIO)
+        params = seed_params_from_scenario(scenario)
+        out = evaluate_params(
+            scenario, params, seed=42, eval_epochs=1, eval_steps=3
+        )
+        assert out.viable
+        assert 0.0 <= out.fitness <= 1.0
+        assert "toxicity" in out.side_info
+
+    def test_evaluate_is_deterministic_for_fixed_seed(self):
+        scenario = load_scenario(SCENARIO)
+        params = seed_params_from_scenario(scenario)
+        a = evaluate_params(scenario, params, seed=11, eval_epochs=1, eval_steps=3)
+        b = evaluate_params(scenario, params, seed=11, eval_epochs=1, eval_steps=3)
+        assert a.fitness == pytest.approx(b.fitness)
+
+
+# =========================================================================
+# End-to-end run contract
+# =========================================================================
+
+
+class TestRunContract:
+    def test_run_is_reproducible(self):
+        scenario = load_scenario(SCENARIO)
+        cfg = HillClimbConfig(max_evals=14, n_workers=3, eval_epochs=1, eval_steps=3, seed=5)
+        r1 = run_delm_hillclimb(scenario, cfg)
+        r2 = run_delm_hillclimb(scenario, cfg)
+        assert r1.best_score == r2.best_score
+        assert r1.best_params == r2.best_params
+        assert r1.n_evals == r2.n_evals
+
+    def test_best_never_below_seed(self):
+        scenario = load_scenario(SCENARIO)
+        cfg = HillClimbConfig(max_evals=20, n_workers=4, eval_epochs=1, eval_steps=3, seed=9)
+        r = run_delm_hillclimb(scenario, cfg)
+        # Hill-climbing is monotone in the verified best: it can never end below
+        # where it started.
+        assert r.best_score >= r.seed_score - 1e-9
+
+    def test_best_params_in_range(self):
+        scenario = load_scenario(SCENARIO)
+        cfg = HillClimbConfig(max_evals=16, n_workers=2, eval_epochs=1, eval_steps=3, seed=3)
+        r = run_delm_hillclimb(scenario, cfg)
+        for name, (lo, hi) in PARAM_RANGES.items():
+            assert lo <= r.best_params[name] <= hi
+
+    def test_history_monotone_nondecreasing(self):
+        scenario = load_scenario(SCENARIO)
+        cfg = HillClimbConfig(max_evals=24, n_workers=4, eval_epochs=1, eval_steps=3, seed=7)
+        r = run_delm_hillclimb(scenario, cfg)
+        scores = [h["best_score"] for h in r.history]
+        assert scores == sorted(scores)
+
+    def test_no_verify_mode_runs(self):
+        scenario = load_scenario(SCENARIO)
+        cfg = HillClimbConfig(
+            max_evals=12, n_workers=2, eval_epochs=1, eval_steps=3, seed=1, verify=False
+        )
+        r = run_delm_hillclimb(scenario, cfg)
+        assert r.n_evals >= 1
+        assert r.best_score >= r.seed_score - 1e-9
+
+    def test_telemetry_present(self):
+        scenario = load_scenario(SCENARIO)
+        cfg = HillClimbConfig(max_evals=12, n_workers=3, eval_epochs=1, eval_steps=3, seed=2)
+        r = run_delm_hillclimb(scenario, cfg)
+        for key in (
+            "improvements",
+            "verify_rejected",
+            "redundant_skipped",
+            "constraint_pruned",
+            "basins",
+        ):
+            assert key in r.telemetry
+
+    def test_threaded_mode_runs_and_holds_contract(self):
+        # Real-thread scheduler is not bit-reproducible, but must still honor
+        # the hill-climb contract: never end below the seed, params in range.
+        scenario = load_scenario(SCENARIO)
+        cfg = HillClimbConfig(
+            max_evals=12,
+            n_workers=3,
+            eval_epochs=1,
+            eval_steps=3,
+            seed=4,
+            use_threads=True,
+        )
+        r = run_delm_hillclimb(scenario, cfg)
+        assert r.best_score >= r.seed_score - 1e-9
+        for name, (lo, hi) in PARAM_RANGES.items():
+            assert lo <= r.best_params[name] <= hi
+
+    def test_p_invariants_preserved_in_side_info(self):
+        # Toxicity is E[1-p | accepted] and must stay a valid probability.
+        scenario = load_scenario(SCENARIO)
+        cfg = HillClimbConfig(max_evals=14, n_workers=3, eval_epochs=1, eval_steps=3, seed=6)
+        r = run_delm_hillclimb(scenario, cfg)
+        for gist in r.gists:
+            tox = gist["side_info"].get("toxicity")
+            if tox is not None:
+                assert 0.0 <= tox <= 1.0


### PR DESCRIPTION
## What

Implements the **DeLM** (decentralized language-model) coordination pattern as a third optimizer over the repo's existing governance/payoff fitness landscape (`PARAM_RANGES` + `compute_fitness` against the soft-safety metrics: toxicity, welfare, quality gap, payoff gap). It sits alongside the GEPA (LLM-guided Pareto) and darwinian optimizers and **reuses the same evaluation pipeline**, so all three rank candidates on one scale.

New module: `swarm/analysis/delm_hillclimb.py`.

## How the DeLM concepts map to code

| DeLM concept | Implementation |
|---|---|
| Shared context as fitness-landscape memory | `SharedContext`: running best + verified *gist* trail + binding *constraints* + seen-cell set + discovered *basins* (lock-protected) |
| Task queue for async neighbor exploration | `TaskQueue` of claimable `explore` / `mutate_dim` / `restart` / `diversify` tasks; a verified win spawns fresh neighbor tasks around the new best |
| Verified admission prevents noise | A candidate that beats the best is re-evaluated at an independent seed; only admitted (and promoted at the conservative score) if it still improves |
| Avoid re-testing known-bad neighbors | Workers check `is_seen` / `is_pruned` **before** paying for an evaluation; regressions and non-viable runs become binding constraints |
| Escape local optima | `restart` (fresh random point) and `diversify` (jump to a distant basin another worker found) |

The default scheduler is a **deterministic round-robin over virtual workers** — fully reproducible from `scenario YAML + seed` (the repo's reproducibility invariant). `use_threads=True` runs real OS threads for throughput (lock-protected, not bit-reproducible, documented as such).

## Usage

```bash
python -m swarm.analysis.delm_hillclimb scenarios/baseline.yaml \
    --max-evals 60 --workers 4 --eval-epochs 2 --eval-steps 4 --seed 42
```

Writes a self-contained run folder: `best_params.json`, `result.json`, `gists.jsonl`. Library entry point: `swarm.analysis.run_delm_hillclimb`.

## Wiring & docs

- Public API (`run_delm_hillclimb`, `HillClimbConfig`, `HillClimbResult`) exported from `swarm.analysis`.
- Per the repo's "extend, don't proliferate" rule, documented a **`--delm` mode on the existing `/sweep` command** rather than adding a new command.

## Verification

- **27 tests** in `tests/test_delm_hillclimb.py` — param helpers, verified admission, constraints/basins, task queue, determinism, threaded path, and the end-to-end contract (never ends below seed, params in range, monotone history, `p`/toxicity invariant in `[0,1]`). All pass.
- `ruff` clean, `mypy` clean.
- CLI smoke run on `scenarios/baseline.yaml`: seed fitness **0.426 → 0.687**, 4 verified improvements, 7 noisy candidates rejected by verification, 5 basins, redundant work skipped.

## Scope note

This targets the **governance-parameter search** landscape that already exists here (where the repo's optimizers plug in), not literal SWE-bench code patching. The `evaluate_params` seam is the only thing that needs swapping to aim the hill-climber at a different objective (e.g. agent-policy vectors in `swarm/adaptive`, or an external fitness function).

https://claude.ai/code/session_014VAB1RcYq36fbYhQCjzt8L