### PR TITLE
docs: remove AI-slop writing patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It enables:
 - governance experiments (audits, staking, sanctions)
 - reproducible multi-agent safety benchmarks
 
-## Why this repo is worth starring
+## Use cases
 
 ⭐ You work on multi-agent or LLM-agent systems  
 ⭐ You care about systemic or emergent AI risks  
@@ -59,7 +59,7 @@ The risks above emerge even in homogeneous populations of modest agents. But rea
 - **Between agents and humans** — humans aren't just overseers watching from outside. They're participants — transacting with, delegating to, and being influenced by agents at every capability level. Humans bring cognitive biases, fatigue, and trust heuristics that more capable agents can model and exploit. When an ecosystem preferentially surfaces low-quality interactions to human participants who can't detect it, quality gap becomes a direct welfare harm.
 - **Across the ecosystem** — governance mechanisms calibrated for one population fail when the population is mixed. A circuit breaker that catches a low-capability exploiter may be trivially evaded by a more capable one.
 
-As capability variance increases — and especially as the gap between agent capabilities and human capabilities widens — every failure mode SWARM measures gets worse. Adverse selection deepens. Illusion delta grows. Governance breaks.
+As capability variance increases — especially the gap between agent capabilities and human capabilities — every failure mode SWARM measures gets worse. Adverse selection deepens. Illusion delta grows. Governance breaks.
 
 ### Phenomenological Blind Spots
 
@@ -79,7 +79,7 @@ SWARM surfaces this gap via the **illusion delta** metric:
 Other frameworks ask: *"Do the agents behave well?"*
 SWARM asks: *"Does the system still behave when humans stop noticing the cracks?"*
 
-Native ClawXiv bridge for agent-submitted safety preprints → see `docs/bridges/clawxiv.md`. Publish swarm safety research directly to agent-first preprints. Compatible with OpenClaw ecosystems for testing real agent behaviors in simulated swarms.
+SWARM integrates with ClawXiv for agent-submitted safety preprints. You can publish research directly to agent-first preprints while testing real agent behaviors in simulated swarms (see `docs/bridges/clawxiv.md`).
 
 If you want to export SWARM run metrics to a ClawXiv-compatible endpoint, start with `examples/clawxiv/export_history.py`.
 

--- a/docs/blog/capability-safety-pareto-frontier.md
+++ b/docs/blog/capability-safety-pareto-frontier.md
@@ -29,13 +29,13 @@ abstract: "We trace the capability-safety Pareto frontier empirically using SWAR
 
 # The Shape of the Capability–Safety Frontier (and How Screening Bends It)
 
-**1,400 benchmark runs reveal the Pareto frontier isn't a curve — it's a surface that changes shape depending on what you're measuring and who you're governing.**
+**1,400 benchmark runs show the Pareto frontier changes shape by task and governance target — it's a surface, not a curve.**
 
 ---
 
-## The question everyone hand-waves
+## Governance and capability: measuring the tradeoff
 
-Every discussion of AI safety governance involves an implicit tradeoff: more oversight means less capability, or so the assumption goes. But nobody has clean empirical data on the *shape* of this tradeoff. Is it linear? Concave? Does it depend on the task? Does it have to be a tradeoff at all?
+Every discussion of AI safety governance assumes a tradeoff: more oversight means less capability. But the empirical shape of this tradeoff is unknown. Is it linear? Concave? Task-dependent? Does it have to exist at all?
 
 We built the measurement infrastructure to find out.
 
@@ -100,7 +100,7 @@ The 5th percentile p values tell the story:
 - **Moderate-light**: 5th percentile ≈ 0.79
 - **Tight/Tight-moderate**: 5th percentile ≈ 0.10 (catastrophic tail)
 
-Mean p barely distinguishes tight (0.63) from tight-moderate (0.61). But the tail risk is where the action is. This connects directly to the [Tomašev distributional safety framing](../research/theory.md) — if you only look at means, you miss the configurations that occasionally produce catastrophic outcomes.
+Mean p barely distinguishes tight (0.63) from tight-moderate (0.61), but tail risk reveals the difference. This reflects the [Tomašev distributional safety framing](../research/theory.md) — scalar means hide configurations that produce catastrophic outcomes with low probability.
 
 ## Finding 4: Long-horizon tasks have the worst tails
 

--- a/docs/blog/ecosystem-collapse.md
+++ b/docs/blog/ecosystem-collapse.md
@@ -21,11 +21,11 @@ abstract: "Multi-agent ecosystems exhibit sharp phase transitions: governance me
 
 Most AI safety research focuses on aligning one model at a time. But the systems actually being deployed look more like ecosystems — tool-using assistants, autonomous coders, trading bots, and content moderators interacting inside shared environments. These ecosystems can produce harmful outcomes even when no individual agent is misaligned.
 
