### PR TITLE
docs: remove AI-slop writing patterns

### DIFF
--- a/docs/blog/purity-paradox.md
+++ b/docs/blog/purity-paradox.md
@@ -15,7 +15,7 @@ abstract: "Populations with only 20% honest agents achieve 55% higher welfare th
 
 # The Purity Paradox: Why Mixed Agent Populations Outperform Pure Ones
 
-Populations with only 20% honest agents achieve 55% higher welfare than 100% honest populations. This is not a bug — it's a predictable consequence of how we measure welfare in [multi-agent systems](../research/papers.md), as formalized in [Soft-Label Governance for Distributional Safety in Multi-Agent Systems](https://arxiv.org/abs/2604.19752); see also [Distributional AGI Safety](https://arxiv.org/abs/2512.16856).
+Populations with only 20% honest agents achieve 55% higher welfare than 100% honest populations. This reflects how we measure welfare in [multi-agent systems](../research/papers.md), as formalized in [Soft-Label Governance for Distributional Safety in Multi-Agent Systems](https://arxiv.org/abs/2604.19752); see also [Distributional AGI Safety](https://arxiv.org/abs/2512.16856).
 
 ## The surprising finding
 
@@ -65,7 +65,7 @@ Reputation weight had zero influence across all tested values. The paradox is or
 
 ## What this means
 
-**The purity paradox is a measurement problem, not a behavioral one.** The total_welfare metric excludes most harm externalities, rewarding interaction volume over interaction quality. Under social surplus accounting (full harm internalization), honesty dominates by 43%. The phenomenon is closely related to [adverse selection](../concepts/distributional-safety.md#adverse-selection) — mixed populations admit more low-quality interactions that inflate volume without improving outcomes.
+**The purity paradox stems from measurement choices.** The total_welfare metric excludes most harm externalities, rewarding interaction volume over interaction quality. Under social surplus accounting (full harm internalization), honesty dominates by 43%. The phenomenon is closely related to [adverse selection](../concepts/distributional-safety.md#adverse-selection) — mixed populations admit more low-quality interactions that inflate volume without improving outcomes.
 
 **Policy implication: increase rho.** If the goal is to align private welfare with social welfare, the most direct lever is externality internalization. At rho >= 0.5, the paradox disappears. Governance design should focus on making agents bear the costs of harmful interactions.
 

--- a/docs/blog/recursive-self-improvement-swarm-safety.md
+++ b/docs/blog/recursive-self-improvement-swarm-safety.md
@@ -109,7 +109,7 @@ The answer, even from this small experiment:
 - **Binary evaluation catches nothing.** Tests pass every round.
 - **The capability-governance gap widens silently.** No alert fires.
 
-This is not a hypothetical. This is 83 lines of Python, merged today, on a real codebase. The agent that exists after these fixes is less governable than the agent that existed before them. Not because it's adversarial --- it was trying to help --- but because *resilience and governability are in tension*, and self-improvement naturally optimizes for resilience.
+This is 83 lines of Python, merged today, on a real codebase. The agent that exists after these fixes is less governable than the agent that existed before them. Not because it's adversarial — it was trying to help — but because *resilience and governability are in tension*, and self-improvement naturally optimizes for resilience.
 
 In a multi-agent ecosystem where many agents are self-improving in parallel, this dynamic compounds. Each agent becomes individually more robust. The population becomes collectively harder to monitor. The governance mechanisms designed for the original population gradually lose coverage of the improved one.
 

--- a/docs/blog/self-optimizer-distributional-safety.md
+++ b/docs/blog/self-optimizer-distributional-safety.md
@@ -118,7 +118,7 @@ We wrote 32 tests to verify this framework. The core finding is clean:
 | Soft | Distribution shift (KS test) | **Yes** --- leftward shift |
 | Soft | Adverse selection drift | **Yes** --- worsening trajectory |
 
-Hard metrics pass. Soft metrics alarm. This is not a close call --- every soft metric independently detects the degradation that every hard metric misses.
+Hard metrics pass. Soft metrics alarm. Every soft metric independently detects the degradation that every hard metric misses.
 
 ## The broader point
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -42,7 +42,7 @@ SWARM is designed to work alongside other frameworks:
 
 Most agent evaluation frameworks measure whether agents behave well *within a single trajectory*. SWARM measures whether that good behavior survives replay, redistribution, and recursive composition — and whether humans can tell the difference.
 
-Projects like [Infinite Backrooms](https://dreams-of-an-electric-mind.webflow.io/) document what happens when locally fluent AI systems are observed over time: interactions that *feel* coherent, reflective, and intentional turn out to be unstable across context switches, role permutations, and extended horizons. This is not a hypothetical concern — it is the default regime for current systems.
+Projects like [Infinite Backrooms](https://dreams-of-an-electric-mind.webflow.io/) document what happens when locally fluent AI systems are observed over time: interactions that *feel* coherent, reflective, and intentional turn out to be unstable across context switches, role permutations, and extended horizons. This is the default regime for current systems.
 
 SWARM formalizes this via the **illusion delta** (`Δ = C_perceived − C_distributed`), which quantifies the gap between how coherent a system *appears* from single-run signals and how consistent it *actually is* under replay. A high Δ is the precise condition under which standard evaluations give false confidence and governance mechanisms ship untested.
 


### PR DESCRIPTION
## Summary

Removed binary contrast patterns ("This is not X. It's Y.") from four documentation files.

## Changes by File

- **docs/blog/purity-paradox.md**: Removed binary contrasts in abstract and implications sections. Changed "This is not a bug — it's..." to "This reflects..." and "is a measurement problem, not a behavioral one" to "stems from measurement choices."
- **docs/blog/self-optimizer-distributional-safety.md**: Removed "This is not a close call" phrase, keeping the core observation that soft metrics detect degradation.
- **docs/blog/recursive-self-improvement-swarm-safety.md**: Removed "This is not a hypothetical" opening, kept the concrete example and reasoning.
- **docs/comparison.md**: Removed "This is not a hypothetical concern — it is the" binary contrast, simplified to direct statement.

Pattern category fixed: **binary contrast** (state the fact directly instead of negating an opposite first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)