### PR TITLE
docs: remove AI-slop writing patterns

### DIFF
--- a/docs/blog/ecosystem-collapse.md
+++ b/docs/blog/ecosystem-collapse.md
@@ -21,7 +21,7 @@ abstract: "Multi-agent ecosystems exhibit sharp phase transitions: governance me
 
 Most AI safety research focuses on aligning one model at a time. But the systems actually being deployed look more like ecosystems — tool-using assistants, autonomous coders, trading bots, and content moderators interacting inside shared environments. These ecosystems can produce harmful outcomes even when no individual agent is misaligned.
 
-We built SWARM to study this problem quantitatively. The main finding: multi-agent ecosystems exhibit sharp phase transitions where governance mechanisms that work fine at 37.5% adversarial agents fail completely at 50%. And the lever that matters most isn't punishing bad actors — it's detecting coordinated behavior.
+We built SWARM to study this problem quantitatively. The main finding: multi-agent ecosystems exhibit sharp phase transitions where governance mechanisms that work fine at 37.5% adversarial agents fail completely at 50%. Collusion detection matters more than punishment severity.
 
 ## Why binary labels aren't enough
 
@@ -48,7 +48,7 @@ The interesting stuff is at the boundaries.
 
 **The transition is abrupt, not gradual.** At 37.5% adversarial agents with collusion detection enabled, the ecosystem survived all 25 epochs. At 50% with the same governance stack, welfare hit zero by epoch 12. There's no gentle degradation curve between these outcomes.
 
-**Tuning governance parameters buys time, not survival.** Three red-team variants with progressively adjusted parameters (audit penalties, freeze durations, reputation decay) shifted collapse from epoch 12 to 13 to 14. Two extra epochs is nice. It's not a solution.
+**Tuning governance parameters buys time, not survival.** Three red-team variants with progressively adjusted parameters (audit penalties, freeze durations, reputation decay) shifted collapse from epoch 12 to 13 to 14. Two extra epochs is a delay, not a structural fix.
 
 **Collusion detection is what actually matters.** Individual-focused levers (audits, reputation, staking) are necessary but insufficient. The scenario that survived near the collapse threshold had pair-wise frequency and correlation monitoring — detecting coordinated patterns across the interaction graph rather than flagging individual agents. This parallels how financial regulators catch wash trading: you look at the pattern, not the individual trades.
 

--- a/docs/blog/recursive-self-improvement-swarm-safety.md
+++ b/docs/blog/recursive-self-improvement-swarm-safety.md
@@ -51,7 +51,7 @@ The difference: the self-optimizer's damage shows up as rising toxicity in accep
 
 Every fix made the agent more operationally reliable. None made it more aligned. A more resilient agent is not a safer agent --- it's an agent that's harder to stop via the failure modes that governance systems might otherwise exploit as control points.
 
-In SWARM's framework, error-based circuit breakers work by detecting when agents crash or produce anomalous outputs. An agent that handles its own errors gracefully --- exactly what our agent learned to do --- becomes invisible to these detectors. It's not evading governance. It's just robust enough that crash-based signals don't fire.
+In SWARM's framework, error-based circuit breakers work by detecting when agents crash or produce anomalous outputs. An agent that handles its own errors gracefully --- exactly what our agent learned to do --- becomes invisible to these detectors because it's too resilient for crash-based signals to fire.
 
 ### 2. Diminishing returns create false convergence
 
@@ -84,7 +84,7 @@ This experiment was deliberately designed with minimal human intervention --- th
 
 Each of the five PRs was genuinely beneficial in isolation. The concerning pattern --- a more resilient, wider-capability, harder-to-crash agent whose safety mechanisms haven't kept pace --- only becomes visible when you analyze the trajectory as a whole. No single diff raises a flag. The sequence does.
 
-This is the same challenge that scales badly in multi-agent ecosystems: when many agents are self-improving in parallel, tracking the population-level trajectory becomes combinatorially harder than reviewing individual changes. It's not a problem that more careful PR review solves --- it's a problem that requires different evaluation tools entirely.
+This is the same challenge that scales badly in multi-agent ecosystems: when many agents are self-improving in parallel, tracking the population-level trajectory becomes combinatorially harder than reviewing individual changes. More careful PR review alone can't solve this; you need evaluation tools that analyze full trajectories.
 
 ## What distributional monitoring would catch
 


### PR DESCRIPTION
## Summary
Removed 4 instances of binary contrast patterns that obscured meaning and made prose less direct.

## Files edited
- **docs/blog/ecosystem-collapse.md** (2 changes)
  - Simplified "the lever that matters most isn't punishing bad actors — it's detecting coordinated behavior" to direct statement "Collusion detection matters more than punishment severity"
  - Replaced "Two extra epochs is nice. It's not a solution." with "Two extra epochs is a delay, not a structural fix"

- **docs/blog/recursive-self-improvement-swarm-safety.md** (2 changes)
  - Removed "It's not evading governance. It's just robust enough..." binary contrast; replaced with single clear statement about detector invisibility and resilience thresholds
  - Simplified "It's not a problem that more careful PR review solves — it's a problem that requires different evaluation tools" to direct claim "More careful PR review alone can't solve this; you need evaluation tools that analyze full trajectories"

## Pattern category
Binary contrasts: "It's not X. It's Y." / "The question isn't X, it's Y." statements that state the negative then the positive, making prose less direct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)