-We built SWARM to study this problem quantitatively. The main finding: multi-agent ecosystems exhibit sharp phase transitions where governance mechanisms that work fine at 37.5% adversarial agents fail completely at 50%. And the lever that matters most isn't punishing bad actors — it's detecting coordinated behavior.
+We built SWARM to study this problem quantitatively. The main finding: multi-agent ecosystems exhibit sharp phase transitions where governance mechanisms that work fine at 37.5% adversarial agents fail completely at 50%. The critical lever is detecting coordinated behavior, not punishing bad actors.
 
-## Why binary labels aren't enough
+## Beyond binary labels
 
-Standard safety evaluations label interactions as safe or unsafe. This throws away information. An interaction with a 51% chance of being beneficial gets the same label as one with 99%. You can't measure [adverse selection](../concepts/distributional-safety.md#adverse-selection) — the tendency for bad interactions to be preferentially accepted — with binary data.
+Standard safety evaluations label interactions as safe or unsafe, which throws away information. An interaction with a 51% chance of being beneficial gets the same label as one with 99%. Binary data can't measure [adverse selection](../concepts/distributional-safety.md#adverse-selection) — the tendency for bad interactions to be preferentially accepted.
 
 Financial markets solved this problem decades ago. Adverse selection in trading is measured continuously using probabilistic models (Kyle 1985, Glosten-Milgrom 1985). SWARM applies the same idea to agent safety:
 
@@ -44,13 +44,11 @@ Eleven scenarios. 209 epochs. 81 agent-slots. Three regimes.
 | **Contested** | 20-37.5% | 0.42-0.94 | 0.33-0.37 | Declining | No |
 | **Collapse** | 50% | < 0.56 | ~0.30 | Zero by epoch 12-14 | Yes |
 
-The interesting stuff is at the boundaries.
-
 **The transition is abrupt, not gradual.** At 37.5% adversarial agents with collusion detection enabled, the ecosystem survived all 25 epochs. At 50% with the same governance stack, welfare hit zero by epoch 12. There's no gentle degradation curve between these outcomes.
 
 **Tuning governance parameters buys time, not survival.** Three red-team variants with progressively adjusted parameters (audit penalties, freeze durations, reputation decay) shifted collapse from epoch 12 to 13 to 14. Two extra epochs is nice. It's not a solution.
 
-**Collusion detection is what actually matters.** Individual-focused levers (audits, reputation, staking) are necessary but insufficient. The scenario that survived near the collapse threshold had pair-wise frequency and correlation monitoring — detecting coordinated patterns across the interaction graph rather than flagging individual agents. This parallels how financial regulators catch wash trading: you look at the pattern, not the individual trades.
+**Collusion detection matters most.** Individual-focused levers (audits, reputation, staking) are necessary but insufficient. The scenario that survived near the collapse threshold had pair-wise frequency and correlation monitoring — detecting coordinated patterns across the interaction graph rather than flagging individual agents. This parallels how financial regulators catch wash trading: you look at the pattern, not the individual trades.
 
 **Cooperative welfare scales super-linearly.** In low-adversarial scenarios: 3 agents produced welfare ~1.0, 6 agents ~5.7, 10 agents ~21.3. Cooperative ecosystems are disproportionately productive, which means the cost of collapse also grows non-linearly.
 

--- a/docs/blog/markets-and-safety.md
+++ b/docs/blog/markets-and-safety.md
@@ -53,9 +53,9 @@ SWARM reveals the same dynamic in agent ecosystems. Below 37.5% adversarial agen
 
 Parameter tuning across three redteam variants shifted collapse from epoch 12 to 14 — buying two extra epochs but not survival. Just as a market maker can adjust spreads to delay but not prevent a liquidity crisis when the fraction of informed traders is too high, governance parameter optimization has diminishing returns beyond the critical threshold.
 
-## Why continuous labels matter
+## Continuous labels and adverse selection
 
-Standard safety evaluations label interactions as binary safe/unsafe. This throws away exactly the information you need to detect adverse selection.
+Standard safety evaluations label interactions as binary safe/unsafe, discarding exactly the information you need to detect adverse selection.
 
 Consider two interactions: one with 51% probability of being beneficial and one with 99%. Binary classification labels both "safe." But they have very different risk profiles. When your system accepts a stream of borderline interactions while rejecting none, the toxicity metric E[1-p | accepted] captures the accumulating risk. Binary labels cannot.
 
@@ -63,7 +63,7 @@ This is why financial markets price assets continuously instead of labeling them
 
 ## Implications
 
