### PR TITLE
fix(ci): bump mypy python_version to 3.12 for numpy PEP 695 stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,7 +199,10 @@ markers = [
 ]
 
 [tool.mypy]
-python_version = "3.10"
+# Must be >= 3.12: numpy's stubs use PEP 695 `type` statements, which mypy
+# rejects as syntax errors when emulating an older target version. CI runs on
+# 3.12, so check against it. Runtime support floor stays at 3.10 (requires-python).
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true


### PR DESCRIPTION
numpy 2.5.0 ships stubs using PEP 695 `type` statements. mypy applies the
target python_version's syntax rules to all parsed files (including dependency
stubs), so with python_version=3.10 it rejected numpy/__init__.pyi as a syntax
error, failing the CI mypy step. CI runs on 3.12; check against it. Runtime
support floor stays at 3.10 via requires-python.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013pH6GQYnqCi7f548EWjzVm