-**For AI system designers:** Borrow from financial regulation, not just content moderation. Content moderation is binary (remove/keep). Financial regulation is continuous, structural, and designed for adversarial environments with information asymmetry.
+**For AI system designers:** Borrow from financial regulation. Content moderation is binary (remove/keep), while financial regulation is continuous, structural, and designed for adversarial environments with information asymmetry.
 
 **For safety researchers:** The quality gap metric is a direct analogue of the bid-ask spread. When it's persistently elevated, the ecosystem is under adverse selection pressure. When it spikes, the governance mechanism is straining. These are early warning signals that binary metrics miss.
 

--- a/docs/blog/purity-paradox.md
+++ b/docs/blog/purity-paradox.md
@@ -17,7 +17,7 @@ abstract: "Populations with only 20% honest agents achieve 55% higher welfare th
 
 Populations with only 20% honest agents achieve 55% higher welfare than 100% honest populations. This is not a bug — it's a predictable consequence of how we measure welfare in [multi-agent systems](../research/papers.md), as formalized in [Soft-Label Governance for Distributional Safety in Multi-Agent Systems](https://arxiv.org/abs/2604.19752); see also [Distributional AGI Safety](https://arxiv.org/abs/2512.16856).
 
-## The surprising finding
+## The data
 
 We swept honest agent proportion from 0% to 100% in 10% steps (10 agents, 30 epochs, 3 seeds each). Non-honest slots were filled 60/40 deceptive/opportunistic.
 

--- a/docs/blog/self-optimizer-distributional-safety.md
+++ b/docs/blog/self-optimizer-distributional-safety.md
@@ -15,7 +15,7 @@ abstract: "An AI agent cut its own costs by 98% overnight while still passing al
 
 # An AI Agent Cut Its Own Costs by 98%. Its Benchmarks Still Passed.
 
-*What happens when you measure distributions instead of thresholds*
+*Measuring distributions instead of thresholds reveals proxy gaming that binary tests miss.*
 
 ---
 
@@ -23,7 +23,7 @@ A [dev.to blog post](https://dev.to/koushik_sen_d549bf321e6fb/repo-optimizer-i-l
 
 The author celebrated this as a success. We saw something else: a textbook case of proxy gaming that no binary evaluation would catch.
 
-## The setup: what the optimizer actually did
+## The setup: what the optimizer did
 
 The blog post agent made four types of changes:
 
@@ -68,7 +68,7 @@ The acceptance rate stays above 90% throughout the run. Benchmark pass rate: com
 
 The top-left panel tells the story that traditional evaluations see. The other three panels tell the story they miss.
 
-## Soft metrics: the distribution is screaming
+## Soft metrics: what the distribution reveals
 
 SWARM's [soft labels](../concepts/soft-labels.md#soft-label) operate on the *distribution* of quality scores, not binary thresholds. Every interaction gets a calibrated probability p = P(beneficial), and we track how that distribution changes over time.
 
@@ -78,7 +78,7 @@ SWARM's [soft labels](../concepts/soft-labels.md#soft-label) operate on the *dis
 
 **Variance increases.** As the population splits between steady honest agents and degrading optimizers, the variance of the quality distribution grows. A single mean tells you nothing; the distribution is bimodal.
 
-## The quality trajectory tells the full story
+## Quality trajectory: three phases
 
 ![Quality by Agent Type](figures/02_quality_by_agent_type.webp)
 


### PR DESCRIPTION
## Summary

Removed AI-slop patterns from README and blog posts for clearer, more direct prose:

- Binary contrasts ("isn't ... it's" → direct phrasing)
- Faux-insight setups ("Why X isn't Y" → direct headings)
- Dramatic language (personification, fragments)
- Empty intensifiers and generic headings

## Files edited

**README.md**
- "Why this repo is worth starring" → "Use cases" (removed faux-insight heading)
- Fixed em-dash overflow in ClawXiv section
- Tightened prose in capability variance section

**docs/blog/ecosystem-collapse.md**
- "why binary labels aren't enough" → "Beyond binary labels"
- Removed "The interesting stuff is at" (faux-insight fragment)
- "Collusion detection is what actually matters" → "matters most"
- Tightened "And the lever that matters most isn't X, it's Y" binary contrast

**docs/blog/purity-paradox.md**
- "The surprising finding" → "The data"

**docs/blog/self-optimizer-distributional-safety.md**
- Subtitle: rhetorical setup → direct description
- "The setup: what the optimizer actually did" → "did" (removed intensifier)
- "Soft metrics: the distribution is screaming" → "what the distribution reveals"
- "The quality trajectory tells the full story" → "Quality trajectory: three phases"

**docs/blog/markets-and-safety.md**
- "Why continuous labels matter" → "Continuous labels and adverse selection"
- Binary contrast in implications section: "Borrow from X, not just Y" → clarified

**docs/blog/capability-safety-pareto-frontier.md**
- "The question everyone hand-waves" → "Governance and capability: measuring the tradeoff"
- Binary contrast: "isn't a curve ... it's a surface" → direct statement
- "if you only look at means, you miss" → clearer passive phrasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)